### PR TITLE
fix: remove child nodes, which are whitespace strings

### DIFF
--- a/packages/components/src/components/button/__snapshots__/button.spec.ts.snap
+++ b/packages/components/src/components/button/__snapshots__/button.spec.ts.snap
@@ -22,10 +22,22 @@ exports[`Button should handle click 2`] = `
 </scale-button>
 `;
 
-exports[`Button should handle more than 1 node 1`] = `
+exports[`Button should handle icon after 1`] = `
 <scale-button icon-position="after" size="small">
   <mock:shadow-root>
     <button class="button button--icon-after button--size-small button--variant-primary" part="base variant-primary after">
+      <slot></slot>
+    </button>
+  </mock:shadow-root>
+  Label
+  <scale-icon-action-search size="16"></scale-icon-action-search>
+</scale-button>
+`;
+
+exports[`Button should handle icon before 1`] = `
+<scale-button icon-position="before" size="small">
+  <mock:shadow-root>
+    <button class="button button--icon-before button--size-small button--variant-primary" part="base variant-primary before">
       <slot></slot>
     </button>
   </mock:shadow-root>

--- a/packages/components/src/components/button/button.spec.ts
+++ b/packages/components/src/components/button/button.spec.ts
@@ -38,12 +38,27 @@ describe('Button', () => {
     expect(element.getCssClassMap()).toContain('button--disabled');
   });
 
-  it('should handle more than 1 node', async () => {
+  it('should handle icon before', async () => {
     const page = await newSpecPage({
       components: [Button],
       html: `    
       <scale-button size="small">
-        <scale-icon-action-search size="16" /> Label
+        <scale-icon-action-search size="16" /> 
+        Label
+      </scale-button>
+      `,
+    });
+    expect(page.rootInstance.iconPosition).toBe('before');
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should handle icon after', async () => {
+    const page = await newSpecPage({
+      components: [Button],
+      html: `    
+      <scale-button size="small">
+        Label 
+        <scale-icon-action-search size="16" />
       </scale-button>
       `,
     });

--- a/packages/components/src/components/button/button.tsx
+++ b/packages/components/src/components/button/button.tsx
@@ -85,13 +85,10 @@ export class Button {
    * If so, it's probably an icon, so we set `iconPosition` to `after`.
    */
   setIconPositionProp() {
-    const nodes = Array.from(this.hostElement.childNodes);
-    // delete empty text nodes, which are due to formatting
-    for (let i = 0; i < nodes.length; i++) {
-      if (nodes[i].nodeType === 3 && nodes[i].nodeValue.trim() === '') {
-        nodes.splice(i, 1);
-      }
-    }
+    const nodes = Array.from(this.hostElement.childNodes).filter((node) => {
+      // ignore empty text nodes, which are probably due to formatting
+      return !(node.nodeType === 3 && node.nodeValue.trim() === '');
+    });
     if (nodes.length < 2) {
       return;
     }

--- a/packages/components/src/components/button/button.tsx
+++ b/packages/components/src/components/button/button.tsx
@@ -86,6 +86,12 @@ export class Button {
    */
   setIconPositionProp() {
     const nodes = Array.from(this.hostElement.childNodes);
+    // delete empty text nodes, which are due to formatting
+    for (let i = 0; i < nodes.length; i++) {
+      if (nodes[i].nodeType === 3 && nodes[i].nodeValue.trim() === '') {
+        nodes.splice(i, 1);
+      }
+    }
     if (nodes.length < 2) {
       return;
     }


### PR DESCRIPTION
child nodes, which are whitespace strings have to be removed to let 'icon after' work fine