### PR TITLE
fix: button

### DIFF
--- a/packages/components/src/components/button/button.css
+++ b/packages/components/src/components/button/button.css
@@ -10,6 +10,7 @@
  */
 
 :host {
+  --width: auto;
   --spacing-x: var(--scl-spacing-24);
   --spacing-x-icon-only: var(--scl-spacing-8);
   --min-height: var(--scl-spacing-40);
@@ -74,6 +75,7 @@
   font-size: var(--font-size);
   line-height: var(--line-height);
   min-height: var(--min-height);
+  width: var(--width);
   padding-left: var(--spacing-x);
   padding-right: var(--spacing-x);
   vertical-align: var(--vertical-align);

--- a/packages/components/src/components/button/button.tsx
+++ b/packages/components/src/components/button/button.tsx
@@ -9,7 +9,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { Component, Prop, h, Host, Element } from '@stencil/core';
+import { Component, Prop, h, Host, Listen, Element } from '@stencil/core';
 import classNames from 'classnames';
 import { hasShadowDom } from '../../utils/utils';
 
@@ -43,11 +43,23 @@ export class Button {
   @Prop() styles?: string;
 
   /**
+   * Prevent clicks from being emitted from the host
+   * when the component is `disabled`.
+   */
+  @Listen('click', { capture: true })
+  handleHostClick(event: Event) {
+    if (this.disabled === true) {
+      event.stopImmediatePropagation();
+    }
+  }
+
+  /**
    * Hack to make the button behave has expected when inside forms.
    * @see https://github.com/ionic-team/ionic-framework/blob/master/core/src/components/button/button.tsx#L155-L175
    */
   handleClick = (ev: Event) => {
-    if (hasShadowDom(this.hostElement) && this.disabled === false) {
+    // No need to check for `disabled` because disabled buttons won't emit clicks
+    if (hasShadowDom(this.hostElement)) {
       const form = this.hostElement.closest('form');
       if (form) {
         ev.preventDefault();

--- a/packages/storybook-vue/stories/3_components/button/Button.stories.mdx
+++ b/packages/storybook-vue/stories/3_components/button/Button.stories.mdx
@@ -80,6 +80,7 @@ export const Template = (args, { argTypes }) => ({
 
 ```css
 :host {
+  --width: auto;
   --spacing-x: var(--scl-spacing-24);
   --spacing-x-icon-only: var(--scl-spacing-8);
   --min-height: var(--scl-spacing-40);


### PR DESCRIPTION
- [x] prevent the button from emitting click events when disabled
- [ ] add unit test (missing, but 🆗)
- [x] add missing `--width` scoped variables (bonus ✨)

the "click event fired when disabled" issue is not reproducible in Storybook, and I'm 99% sure that's because of the "Vue layer" — I think we should consider —proudly— switching to a WC-only Storybook