### PR TITLE
fix(components): incorrect esm module link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To use the components, you need to load a CSS file and some JavaScript. The CSS 
 />
 <script
   type="module"
-  src="node_modules/@telekom/scale-components-neutral/dist/scale-components/scale-components.js"
+  src="node_modules/@telekom/scale-components-neutral/dist/scale-components/scale-components.esm.js"
 ></script>
 ```
 
@@ -105,7 +105,7 @@ npm install @telekom/scale-components
 />
 <script
   type="module"
-  src="node_modules/@telekom/scale-components/dist/scale-components/scale-components.js"
+  src="node_modules/@telekom/scale-components/dist/scale-components/scale-components.esm.js"
 ></script>
 ```
 

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -37,7 +37,7 @@ To use the components, you need to load a CSS file and some JavaScript. The CSS 
 />
 <script
   type="module"
-  src="node_modules/@telekom/scale-components-neutral/dist/scale-components/scale-components.js"
+  src="node_modules/@telekom/scale-components-neutral/dist/scale-components/scale-components.esm.js"
 ></script>
 ```
 
@@ -101,7 +101,7 @@ npm install @telekom/scale-components
 />
 <script
   type="module"
-  src="node_modules/@telekom/scale-components/dist/scale-components/scale-components.js"
+  src="node_modules/@telekom/scale-components/dist/scale-components/scale-components.esm.js"
 ></script>
 ```
 

--- a/packages/design-tokens/README.md
+++ b/packages/design-tokens/README.md
@@ -37,7 +37,7 @@ To use the components, you need to load a CSS file and some JavaScript. The CSS 
 />
 <script
   type="module"
-  src="node_modules/@telekom/scale-components-neutral/dist/scale-components/scale-components.js"
+  src="node_modules/@telekom/scale-components-neutral/dist/scale-components/scale-components.esm.js"
 ></script>
 ```
 
@@ -101,7 +101,7 @@ npm install @telekom/scale-components
 />
 <script
   type="module"
-  src="node_modules/@telekom/scale-components/dist/scale-components/scale-components.js"
+  src="node_modules/@telekom/scale-components/dist/scale-components/scale-components.esm.js"
 ></script>
 ```
 

--- a/packages/storybook-vue/stories/2_for_developers/01.Setup_de.md
+++ b/packages/storybook-vue/stories/2_for_developers/01.Setup_de.md
@@ -16,7 +16,7 @@ Um die Komponenten zu verwenden, lade die CSS-Datei sowie JavaScript. Die CSS-Da
 
 ```bash
 <link rel="stylesheet" href="node_modules/@telekom/scale-components/dist/scale-components/scale-components.css">
-<script type="module" src="node_modules/@telekom/scale-components/dist/scale-components/scale-components.js"></script>
+<script type="module" src="node_modules/@telekom/scale-components/dist/scale-components/scale-components.esm.js"></script>
 ```
 
 ### Mit Bundler oder ES-Modulen

--- a/packages/storybook-vue/stories/2_for_developers/01.Setup_en.md
+++ b/packages/storybook-vue/stories/2_for_developers/01.Setup_en.md
@@ -18,7 +18,7 @@ To use the components, you need to load a CSS file and some JavaScript. The CSS 
 
 ```bash
 <link rel="stylesheet" href="node_modules/@telekom/scale-components/dist/scale-components/scale-components.css">
-<script type="module" src="node_modules/@telekom/scale-components/dist/scale-components/scale-components.js"></script>
+<script type="module" src="node_modules/@telekom/scale-components/dist/scale-components/scale-components.esm.js"></script>
 ```
 
 ### With a bundler or ES modules


### PR DESCRIPTION
The vanilla snippets currently use a broken URL, this fixes that.

<img width="958" alt="Captura de Pantalla 2021-05-18 a les 13 12 31" src="https://user-images.githubusercontent.com/851105/118641684-bc9b9b00-b7da-11eb-8207-671acf0677c1.png">
