### PR TITLE
docs(storybook): added angular.json

### DIFF
--- a/packages/storybook-vue/stories/2_for_developers/03.ScaleAndAngular_de.md
+++ b/packages/storybook-vue/stories/2_for_developers/03.ScaleAndAngular_de.md
@@ -56,15 +56,15 @@ export class AppModule {}
 ```
 
 ## angular.json
-```json
-"build" : {
-  "styles": [
-              "src/styles.css",
-              "node_modules/@telekom/scale-components/dist/scale-components/scale-components.css"
-            ],
-}
-```
 
+ ```json
+ {
+   "build": {
+     "styles": [
+       "node_modules/@telekom/scale-components/dist/scale-components/scale-components.css"
+     ]
+   }
+ }
 ## src/app.component.html
 
 ```html

--- a/packages/storybook-vue/stories/2_for_developers/03.ScaleAndAngular_de.md
+++ b/packages/storybook-vue/stories/2_for_developers/03.ScaleAndAngular_de.md
@@ -55,6 +55,16 @@ import { AppComponent } from './app.component';
 export class AppModule {}
 ```
 
+## angular.json
+```json
+"build" : {
+  "styles": [
+              "src/styles.css",
+              "node_modules/@telekom/scale-components/dist/scale-components/scale-components.css"
+            ],
+}
+```
+
 ## src/app.component.html
 
 ```html

--- a/packages/storybook-vue/stories/2_for_developers/03.ScaleAndAngular_de.md
+++ b/packages/storybook-vue/stories/2_for_developers/03.ScaleAndAngular_de.md
@@ -65,6 +65,7 @@ export class AppModule {}
      ]
    }
  }
+ 
 ## src/app.component.html
 
 ```html

--- a/packages/storybook-vue/stories/2_for_developers/03.ScaleAndAngular_en.md
+++ b/packages/storybook-vue/stories/2_for_developers/03.ScaleAndAngular_en.md
@@ -56,15 +56,15 @@ export class AppModule {}
 ```
 
 ## angular.json
-```json
-"build" : {
-  "styles": [
-              "src/styles.css",
-              "node_modules/@telekom/scale-components/dist/scale-components/scale-components.css"
-            ],
-}
-```
 
+ ```json
+ {
+   "build": {
+     "styles": [
+       "node_modules/@telekom/scale-components/dist/scale-components/scale-components.css"
+     ]
+   }
+ }
 ## src/app.component.html
 
 ```html

--- a/packages/storybook-vue/stories/2_for_developers/03.ScaleAndAngular_en.md
+++ b/packages/storybook-vue/stories/2_for_developers/03.ScaleAndAngular_en.md
@@ -55,6 +55,16 @@ import { AppComponent } from './app.component';
 export class AppModule {}
 ```
 
+## angular.json
+```json
+"build" : {
+  "styles": [
+              "src/styles.css",
+              "node_modules/@telekom/scale-components/dist/scale-components/scale-components.css"
+            ],
+}
+```
+
 ## src/app.component.html
 
 ```html

--- a/packages/storybook-vue/stories/2_for_developers/03.ScaleAndAngular_en.md
+++ b/packages/storybook-vue/stories/2_for_developers/03.ScaleAndAngular_en.md
@@ -65,6 +65,7 @@ export class AppModule {}
      ]
    }
  }
+ 
 ## src/app.component.html
 
 ```html


### PR DESCRIPTION
Hello,
I tried to implement Scale in an empty Angular project, but the styles were not applied correctly (missing fonts and colors). After some research, I found out that the stylesheet in ``angular.json`` was missing. After I added the specified line, all styles were applied correctly and worked. 
I think this should be added in the storybook to avoid any surprises.