### PR TITLE
fix(select): add  -moz query for rendering visual padding correctly

### DIFF
--- a/packages/components/src/components/dropdown/dropdown.css
+++ b/packages/components/src/components/dropdown/dropdown.css
@@ -66,6 +66,7 @@ scale-dropdown {
 .dropdown .input__helper-text {
   font-weight: var(--font-weight);
 }
+
 .dropdown .input__dropdown {
   width: 100%;
   height: var(--height);
@@ -84,6 +85,12 @@ scale-dropdown {
   text-overflow: ellipsis;
   appearance: none;
   -webkit-appearance: none;
+}
+
+@-moz-document url-prefix() {
+  .dropdown .input__dropdown {
+    text-indent: -2px;
+  }
 }
 
 .dropdown .input__dropdown-wrapper {
@@ -183,6 +190,7 @@ scale-dropdown {
 .dropdown--transparent .input__dropdown {
   background-color: transparent;
 }
+
 .dropdown--disabled label,
 .dropdown--disabled .input__label,
 .dropdown--disabled input,


### PR DESCRIPTION
fixes additional spacing for selected input value generated by firefox