### PR TITLE
chore: change h5 in Tables to caption (same as code example)

### DIFF
--- a/packages/storybook-vue/stories/3_components/table/Table.stories.mdx
+++ b/packages/storybook-vue/stories/3_components/table/Table.stories.mdx
@@ -258,7 +258,8 @@ scale-table {
 ```html
 <scale-table size="small">
   <table>
-    <h5>Table title</h5>
+    <!-- Add visibility CSS to caption, to not show the caption. For example shifting it out of the view -->
+    <caption>Table title</caption>
     <thead>
       <tr>
         <th>Title</th>
@@ -302,7 +303,7 @@ Please switch to the Canvas view for a working example
 ```html
 <scale-table show-sort>
   <table>
-    <h5>Table title</h5>
+    <caption>Table title</caption>
     <thead>
       <tr>
         <!-- aria-sort can be descending or ascending -->


### PR DESCRIPTION
Hi,
while working with Tables I noticed a discrepancy between the storybook documentation and the presented examples.
The examples are using `<caption>` Tags following the HTML standard. But the corresponding shown code is using h5 Tags.

I concluded that `<h5>` is probably leftover from previous Versions. So I adjusted the Markdown. Also, I added a Comment suggesting to shift out the caption so it doesn't get shown (the same way it's done in the Example).

I did a little bit of digging into the old GitLab repo but couldn't pin down the exact Point h5 got introduced. But I concluded that `<caption>` should be mentioned here since WCAG 2.0 ([WCAG Table Caption](https://www.w3.org/WAI/tutorials/tables/caption-summary/))  implies the usage for accessibility reasons.

The storybook `build` and `serve` is working. And the changes are getting shown. I didn't do any additional tests.