### PR TITLE
fix: icon Buttons on Indexhtml wrong syntax

### DIFF
--- a/packages/components/src/html/index.html
+++ b/packages/components/src/html/index.html
@@ -573,12 +573,10 @@
     <h3>Button variants</h3>
     <scale-button
       variant="primary"
-      icon-before="M10 2a8 8 0 016.472 12.703l4.912 4.913.06.065a1.25 1.25 0 01-1.726 1.794l-.102-.091-4.913-4.912A8 8 0 1110 2zm0 1.5A6.508 6.508 0 003.5 10c0 3.584 2.916 6.5 6.5 6.5s6.5-2.916 6.5-6.5-2.916-6.5-6.5-6.5z"
       >Hello</scale-button
     >
     <scale-button
       variant="secondary"
-      icon-before="M10 2a8 8 0 016.472 12.703l4.912 4.913.06.065a1.25 1.25 0 01-1.726 1.794l-.102-.091-4.913-4.912A8 8 0 1110 2zm0 1.5A6.508 6.508 0 003.5 10c0 3.584 2.916 6.5 6.5 6.5s6.5-2.916 6.5-6.5-2.916-6.5-6.5-6.5z"
       >Hello</scale-button
     >
 
@@ -589,7 +587,7 @@
 
     <h3>Button icon After</h3>
     <scale-button icon-position="after">
-      Label <scale-icon-navigation-right></cale-icon-navigation-right>
+      Label <scale-icon-navigation-right></scale-icon-navigation-right>
     </scale-button>
 
     <h3>Button icon only</h3>

--- a/packages/components/src/html/index.html
+++ b/packages/components/src/html/index.html
@@ -583,16 +583,19 @@
     >
 
     <h3>Button icon Before</h3>
-    <scale-button
-      icon-before="M10 2a8 8 0 016.472 12.703l4.912 4.913.06.065a1.25 1.25 0 01-1.726 1.794l-.102-.091-4.913-4.912A8 8 0 1110 2zm0 1.5A6.508 6.508 0 003.5 10c0 3.584 2.916 6.5 6.5 6.5s6.5-2.916 6.5-6.5-2.916-6.5-6.5-6.5z"
-    >
-      Hello
+    <scale-button>
+      <scale-icon-action-search></scale-icon-action-search> Label
+    </scale-button>
+
+    <h3>Button icon After</h3>
+    <scale-button icon-position="after">
+      Label <scale-icon-navigation-right></cale-icon-navigation-right>
     </scale-button>
 
     <h3>Button icon only</h3>
-    <scale-button
-      icon="M10 2a8 8 0 016.472 12.703l4.912 4.913.06.065a1.25 1.25 0 01-1.726 1.794l-.102-.091-4.913-4.912A8 8 0 1110 2zm0 1.5A6.508 6.508 0 003.5 10c0 3.584 2.916 6.5 6.5 6.5s6.5-2.916 6.5-6.5-2.916-6.5-6.5-6.5z"
-    ></scale-button>
+    <scale-button icon-only="true">
+      <scale-icon-navigation-external-link accessibility-title="External link, opens in new tab"></scale-icon-navigation-external-link>
+    </scale-button>
 
     <h3>Button Link</h3>
     <scale-button href="http://google.com" target="_blank">

--- a/packages/components/src/html/index.html
+++ b/packages/components/src/html/index.html
@@ -571,14 +571,8 @@
     <scale-button>Hello</scale-button>
 
     <h3>Button variants</h3>
-    <scale-button
-      variant="primary"
-      >Hello</scale-button
-    >
-    <scale-button
-      variant="secondary"
-      >Hello</scale-button
-    >
+    <scale-button variant="primary">Hello</scale-button>
+    <scale-button variant="secondary">Hello</scale-button>
 
     <h3>Button icon Before</h3>
     <scale-button>
@@ -592,7 +586,9 @@
 
     <h3>Button icon only</h3>
     <scale-button icon-only="true">
-      <scale-icon-navigation-external-link accessibility-title="External link, opens in new tab"></scale-icon-navigation-external-link>
+      <scale-icon-navigation-external-link
+        accessibility-title="External link, opens in new tab"
+      ></scale-icon-navigation-external-link>
     </scale-button>
 
     <h3>Button Link</h3>


### PR DESCRIPTION
Tries to fix the problem I found with #382 

### Before
![Bildschirmfoto 2021-06-04 um 15 34 56](https://user-images.githubusercontent.com/26364692/120812838-a79a6800-c54d-11eb-9355-c547d9ad2e4b.png)

### Now
![Bildschirmfoto 2021-06-04 um 15 58 23](https://user-images.githubusercontent.com/26364692/120812908-b7b24780-c54d-11eb-8327-30fd2327bbe7.png)

Uses the same example code as the Storybook.