### PR TITLE
chore: documentation and z-index

### DIFF
--- a/packages/components-sketch/views/index.hbs
+++ b/packages/components-sketch/views/index.hbs
@@ -31,4 +31,5 @@ file, You can obtain one at https://mozilla.org/MPL/2.0/.
   <p><a href="/textarea">Textarea</a></p>
   <p><a href="/text-field">Text Field</a></p>
   <p><a href="/text-lists">Text Lists</a></p>
+  <p><a href="/tooltip">Tooltip</a></p>
 </div>

--- a/packages/components-sketch/views/tooltip.hbs
+++ b/packages/components-sketch/views/tooltip.hbs
@@ -1,0 +1,94 @@
+{{!--
+Scale https://github.com/telekom/scale
+
+Copyright (c) 2021 Egor Kirpichev and contributors, Deutsche Telekom AG
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
+--}}
+
+<div data-sketch-artboard="Tooltip" class="artboard">
+  <h1 class="title--artboard">Tooltip</h1>
+
+  <h2 class="title--artboard-section">Tooltip Top</h2>
+  <div class="agent-states--grid" data-category="Top">
+    <div class="agent-states--item">
+      <p class="agent-states--label">:default</p>
+      <scale-tooltip content="Tooltip" placement="top" open="true">
+      </scale-tooltip>
+    </div>
+    <div class="agent-states--item">
+      <p class="agent-states--label">:start</p>
+      <scale-tooltip content="Tooltip" placement="top-start" open="true">
+      </scale-tooltip>
+    </div>
+    <div class="agent-states--item">
+      <p class="agent-states--label">:end</p>
+      <scale-tooltip content="Tooltip" placement="top-end" open="true">
+      </scale-tooltip>
+    </div> 
+  </div>
+  <h2 class="title--artboard-section">Tooltip Right</h2>
+  <div class="agent-states--grid" data-category="Right">
+    <div class="agent-states--item">
+      <p class="agent-states--label">:default</p>
+      <scale-tooltip content="Tooltip" placement="right" open="true">
+      </scale-tooltip>
+    </div>
+    <div class="agent-states--item">
+      <p class="agent-states--label">:start</p>
+      <scale-tooltip content="Tooltip" placement="right-start" open="true">
+      </scale-tooltip>
+    </div>
+    <div class="agent-states--item">
+      <p class="agent-states--label">:end</p>
+      <scale-tooltip content="Tooltip" placement="right-end" open="true">
+      </scale-tooltip>
+    </div> 
+  </div>
+  <h2 class="title--artboard-section">Tooltip bottom</h2>
+  <div class="agent-states--grid" data-category="Bottom">
+    <div class="agent-states--item">
+      <p class="agent-states--label">:default</p>
+      <scale-tooltip content="Tooltip" placement="bottom" open="true">
+      </scale-tooltip>
+    </div>
+    <div class="agent-states--item">
+      <p class="agent-states--label">:start</p>
+      <scale-tooltip content="Tooltip" placement="bottom-start" open="true">
+      </scale-tooltip>
+    </div>
+    <div class="agent-states--item">
+      <p class="agent-states--label">:end</p>
+      <scale-tooltip content="Tooltip" placement="bottom-end" open="true">
+      </scale-tooltip>
+    </div> 
+  </div>
+  <h2 class="title--artboard-section">Tooltip left</h2>
+  <div class="agent-states--grid" data-category="Left">
+    <div class="agent-states--item">
+      <p class="agent-states--label">:default</p>
+      <scale-tooltip content="Tooltip" placement="left" open="true">
+      </scale-tooltip>
+    </div>
+    <div class="agent-states--item">
+      <p class="agent-states--label">:start</p>
+      <scale-tooltip content="Tooltip" placement="left-start" open="true">
+      </scale-tooltip>
+    </div>
+    <div class="agent-states--item">
+      <p class="agent-states--label">:end</p>
+      <scale-tooltip content="Tooltip" placement="left-end" open="true">
+      </scale-tooltip>
+    </div> 
+  </div>
+</div>
+
+<script src="/symbol_names.js"></script>
+<script>
+  Array.from(document.querySelectorAll('scale-tooltip')).forEach((btn, i) => {
+    btn.dataset.sketchSymbol = `Tooltip / ${order(1, getCategoryName(btn))} / 
+    ${order(2, capitalize(btn.getAttribute('placement')))}`;
+  });
+</script>

--- a/packages/components/src/components/tooltip/readme.md
+++ b/packages/components/src/components/tooltip/readme.md
@@ -7,32 +7,32 @@
 
 ## Properties
 
-| Property    | Attribute   | Description                                                                                                                                                                                                                                   | Type                                                                                                                                                                 | Default         |
-| ----------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
-| `content`   | `content`   | The tooltip's content. Alternatively, you can use the content slot.                                                                                                                                                                           | `string`                                                                                                                                                             | `''`            |
-| `disabled`  | `disabled`  | Set to true to disable the tooltip so it won't show when triggered.                                                                                                                                                                           | `boolean`                                                                                                                                                            | `false`         |
-| `distance`  | `distance`  | The distance in pixels from which to offset the tooltip away from its target.                                                                                                                                                                 | `number`                                                                                                                                                             | `10`            |
-| `open`      | `open`      | Indicates whether or not the tooltip is open. You can use this in lieu of the show/hide methods.                                                                                                                                              | `boolean`                                                                                                                                                            | `false`         |
-| `placement` | `placement` | The preferred placement of the tooltip. Note that the actual placement may vary as needed to keep the tooltip inside of the viewport.                                                                                                         | `"bottom" \| "bottom-end" \| "bottom-start" \| "left" \| "left-end" \| "left-start" \| "right" \| "right-end" \| "right-start" \| "top" \| "top-end" \| "top-start"` | `'top'`         |
-| `skidding`  | `skidding`  | The distance in pixels from which to offset the tooltip along its target.                                                                                                                                                                     | `number`                                                                                                                                                             | `0`             |
-| `trigger`   | `trigger`   | Controls how the tooltip is activated. Possible options include `click`, `hover`, `focus`, and `manual`. Multiple options can be passed by separating them with a space. When manual is used, the tooltip must be activated programmatically. | `string`                                                                                                                                                             | `'hover focus'` |
+| Property    | Attribute   | Description                                                                                                                                                                                           | Type                                                                                                                                                                 | Default         |
+| ----------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| `content`   | `content`   | (optional) The content of the Tooltip supporting Text only                                                                                                                                            | `string`                                                                                                                                                             | `''`            |
+| `disabled`  | `disabled`  | (optional) Disable Tooltip                                                                                                                                                                            | `boolean`                                                                                                                                                            | `false`         |
+| `distance`  | `distance`  | (optional) Distance of the Tooltip from the Target Object (related to the `placement`)                                                                                                                | `number`                                                                                                                                                             | `5`             |
+| `open`      | `open`      | (optional) Set the Tooltip to open per default (will still be closed on closing Events)                                                                                                               | `boolean`                                                                                                                                                            | `false`         |
+| `placement` | `placement` | (optional) Position of the Tooltip on the Object                                                                                                                                                      | `"bottom" \| "bottom-end" \| "bottom-start" \| "left" \| "left-end" \| "left-start" \| "right" \| "right-end" \| "right-start" \| "top" \| "top-end" \| "top-start"` | `'top'`         |
+| `skidding`  | `skidding`  | (optional) skidding moves the tooltip of the element in dependence of its `placement` to the element either on an x-axis (at `placement` top/down) or on a y-axis (for output `placement` left/right) | `number`                                                                                                                                                             | `0`             |
+| `trigger`   | `trigger`   | (optional) Set custom trigger Event selection                                                                                                                                                         | `string`                                                                                                                                                             | `'hover focus'` |
 
 
 ## Events
 
-| Event           | Description                                                                                                  | Type               |
-| --------------- | ------------------------------------------------------------------------------------------------------------ | ------------------ |
-| `sl-after-hide` | Emitted after the tooltip has hidden and all transitions are complete.                                       | `CustomEvent<any>` |
-| `sl-aftershow`  | Emitted after the tooltip has shown and all transitions are complete.                                        | `CustomEvent<any>` |
-| `sl-hide`       | Emitted when the tooltip begins to hide. Calling `event.preventDefault()` will prevent it from being hidden. | `CustomEvent<any>` |
-| `sl-show`       | Emitted when the tooltip begins to show. Calling `event.preventDefault()` will prevent it from being shown.  | `CustomEvent<any>` |
+| Event              | Description | Type               |
+| ------------------ | ----------- | ------------------ |
+| `scale-after-hide` |             | `CustomEvent<any>` |
+| `scale-aftershow`  |             | `CustomEvent<any>` |
+| `scale-hide`       |             | `CustomEvent<any>` |
+| `scale-show`       |             | `CustomEvent<any>` |
 
 
 ## Methods
 
-### `hide() => Promise<void>`
+### `hideTooltip() => Promise<void>`
 
-Shows the tooltip.
+
 
 #### Returns
 
@@ -40,43 +40,22 @@ Type: `Promise<void>`
 
 
 
-### `show() => Promise<void>`
+### `showTooltip() => Promise<void>`
 
-Shows the tooltip.
+
 
 #### Returns
 
 Type: `Promise<void>`
 
 
-
-
-## Slots
-
-| Slot        | Description                                                                      |
-| ----------- | -------------------------------------------------------------------------------- |
-|             | The tooltip's target element. Only the first element will be used as the target. |
-| `"content"` | The tooltip's content. Alternatively, you can use the content prop.              |
 
 
 ## Shadow Parts
 
-| Part     | Description                   |
-| -------- | ----------------------------- |
-| `"base"` | The component's base wrapper. |
-
-
-## CSS Custom Properties
-
-| Name                     | Description                                                  |
-| ------------------------ | ------------------------------------------------------------ |
-| `--hide-delay`           | The amount of time to wait before hiding the tooltip.        |
-| `--hide-duration`        | The amount of time the hide transition takes to complete.    |
-| `--hide-timing-function` | The timing function (easing) to use for the hide transition. |
-| `--max-width`            | The maximum width of the tooltip.                            |
-| `--show-delay`           | The amount of time to wait before showing the tooltip.       |
-| `--show-duration`        | The amount of time the show transition takes to complete.    |
-| `--show-timing-function` | The timing function (easing) to use for the show transition. |
+| Part     | Description |
+| -------- | ----------- |
+| `"base"` |             |
 
 
 ----------------------------------------------

--- a/packages/components/src/components/tooltip/tooltip.css
+++ b/packages/components/src/components/tooltip/tooltip.css
@@ -9,7 +9,7 @@ host*,
   --scale-tooltip-background-color: var(--scl-color-grey-60);
   --scale-tooltip-color: var(--scl-color-white);
   --scale-tooltip-font-weight: var(--scl-font-weight-regular);
-  --scale-tooltip-font-size: var(--scl-font-size-12);
+  --scale-tooltip-font-size: var(--scl-font-size-16);
   --scale-tooltip-line-height: 1.4;
   --scale-tooltip-padding: var(--scl-spacing-2) var(--scl-spacing-8);
   --scale-tooltip-arrow-size: 5px;
@@ -21,6 +21,7 @@ host*,
   --scale-tooltip-hide-timing-function: ease;
   --scale-tooltip-show-duration: 0.125s;
   --scale-tooltip-show-timing-function: ease;
+  --scale-tooltip-z-index: var(--scl-z-index-70);
 
   display: contents;
   position: relative;
@@ -29,7 +30,7 @@ host*,
 
 .tooltip-positioner {
   position: absolute;
-  z-index: var(--scale-z-index-tooltip);
+  z-index: var(--scale-tooltip-z-index);
   pointer-events: none;
 }
 

--- a/packages/components/src/components/tooltip/tooltip.tsx
+++ b/packages/components/src/components/tooltip/tooltip.tsx
@@ -27,8 +27,9 @@ export class Tooltip {
   tooltip: any;
 
   @Element() host: HTMLScaleTooltipElement;
-
+  /** (optional) The content of the Tooltip supporting Text only */
   @Prop() content = '';
+  /** (optional) Position of the Tooltip on the Object */
   @Prop() placement:
     | 'top'
     | 'top-start'
@@ -42,10 +43,16 @@ export class Tooltip {
     | 'left'
     | 'left-start'
     | 'left-end' = 'top';
+  /** (optional) Disable Tooltip */
   @Prop() disabled = false;
+  /** (optional) Distance of the Tooltip from the Target Object (related to the `placement`) */
   @Prop() distance = 5;
+  /** (optional) Set the Tooltip to open per default (will still be closed on closing Events) */
   @Prop({ mutable: true, reflect: true }) open = false;
+  /** (optional) skidding moves the tooltip of the element in dependence of its `placement` to the element either on an x-axis (at `placement` top/down)
+  or on a y-axis (for output `placement` left/right) */
   @Prop() skidding = 0;
+  /** (optional) Set custom trigger Event selection */
   @Prop() trigger: string = 'hover focus';
 
   @Watch('open')

--- a/packages/storybook-vue/.storybook/usage-addon/usage.js
+++ b/packages/storybook-vue/.storybook/usage-addon/usage.js
@@ -73,6 +73,8 @@ import textField_en from 'raw-loader!../../stories/3_components/text-field/text-
 import textField_de from 'raw-loader!../../stories/3_components/text-field/text-field_de.md';
 import footer_en from 'raw-loader!../../stories/3_components/footer/footer.md';
 import footer_de from 'raw-loader!../../stories/3_components/footer/footer_de.md';
+import tooltip_en from 'raw-loader!../../stories/3_components/tooltip/tooltip.md';
+import tooltip_de from 'raw-loader!../../stories/3_components/tooltip/tooltip_de.md';
 
 const NOT_A_COMPONENT_MD = '`Browse to any component to see usage.`';
 const COMPONENT_NOT_MAPPED_MD =
@@ -157,6 +159,8 @@ const Usage = (props) => {
     'text-field_de': textField_de,
     footer_en,
     footer_de,
+    tooltip_en,
+    tooltip_de
   };
 
   // Select the most appropriate markdown text based on if this is a component story and

--- a/packages/storybook-vue/stories/3_components/tooltip/ScaleTooltip.vue
+++ b/packages/storybook-vue/stories/3_components/tooltip/ScaleTooltip.vue
@@ -1,0 +1,11 @@
+<template>
+  <div styles="height: 500px;">
+    <scale-tooltip open="true" placement="right" content="A Tooltip!"></scale-tooltip>
+  </div>
+</template>
+
+<script>
+export default {
+  
+}
+</script>

--- a/packages/storybook-vue/stories/3_components/tooltip/Tooltip.stories.mdx
+++ b/packages/storybook-vue/stories/3_components/tooltip/Tooltip.stories.mdx
@@ -1,0 +1,33 @@
+import { Meta, Story, ArgsTable, Canvas, Description } from '@storybook/addon-docs/blocks';
+import ScaleTooltip from './ScaleTooltip.vue';
+
+<Meta
+    title='Beta Components/Tooltip'
+    component={ScaleTooltip}
+/>
+
+export const Template = (args, { argTypes }) => ({
+    components: { ScaleTooltip },
+    template: `
+    <scale-tooltip>
+      <scale-button>
+        Hover for Tooltip
+      </scale-button>
+    </scale-tooltip>
+  `
+})
+
+## Standard
+
+<Canvas withSource="none">
+  <Story
+    name='Standard'
+    args={{
+      opened: false,
+      showActions: true,
+      shortBody: true
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>

--- a/packages/storybook-vue/stories/3_components/tooltip/tooltip.md
+++ b/packages/storybook-vue/stories/3_components/tooltip/tooltip.md
@@ -1,0 +1,8 @@
+<div style="display: inline-flex; align-items: center; justify-content: space-between; width: 100%;">
+    <h1>Tooltip</h1>
+    <img src="assets/beta.png" alt="Beta Component" />
+</div>
+
+## General
+
+Description of the Tooltip

--- a/packages/storybook-vue/stories/3_components/tooltip/tooltip_de.md
+++ b/packages/storybook-vue/stories/3_components/tooltip/tooltip_de.md
@@ -1,0 +1,8 @@
+<div style="display: inline-flex; align-items: center; justify-content: space-between; width: 100%;">
+    <h1>Tooltip</h1>
+    <img src="assets/beta.png" alt="Beta Component" />
+</div>
+
+## Allgemein
+
+Beschreibung eines Tooltips WIP


### PR DESCRIPTION
Hey @marvinLaubenstein ✌️,
we talked last week about the tooltips.
I finally had some time to add my Ideas to the Tooltips. For now, it's mostly documentation and two fixes.

## Fixes:

1. Changed default font-size design Token to `--scl-font-size-16` matching the Sketch File in your Design Repo.
2. Added the `--scl-z-index-70` Designtoken. The internal CCS Var was already used but without a Value. I also changed the name to match the naming scheme.

## Documentation:

- Added descriptions to the Props
- Added Handlebars -> Generating Sketch Components
The Sketch hierarchy looks like this:
<img width="422" alt="Bildschirmfoto 2021-06-17 um 15 18 51" src="https://user-images.githubusercontent.com/26364692/122404226-55ab0680-cf7f-11eb-93d5-8809ada88e6a.png">
But I'm having an issue with the `::after` arrow of the Element being rendered as a block border instead of an arrow Style. Also, the Sketch Box is way bigger than the Sketch Element. Maybe I could use some assistance here on how to fix this.
<img width="174" alt="Bildschirmfoto 2021-06-17 um 15 21 10" src="https://user-images.githubusercontent.com/26364692/122404601-a884be00-cf7f-11eb-9d8b-ae1ca67bda42.png">

- Added a Storybook Beta Entry without any further work done yet.


## Issues I found
- Looking at [WCAG 1.4.13](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html), I think the Keyboard dismissability of the Tooltip is still not sufficient yat. At the Moment they are dismissable if the focus is set to the Button, so a simple hover is not dismissable.
You could do something like this:
```
@Listen('keydown', { target: 'window' })
  handleKeypress(event: KeyboardEvent) {
    if (!this.open) {
      return;
    }
    if (event.key === 'Escape') {
      event.stopPropagation();
      this.hideTooltip();
    }
  }
```
Or not because in my view People using a mouse are less likely to know keyboard shortcuts and adding events to the escape Button could lead to confusion.

- Also, the tooltips do not seem to be hoverable? They are closing once you are leaving the Slot Content. But I might miss something here.

- Also, an option to disable the Popperjs overflow scroll would be useful for some use cases.
<img width="189" alt="Bildschirmfoto 2021-06-17 um 15 54 36" src="https://user-images.githubusercontent.com/26364692/122410572-52fee000-cf84-11eb-83ef-489778389280.png"> It can lead to the Tooltip beeing shown with out the Slot Element beeing inside the Browserview.

## Further
I'm a fan of the look and feel of the Tooltips. I would be happy to help to fix the issues and work on the Documentation if you don't have different plans for the component.

Just let me know if you have your own plans or which of the Issues I found should be fixed :)