### PR TITLE
feat: add fill to icon with higher priority than color

### DIFF
--- a/packages/components/scripts/icon-component.hbs
+++ b/packages/components/scripts/icon-component.hbs
@@ -20,9 +20,9 @@ export class {{className}} {
   /** (optional) The width and height in pixels */
   @Prop() size?: number = 24;
   /** (optional) Sets the icon color via the `fill` attribute */
-  @Prop() color?: string = 'currentColor';
-  /** (optional) Sets the icon color via the `fill` attribute */
   @Prop() fill?: string = 'currentColor'; 
+  /** (optional) Alias for `fill` */
+  @Prop() color?: string = 'currentColor';
   /** (optional) If `true`, the icon changes visually */
   @Prop() selected?: boolean = false;
   /** (optional) If `true` the SVG element will get `aria-hidden="true"` */

--- a/packages/components/scripts/icon-component.hbs
+++ b/packages/components/scripts/icon-component.hbs
@@ -20,7 +20,9 @@ export class {{className}} {
   /** (optional) The width and height in pixels */
   @Prop() size?: number = 24;
   /** (optional) Sets the icon color via the `fill` attribute */
-  @Prop() color?: string = 'currentColor'; 
+  @Prop() color?: string = 'currentColor';
+  /** (optional) Sets the icon color via the `fill` attribute */
+  @Prop() fill?: string = 'currentColor'; 
   /** (optional) If `true`, the icon changes visually */
   @Prop() selected?: boolean = false;
   /** (optional) If `true` the SVG element will get `aria-hidden="true"` */
@@ -41,7 +43,7 @@ export class {{className}} {
       <Host>
         <svg xmlns="http://www.w3.org/2000/svg" width={this.size} height={this.size} viewBox="{{viewBox}}" {...ariaHidden}>
           {this.accessibilityTitle && <title>{this.accessibilityTitle}</title>}
-          <g fill={this.color}>
+          <g fill={((this.fill === 'currentColor') ? this.color : this.fill)}>
             {this.selected ? (<g>{{{markup.selected}}}</g>) : (<g>{{{markup.default}}}</g>)}
           </g>
         </svg>

--- a/packages/storybook-vue/stories/3_components/icon/Icon.stories.mdx
+++ b/packages/storybook-vue/stories/3_components/icon/Icon.stories.mdx
@@ -153,7 +153,7 @@ When using the `name` attribute, the component assumes there is an object with a
 
 <Canvas withSource="none">
   <Story name="Icon Library" args={{
-    color: '#E20074',
+    fill: '#E20074',
     selected: true,
     size: 24,
     accessibilityTitle: 'favorite',
@@ -164,7 +164,7 @@ When using the `name` attribute, the component assumes there is an object with a
 </Canvas>
 
 ```html
-<scale-icon-action-favorite color="#E20074" size="24" selected accessibility-title="favorite"></scale-icon-action-favorite>
+<scale-icon-action-favorite fill="#E20074" size="24" selected accessibility-title="favorite"></scale-icon-action-favorite>
 ```
 
 ### Full list, grouped by category

--- a/packages/storybook-vue/stories/3_components/icon/ScaleIconLibraryExample.vue
+++ b/packages/storybook-vue/stories/3_components/icon/ScaleIconLibraryExample.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <scale-icon-action-favorite
-      :color="color"
+      :fill="fill"
       :size="size"
       :selected="selected"
       :decorative="decorative"
@@ -13,6 +13,7 @@
 <script>
 export default {
   props: {
+    fill: { type: String, default: 'currentColor'},
     color: { type: String, default: 'currentColor' },
     size: { type: Number, default: 24 },
     selected: { type: Boolean, default: false },


### PR DESCRIPTION
Hi ✌️
yesterday I opened #405 

Resulting from that I took a look at what the icon handlebar actually does (icon-component.hbs). And as you can see in line 44 of the icon component, it just adds the `color` Prop as an SVG `fill` attribute.

This is the same behavior the scale-icon Wrapper Component has (over the pathAttributes).

So I added a `fill` prop which has priority over the `color` prop. Resulting in this behavior:
```
<scale-icon-action-circle-close color="green"> </scale-icon-action-circle-close>
<scale-icon-action-close fill="red"> </scale-icon-action-close>
<scale-icon-action-download fill="red" color="green"> </scale-icon-action-download>
```
<img width="90" alt="Bildschirmfoto 2021-06-16 um 23 04 06" src="https://user-images.githubusercontent.com/26364692/122293299-28b31100-cef7-11eb-99b6-9c27bc0f7983.png">

I reorded the Storybook a bit so it meets the behavior. Showing examples with `fill` instead of `color`.
Like this scale-icons and icons from the Library have the same behavior using `fill`, without removing the support for `color`.

Tests and Visual Tests are passing for me (out of accordion failing occasionally but that also happens on main).