### PR TITLE
feature/svg

### DIFF
--- a/packages/html-to-sketch/html2asketch/helpers/utils.ts
+++ b/packages/html-to-sketch/html2asketch/helpers/utils.ts
@@ -30,11 +30,11 @@ export const makeColorFromCSS = (input: any, alpha: number = 1) => {
 };
 
 // Solid color fill
-export const makeColorFill = (color: any) => {
+export const makeColorFill = (color: any, alpha: number = 1) => {
   return {
     _class: 'fill',
     isEnabled: true,
-    color: makeColorFromCSS(color),
+    color: makeColorFromCSS(color, alpha),
     fillType: 0,
     noiseIndex: 0,
     noiseIntensity: 0,

--- a/packages/html-to-sketch/html2asketch/helpers/visibility.ts
+++ b/packages/html-to-sketch/html2asketch/helpers/visibility.ts
@@ -16,6 +16,8 @@ export function isNodeVisible(node: any, {width, height} = node.getBoundingClien
   display,
   clip,
 }: any = getComputedStyle(node)) {
+  if (node instanceof SVGClipPathElement) return true;
+  
   // skip node when display is set to none for itself or an ancestor
   // helps us catch things such as <noscript>
   // HTMLSlotElement has a null offsetParent, but should still be visible
@@ -47,7 +49,7 @@ export function isNodeVisible(node: any, {width, height} = node.getBoundingClien
     return false;
   }
 
-  if (node instanceof SVGLinearGradientElement || node instanceof SVGDefsElement || node instanceof SVGRadialGradientElement || node instanceof SVGStopElement) {
+  if (node instanceof SVGLinearGradientElement || node instanceof SVGRadialGradientElement || node instanceof SVGStopElement) {
     return false;
   }
 

--- a/packages/html-to-sketch/html2asketch/helpers/visibility.ts
+++ b/packages/html-to-sketch/html2asketch/helpers/visibility.ts
@@ -47,6 +47,10 @@ export function isNodeVisible(node: any, {width, height} = node.getBoundingClien
     return false;
   }
 
+  if (node instanceof SVGLinearGradientElement || node instanceof SVGDefsElement || node instanceof SVGRadialGradientElement || node instanceof SVGStopElement) {
+    return false;
+  }
+
   const parent = node.parentElement;
 
   if (

--- a/packages/html-to-sketch/html2asketch/model/base.ts
+++ b/packages/html-to-sketch/html2asketch/model/base.ts
@@ -13,6 +13,8 @@ class Base {
   _hasClippingMask: any;
   _isLocked: any;
   _variant?: string;
+  _points: any;
+  _isClosed: any;
 
   constructor({id}: any = {}) {
     this._class = null;
@@ -99,6 +101,7 @@ class Base {
       isFlippedVertical: false,
       isLocked: this._isLocked,
       isVisible: true,
+      isClosed: !!this._isClosed,
       layerListExpandedType: 0,
       name: this._name || this._class,
       nameIsFixed: false,
@@ -121,6 +124,10 @@ class Base {
 
     if (this._variant) {
       result.variant = this._variant;
+    }
+
+    if (this._points) {
+      result.points = this._points;
     }
 
     return result;

--- a/packages/html-to-sketch/html2asketch/model/base.ts
+++ b/packages/html-to-sketch/html2asketch/model/base.ts
@@ -15,6 +15,7 @@ class Base {
   _variant?: string;
   _points: any;
   _isClosed?: boolean;
+  _isVisible: boolean = true;
 
   constructor({id}: any = {}) {
     this._class = null;
@@ -100,7 +101,7 @@ class Base {
       isFlippedHorizontal: false,
       isFlippedVertical: false,
       isLocked: this._isLocked,
-      isVisible: true,
+      isVisible: this._isVisible,
       layerListExpandedType: 0,
       name: this._name || this._class,
       nameIsFixed: false,

--- a/packages/html-to-sketch/html2asketch/model/base.ts
+++ b/packages/html-to-sketch/html2asketch/model/base.ts
@@ -14,7 +14,7 @@ class Base {
   _isLocked: any;
   _variant?: string;
   _points: any;
-  _isClosed: any;
+  _isClosed?: boolean;
 
   constructor({id}: any = {}) {
     this._class = null;
@@ -101,7 +101,6 @@ class Base {
       isFlippedVertical: false,
       isLocked: this._isLocked,
       isVisible: true,
-      isClosed: !!this._isClosed,
       layerListExpandedType: 0,
       name: this._name || this._class,
       nameIsFixed: false,
@@ -113,6 +112,10 @@ class Base {
       clippingMaskMode: 0,
       hasClippingMask: this._hasClippingMask,
     };
+
+    if (this._isClosed !== undefined) {
+      result.isClosed = this._isClosed;
+    }
 
     if (this._userInfo) {
       result.userInfo = this._userInfo;

--- a/packages/html-to-sketch/html2asketch/model/ref.ts
+++ b/packages/html-to-sketch/html2asketch/model/ref.ts
@@ -1,0 +1,41 @@
+import { generateID } from '../helpers/utils';
+import Group from './group';
+
+class Ref {
+  _obj: any;
+  _hasClippingMask: boolean = false;
+  parent: Group;
+
+  constructor(obj: any, parent: Group, hasClippingMask: boolean = false) {
+    this._obj = obj;
+    this.parent = parent;
+    this._hasClippingMask = hasClippingMask;
+  }
+
+  traverse(obj:any) {
+    if (obj instanceof Array) {
+      obj.forEach(v => this.traverse(v));
+    } else if (typeof obj === 'object') {
+      for (const k in obj) {
+        if (k === 'do_objectID') {
+          obj[k] = generateID();
+        } else if (k === 'fills' || k === 'borders') {
+          obj[k] = [];
+        } else {
+          this.traverse(obj[k]);
+        }
+      }
+    }
+  }
+
+  toJSON() {
+    const obj: any = this._obj.toJSON();
+    this.traverse(obj);
+    obj.hasClippingMask = this._hasClippingMask;
+    obj.frame.x -= this.parent._x;
+    obj.frame.y -= this.parent._y;
+    return obj;
+  }
+}
+
+export default Ref;

--- a/packages/html-to-sketch/html2asketch/model/shapeGroup.ts
+++ b/packages/html-to-sketch/html2asketch/model/shapeGroup.ts
@@ -6,7 +6,7 @@ class ShapeGroup extends Base {
   _height: any;
   _x: any;
   _y: any;
-
+  
   constructor({x, y, width, height, id}: any) {
     super({id});
     this._class = 'shapeGroup';

--- a/packages/html-to-sketch/html2asketch/model/style.ts
+++ b/packages/html-to-sketch/html2asketch/model/style.ts
@@ -8,6 +8,8 @@ class Style {
   _innerShadows: any;
   _opacity: any;
   _borderOptions: any;
+  _miterLimit: number = 10;
+  _windingRule: number = 0;
 
   constructor() {
     this._fills = [];
@@ -17,8 +19,8 @@ class Style {
     this._opacity = '1';
   }
 
-  addColorFill(color: any) {
-    this._fills.push(makeColorFill(color));
+  addColorFill(color: any, alpha: number = 1) {
+    this._fills.push(makeColorFill(color, alpha));
   }
 
   addGradientFill({angle, stops}: any) {
@@ -56,11 +58,11 @@ class Style {
     this._fills.push(fill);
   }
 
-  addBorder({color, thickness}: any) {
+  addBorder({color, thickness, alpha}: {color:any, thickness:number, alpha?:number}) {
     this._borders.push({
       _class: 'border',
       isEnabled: true,
-      color: makeColorFromCSS(color),
+      color: makeColorFromCSS(color, alpha),
       fillType: 0,
       position: 1,
       thickness,
@@ -114,7 +116,8 @@ class Style {
       shadows: this._shadows,
       innerShadows: this._innerShadows,
       endDecorationType: 0,
-      miterLimit: 10,
+      miterLimit: this._miterLimit,
+      windingRule: this._windingRule,
       startDecorationType: 0,
       contextSettings: {
         _class: 'graphicsContextSettings',

--- a/packages/html-to-sketch/html2asketch/model/style.ts
+++ b/packages/html-to-sketch/html2asketch/model/style.ts
@@ -52,6 +52,33 @@ class Style {
     });
   }
 
+  addSVGGradientFill(fill: any, alpha: number = 1) {
+    this._fills.push({
+      _class: 'fill',
+      isEnabled: true,
+      fillType: 1,
+      gradient: {
+        _class: 'gradient',
+        ellipseLength: 0,
+        from: `{${fill.gradient.from.x}, ${fill.gradient.from.y}}`,
+        gradientType: fill.gradient.gradientType,
+        shouldSmoothenOpacity: false,
+        stops: fill.gradient.stops.map(({color, position}:{color:string,position:number}) => {
+          return {
+            _class: 'gradientStop',
+            color: makeColorFromCSS(color, alpha),
+            position,
+          }
+        }),
+        to: `{${fill.gradient.to.x}, ${fill.gradient.to.y}}`,
+      },
+      noiseIndex: 0,
+      noiseIntensity: 0,
+      patternFillType: 1,
+      patternTileScale: 1,
+    });
+  }
+
   addImageFill(image: any) {
     const fill = makeImageFill(image);
 

--- a/packages/html-to-sketch/html2asketch/model/style.ts
+++ b/packages/html-to-sketch/html2asketch/model/style.ts
@@ -7,6 +7,7 @@ class Style {
   _shadows: any;
   _innerShadows: any;
   _opacity: any;
+  _borderOptions: any;
 
   constructor() {
     this._fills = [];
@@ -109,6 +110,7 @@ class Style {
       _class: 'style',
       fills: this._fills,
       borders: this._borders,
+      borderOptions: this._borderOptions,
       shadows: this._shadows,
       innerShadows: this._innerShadows,
       endDecorationType: 0,

--- a/packages/html-to-sketch/html2asketch/nodeToSketchLayers.ts
+++ b/packages/html-to-sketch/html2asketch/nodeToSketchLayers.ts
@@ -765,7 +765,7 @@ export default function nodeToSketchLayers(node: HTMLElement, options: any) {
       bbox.y += shapeGroup._y;
 
       // Set stroke parameters
-      if (anyStyles.stroke && anyStyles.stroke !== 'none' && anyStyles.stroke !== 'transparent') {
+      if (anyStyles.stroke && anyStyles.stroke !== 'none') {
         style.addBorder({ color: anyStyles.stroke, alpha: parseStyleNumber(anyStyles.strokeOpacity, 1), thickness: parseStyleNumber(anyStyles.strokeWidth) * nodeScale });
         style._borders[style._borders.length-1].position = 0;
         switch (anyStyles.strokeLinecap) {

--- a/packages/html-to-sketch/html2asketch/nodeToSketchLayers.ts
+++ b/packages/html-to-sketch/html2asketch/nodeToSketchLayers.ts
@@ -268,12 +268,12 @@ function convertSVGPointToObjectBoundingBox(point: DOMPoint, x: SVGAnimatedLengt
     if (x.baseVal.unitType === 2) { // Percent value, scale to bbox.
       point.x = bbox.x + (point.x - bbox.x) / (node.ownerSVGElement!.getBBox().width / bbox.width);
     } else { // pixel value, move origin to bbox
-      point.x += bbox.x;
+      point.x = bbox.x + point.x * bbox.width;
     }
     if (y.baseVal.unitType === 2) { // Percent value, scale to bbox.
       point.y = bbox.y + (point.y - bbox.y) / (node.ownerSVGElement!.getBBox().height / bbox.height);
     } else {
-      point.y += bbox.y;
+      point.y = bbox.y + point.y * bbox.height;
     }
 }
 
@@ -331,6 +331,9 @@ function parseSVGRadialGradient(node:SVGRadialGradientElement, ctm:DOMMatrix, bb
     let d = new DOMPoint(node.r.baseVal.valueInSpecifiedUnits * 0.01 * bbox.width, 0).matrixTransform(gtm);
     radiusPoint.x = center.x + d.x;
     radiusPoint.y = center.y + d.y;
+  } else if (node.gradientUnits.baseVal === 2) { // Add radius vector to center point.
+    radiusPoint.x = radiusPoint.x * bbox.width + center.x;
+    radiusPoint.y = radiusPoint.y * bbox.height + center.y;
   } else { // Add radius vector to center point.
     radiusPoint.x += center.x;
     radiusPoint.y += center.y;

--- a/packages/html-to-sketch/html2asketch/nodeToSketchLayers.ts
+++ b/packages/html-to-sketch/html2asketch/nodeToSketchLayers.ts
@@ -275,10 +275,11 @@ function parseSVGLinearGradient(node:SVGLinearGradientElement, ctm:DOMMatrix, bb
     }
   };
   ctm;
-  const point = new DOMPoint(node.x1.baseVal.value, node.y1.baseVal.value)// .matrixTransform(ctm);
+  const gtm = new DOMMatrix(getComputedStyle(node).transform);
+  const point = new DOMPoint(node.x1.baseVal.value, node.y1.baseVal.value).matrixTransform(gtm); // .matrixTransform(ctm);
   template.gradient.from.x = (point.x - bbox.x) / bbox.width;
   template.gradient.from.y = (point.y - bbox.y) / bbox.height;
-  const point2 = new DOMPoint(node.x2.baseVal.value, node.y2.baseVal.value)// .matrixTransform(ctm);
+  const point2 = new DOMPoint(node.x2.baseVal.value, node.y2.baseVal.value).matrixTransform(gtm); // .matrixTransform(ctm);
   template.gradient.to.x = (point2.x - bbox.x) / bbox.width;
   template.gradient.to.y = (point2.y - bbox.y) / bbox.height;
   template.gradient.stops = parseSVGGradientStops(node);
@@ -296,10 +297,11 @@ function parseSVGRadialGradient(node:SVGRadialGradientElement, ctm:DOMMatrix, bb
     }
   };
   ctm;
-  const f = new DOMPoint(node.fx.baseVal.value, node.fy.baseVal.value); //.matrixTransform(ctm);
+  const gtm = new DOMMatrix(getComputedStyle(node).transform);
+  const f = new DOMPoint(node.fx.baseVal.value, node.fy.baseVal.value).matrixTransform(gtm); //.matrixTransform(ctm);
   template.gradient.from.x = (f.x - bbox.x) / bbox.width;
   template.gradient.from.y = (f.y - bbox.y) / bbox.height;
-  const c = new DOMPoint(node.cx.baseVal.value, node.cy.baseVal.value); //.matrixTransform(ctm);
+  const c = new DOMPoint(node.cx.baseVal.value, node.cy.baseVal.value).matrixTransform(gtm); //.matrixTransform(ctm);
   // This should be `from + vec2(radius, 0)`
   template.gradient.to.x = (c.x - bbox.x) / bbox.width;
   template.gradient.to.y = (c.y - bbox.y) / bbox.height;

--- a/packages/html-to-sketch/html2asketch/nodeTreeToSketchGroup.ts
+++ b/packages/html-to-sketch/html2asketch/nodeTreeToSketchGroup.ts
@@ -29,48 +29,46 @@ export default function nodeTreeToSketchGroup(node: HTMLElement, options: any) {
   const layers = nodeToSketchLayers(node, {...options, layerOpacity: false}) || [];
 
 
-  if (node.nodeName !== 'svg') {
-    const processChild = (childNode: HTMLElement) => {
-      if (childNode.shadowRoot) {
-        // Get parent shadow root element
-        const root = nodeTreeToSketchGroup(childNode, options)
-        // Remove slotted content as it is already assigned
-        root._layers = []
-        // Process children
-        const children = Array.from(childNode.shadowRoot.children)
-          .filter(isNodeVisible)
-          .map(nodeTreeToSketchGroup)
-        // Align child and root positioning
-        children.forEach(layer => {
-          root._width = layer._width
-          root._height = layer._height
-          layer._x = 0
-          layer._y = 0
-          root._layers.push(layer)
-        });
-        layers.push(root)
-      } else {
-        layers.push(nodeTreeToSketchGroup(childNode, options));
-      }
-    };
-    const children = Array.from(node.children);
-    children
-      .map(getAssignedNodes)
-      .filter(isNodeVisible)
-      // sort the children by computed z-index so that nodes with lower z-indexes are added
-      // to the group first, "beneath" those with higher z-indexes
-      .sort((a, b) => {
-        const computedA: string = getComputedStyle(a).zIndex
-        const computedB: string = getComputedStyle(b).zIndex
-        const zIndexA: number = isNaN(Number(computedA)) ? 0 : +computedA
-        const zIndexB: number = isNaN(Number(computedB)) ? 0 : +computedB
-        return zIndexA - zIndexB;
-      })
-      .forEach(processChild);
-    // Process the added children. This is used for range input -webkit-slider-thumb and -webkit-slider-runnable-track.
-    for (let i = children.length, l = node.children.length; i < l; i++) {
-      processChild(node.children[i] as HTMLElement);
+  const processChild = (childNode: HTMLElement) => {
+    if (childNode.shadowRoot) {
+      // Get parent shadow root element
+      const root = nodeTreeToSketchGroup(childNode, options)
+      // Remove slotted content as it is already assigned
+      root._layers = []
+      // Process children
+      const children = Array.from(childNode.shadowRoot.children)
+        .filter(isNodeVisible)
+        .map(nodeTreeToSketchGroup)
+      // Align child and root positioning
+      children.forEach(layer => {
+        root._width = layer._width
+        root._height = layer._height
+        layer._x = 0
+        layer._y = 0
+        root._layers.push(layer)
+      });
+      layers.push(root)
+    } else {
+      layers.push(nodeTreeToSketchGroup(childNode, options));
     }
+  };
+  const children = Array.from(node.children);
+  children
+    .map(getAssignedNodes)
+    .filter(isNodeVisible)
+    // sort the children by computed z-index so that nodes with lower z-indexes are added
+    // to the group first, "beneath" those with higher z-indexes
+    .sort((a, b) => {
+      const computedA: string = getComputedStyle(a).zIndex
+      const computedB: string = getComputedStyle(b).zIndex
+      const zIndexA: number = isNaN(Number(computedA)) ? 0 : +computedA
+      const zIndexB: number = isNaN(Number(computedB)) ? 0 : +computedB
+      return zIndexA - zIndexB;
+    })
+    .forEach(processChild);
+  // Process the added children. This is used for range input -webkit-slider-thumb and -webkit-slider-runnable-track.
+  for (let i = children.length, l = node.children.length; i < l; i++) {
+    processChild(node.children[i] as HTMLElement);
   }
 
   // Now build a group for all these children

--- a/packages/html-to-sketch/html2asketch/nodeTreeToSketchGroup.ts
+++ b/packages/html-to-sketch/html2asketch/nodeTreeToSketchGroup.ts
@@ -25,9 +25,10 @@ export default function nodeTreeToSketchGroup(node: HTMLElement, options: any) {
   const width = bcr.right - bcr.left;
   const height = bcr.bottom - bcr.top;
 
-  // Collect layers for the node level itself
-  const layers = nodeToSketchLayers(node, {...options, layerOpacity: false}) || [];
+  const group = new Group({x: left, y: top, width, height});
 
+  // Collect layers for the node level itself
+  const layers = nodeToSketchLayers(node, group, {...options, layerOpacity: false}) || [];
 
   const processChild = (childNode: HTMLElement) => {
     if (childNode.shadowRoot) {
@@ -75,7 +76,6 @@ export default function nodeTreeToSketchGroup(node: HTMLElement, options: any) {
   const styles = getComputedStyle(node);
   const {opacity} = styles;
 
-  const group = new Group({x: left, y: top, width, height});
   const groupStyle = new Style();
 
   groupStyle.addOpacity(opacity);
@@ -112,6 +112,10 @@ export default function nodeTreeToSketchGroup(node: HTMLElement, options: any) {
   // set group name from node name
   else {
     group.setName(`${node.nodeName.toLowerCase()}`);
+  }
+
+  if (node instanceof SVGClipPathElement || node instanceof SVGDefsElement) { // Hide clipPaths
+    group._isVisible = false;
   }
 
   return group;

--- a/packages/html-to-sketch/package.json
+++ b/packages/html-to-sketch/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "normalize-css-color": "^1.0.2",
     "sketch-constants": "^1.1.0",
+    "svgpath": "^2.2.3",
     "uuid": "^3.4.0"
   },
   "main": "build/index"


### PR DESCRIPTION
This PR tracks work to add SVG parsing support to html-to-sketch.

# SVGs
- Only rect rx used as cornerRadius, ry is ignored.
- Sketch doesn't have transformation matrices in the document format. Object rotation is passed through though. Maybe it SVDs transformation matrices internally into rotation-scale-rotation sequences.

- [x] Convert path segments to cubics
- [x] Convert path segments to curvePoints
    - [x] Split path into layers at each M
- [x] Apply transformation stack to path points
    - multiply path points with node CTM
    - go through path points to compute bbox
    - export curvePoints
- [x] Clip SVG to viewport
    - create rect path for SVG element
    - add to SVG layers
    - set hasClippingMask to true
- [x] Convert other nodes to paths
    - [x] rect
    - [x] circle
    - [x] ellipse
    - [x] polygon
    - [x] polyline
    - [x] line
- [ ] Pass styles to SVG
    - [x] Stroke
        - [x] stroke
        - [x] stroke-dasharray
        - [x] stroke-dashoffset (Not supported)
        - [x] stroke-linecap
        - [x] stroke-linejoin
        - [x] stroke-miterlimit
        - [x] stroke-opacity
        - [x] stroke-width
    - [ ] Fill
        - [x] fill
        - [x] fill-opacity
        - [x] fill-rule
        - [x] gradient fill
            ```
            fill="url(#a)"
            <linearGradient id="a" gradientUnits="userSpaceOnUse" x1="32.002" y1="60" x2="32.002" y2="4.0049">
                <stop offset="0" stop-color="#ddd6d3"></stop>
                <stop offset=".3881" stop-color="#e9e4e2"></stop>
                <stop offset="1" stop-color="#e9e4e2"></stop>
            </linearGradient>
            ```
            ```
            {
                fillType: Style.FillType.Gradient,
                // color, gradient, pattern: 0, 1, 2
                gradient: {
                    gradientType: Style.GradientType.Linear,
                    // linear, radial, angular: 0, 1, 2
                    aspectRatio: number, // for radial: When the gradient is Radial, the from and to points makes one axis of the ellipse of the gradient while the aspect ratio determine the length of the orthogonal axis (aspectRatio === 1 means that it’s a circle).
                    // Not sure how from/to work with radial gradients.
                    from: {
                        x: 0,
                        y: 0,
                    },
                    to: {
                        x: 50,
                        y: 50,
                    },
                    stops: [
                        {
                        position: 0,
                        color: '#bbbbbb',
                        },
                        {
                        position: 0.5,
                        color: '#aaaaaa',
                        },
                        {
                        position: 1,
                        color: '#cccccc',
                        },
                    ],
                },
            }
            ```
            - [x] Transform gradient coordinates to correct system
                - [x] Convert gradient coords to path-bbox-relative coords ((point - bbox.topLeft) / bbox.dimensions)
                - [x] Apply gradientTransform
                - [ ] Do path transform affect gradients?
        - [x] Object bounding box coords
            - [x] Radial gradients
                - [x] Test
            - [x] Linear gradients
                - [x] Test
        - [ ] Image fill
            - https://developer.sketch.com/reference/api/#fill
        - [x] Pattern fill
            - Doesn't really exist in Sketch
- [x] How to deal with the (#( )#) filled paths
    - Inside path cuts away fill of outside path
    - Sketch imports the path with multiple inner paths
- [ ] Convert text to a text object
- [x] Clip paths from defs
    - [x] clip-path
    - [x] clip-rule
- [ ] Arrowheads
    - [ ] marker-end
    - [ ] marker-mid
    - [ ] marker-start
- [ ] Which of these CSS attributes are supported
    - [ ] mask
    - [ ] mask-type
    - [ ] filter
    - [ ] flood-color
    - [ ] flood-opacity
    - [ ] lighting-color
    - [ ] stop-color
    - [ ] stop-opacity
    - [ ] color-interpolation
    - [ ] color-interpolation-filters
    - [ ] color-rendering
    - [ ] shape-rendering
    - [ ] vector-effect
    - [ ] paint-order
- [x] Test with all icons
    - [x] Make all_icons.html
