### PR TITLE
chore: adjust documentation showStatus no default

### DIFF
--- a/packages/storybook-vue/stories/3_components/progress-bar/ProgressBar.stories.mdx
+++ b/packages/storybook-vue/stories/3_components/progress-bar/ProgressBar.stories.mdx
@@ -150,7 +150,8 @@ For Shadow Parts, please inspect the element's #shadow.
     args={{
       percentage: 20,
       customColor: "#009DE0",
-      label:"Progress custom"
+      label:"Progress custom",
+      showStatus: true
     }}
   >
     {Template.bind({})}
@@ -158,7 +159,7 @@ For Shadow Parts, please inspect the element's #shadow.
 </Canvas>
 
 ```html
-<scale-progress-bar percentage="20" custom-color="#009DE0" label="Progress custom"></scale-progress-bar>
+<scale-progress-bar percentage="20" custom-color="#009DE0" label="Progress custom" show-status="true"></scale-progress-bar>
 ```
 
 

--- a/packages/storybook-vue/stories/3_components/progress-bar/ProgressBar.stories.mdx
+++ b/packages/storybook-vue/stories/3_components/progress-bar/ProgressBar.stories.mdx
@@ -150,8 +150,7 @@ For Shadow Parts, please inspect the element's #shadow.
     args={{
       percentage: 20,
       customColor: "#009DE0",
-      label:"Progress custom",
-      showStatus: true
+      label:"Progress custom"
     }}
   >
     {Template.bind({})}
@@ -159,7 +158,7 @@ For Shadow Parts, please inspect the element's #shadow.
 </Canvas>
 
 ```html
-<scale-progress-bar percentage="20" custom-color="#009DE0" label="Progress custom" show-status="true"></scale-progress-bar>
+<scale-progress-bar percentage="20" custom-color="#009DE0" label="Progress custom"></scale-progress-bar>
 ```
 
 
@@ -171,7 +170,8 @@ For Shadow Parts, please inspect the element's #shadow.
     args={{
       percentage: 40,
       statusDescription: 'Progress status description text',
-      label: 'Progress with description'
+      label: 'Progress with description',
+      showStatus: true
     }}
   >
     {Template.bind({})}
@@ -179,7 +179,7 @@ For Shadow Parts, please inspect the element's #shadow.
 </Canvas>
 
 ```html
-<scale-progress-bar percentage="40" stroke-width="40" status-description="Progress status description text"></scale-progress-bar>
+<scale-progress-bar percentage="40" stroke-width="40" status-description="Progress status description text" show-status="true"></scale-progress-bar>
 ```
 
 

--- a/packages/storybook-vue/stories/3_components/progress-bar/ScaleProgressBar.vue
+++ b/packages/storybook-vue/stories/3_components/progress-bar/ScaleProgressBar.vue
@@ -27,7 +27,7 @@ export default {
     hasError: Boolean,
     statusDescription: String,
     styles: String,
-    showStatus: { type: Boolean, default: true },
+    showStatus: Boolean,
     strokeWidth: Number,
     percentage: Number,
     message: String,


### PR DESCRIPTION
Hi,
while working with the progress bar I noticed another problem with the documentation. It suggests that show-status has a default value, which is not the case in the Stencil Component. Also, the shown Code for the first and second examples doesn't match the canvas.

I changed the default Value of show-status to none in the Storybook-Vue file so it does not suggest that show-status has a default.
Also, I changed the first example to be coherent to before adding `show-status: true` to the canvas and adding it to the example HTML code.
The second example now does not show the status anymore, but the example HTML code also doesn't contain it.

Like this, the Storybook represents the Stencil component and the example codes match the canvases they represent.

The Storybook is building and is working correctly. No additional tests.

If not the documentation is wrong, but the Stencil Component has unwanted behavior, I can change it the other way around in another PR, I already prepared such a Branch.