### PR TITLE
fix: events and `checked` prop in Radio

### DIFF
--- a/packages/components/src/components/radio-button/radio-button.tsx
+++ b/packages/components/src/components/radio-button/radio-button.tsx
@@ -63,7 +63,7 @@ export class RadioButton {
   };
 
   // Prevent click event being fired twice when the target is the label.
-  handleLabelClick = (event) => {
+  handleLabelClick = (event: any) => {
     event.stopPropagation();
   };
 

--- a/packages/components/src/components/radio-button/radio-button.tsx
+++ b/packages/components/src/components/radio-button/radio-button.tsx
@@ -13,7 +13,6 @@ import {
   Component,
   Event,
   EventEmitter,
-  Element,
   h,
   Host,
   Prop,
@@ -32,8 +31,6 @@ let i = 0;
   shadow: false,
 })
 export class RadioButton {
-  @Element() hostElement: HTMLElement;
-
   /** (optional) Input name */
   @Prop() name?: string = '';
   /** (optional) Input label */

--- a/packages/components/src/components/radio-button/radio-button.tsx
+++ b/packages/components/src/components/radio-button/radio-button.tsx
@@ -51,7 +51,7 @@ export class RadioButton {
     }
   }
 
-  handleCheckChange = (event: any) => {
+  handleCheckedChange = (event: any) => {
     this.checked = event.target.checked;
     // I don't think this is ever going to be `false` but well...
     if (this.checked) {
@@ -96,7 +96,7 @@ export class RadioButton {
             type="radio"
             name={this.name}
             id={this.inputId}
-            onChange={this.handleCheckChange}
+            onChange={this.handleCheckedChange}
             value={this.value}
             checked={this.checked}
             disabled={this.disabled}

--- a/packages/components/src/components/radio-button/radio-button.tsx
+++ b/packages/components/src/components/radio-button/radio-button.tsx
@@ -9,14 +9,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import {
-  Component,
-  Event,
-  EventEmitter,
-  h,
-  Host,
-  Prop,
-} from '@stencil/core';
+import { Component, Event, EventEmitter, h, Host, Prop } from '@stencil/core';
 import classNames from 'classnames';
 
 interface InputChangeEventDetail {

--- a/packages/components/src/components/radio-button/radio-button.tsx
+++ b/packages/components/src/components/radio-button/radio-button.tsx
@@ -13,10 +13,10 @@ import {
   Component,
   Event,
   EventEmitter,
+  Element,
   h,
   Host,
   Prop,
-  Watch,
 } from '@stencil/core';
 import classNames from 'classnames';
 
@@ -32,6 +32,8 @@ let i = 0;
   shadow: false,
 })
 export class RadioButton {
+  @Element() hostElement: HTMLElement;
+
   /** (optional) Input name */
   @Prop() name?: string = '';
   /** (optional) Input label */
@@ -42,7 +44,7 @@ export class RadioButton {
   @Prop() status?: string = '';
   /** (optional) Input disabled */
   @Prop() disabled?: boolean;
-  /** (optional) Active switch */
+  /** (optional) Input checked */
   @Prop({ reflect: true }) checked?: boolean = false;
   /** (optional) Input value */
   @Prop({ mutable: true }) value?: string | number | null = '';
@@ -51,7 +53,6 @@ export class RadioButton {
   /** (optional) Injected CSS styles */
   @Prop() styles?: string;
 
-  /** Emitted when the value has changed. */
   @Event() scaleChange!: EventEmitter<InputChangeEventDetail>;
 
   componentWillLoad() {
@@ -60,25 +61,37 @@ export class RadioButton {
     }
   }
 
-  // We're not watching `value` like we used to
-  // because we get unwanted `scaleChange` events
-  // because how we keep this.value up-to-date for type="select"
-  // `this.value = selectedValue`
-  emitChange() {
+  handleCheckChange = (event: any) => {
+    this.checked = event.target.checked;
+    // I don't think this is ever going to be `false` but well...
+    if (this.checked) {
+      this.uncheckSiblings();
+    }
     this.scaleChange.emit({
       value: this.value == null ? this.value : this.value.toString(),
     });
-  }
-
-  @Watch('checked')
-  checkedChanged() {
-    this.scaleChange.emit({ value: this.checked });
-  }
-
-  // Handle checkbox/radio change (click on label)
-  handleCheckChange = (event) => {
-    this.checked = event.target.checked;
   };
+
+  // Prevent click event being fired twice when the target is the label.
+  handleLabelClick = (event) => {
+    event.stopPropagation();
+  };
+
+  // We manually set `checked` to false on sibling <scale-radio-button> elements,
+  // otherwise they stayed `checked` after being clicked once, forever.
+  uncheckSiblings() {
+    this.getSiblingRadios().forEach((radio: HTMLScaleRadioButtonElement) => {
+      radio.checked = false;
+    });
+  }
+
+  getSiblingRadios(): HTMLScaleRadioButtonElement[] {
+    return Array.from(
+      document.querySelectorAll(`scale-radio-button[name="${this.name}"]`)
+    ).filter(
+      (radio: HTMLScaleRadioButtonElement) => radio.inputId !== this.inputId
+    ) as HTMLScaleRadioButtonElement[];
+  }
 
   render() {
     const ariaInvalidAttr =
@@ -100,7 +113,9 @@ export class RadioButton {
             {...ariaInvalidAttr}
             {...(this.helperText ? ariaDescribedByAttr : {})}
           />
-          <label htmlFor={this.inputId}>{this.label}</label>
+          <label htmlFor={this.inputId} onClick={this.handleLabelClick}>
+            {this.label}
+          </label>
           {!!this.helperText && (
             <div
               class="radio-button__meta"

--- a/packages/components/src/components/radio-button/readme.md
+++ b/packages/components/src/components/radio-button/readme.md
@@ -9,7 +9,7 @@
 
 | Property     | Attribute     | Description                    | Type               | Default     |
 | ------------ | ------------- | ------------------------------ | ------------------ | ----------- |
-| `checked`    | `checked`     | (optional) Active switch       | `boolean`          | `false`     |
+| `checked`    | `checked`     | (optional) Input checked       | `boolean`          | `false`     |
 | `disabled`   | `disabled`    | (optional) Input disabled      | `boolean`          | `undefined` |
 | `helperText` | `helper-text` | (optional) Input helper text   | `string`           | `''`        |
 | `inputId`    | `input-id`    | (optional) Input checkbox id   | `string`           | `undefined` |
@@ -22,9 +22,9 @@
 
 ## Events
 
-| Event         | Description                         | Type                                  |
-| ------------- | ----------------------------------- | ------------------------------------- |
-| `scaleChange` | Emitted when the value has changed. | `CustomEvent<InputChangeEventDetail>` |
+| Event         | Description | Type                                  |
+| ------------- | ----------- | ------------------------------------- |
+| `scaleChange` |             | `CustomEvent<InputChangeEventDetail>` |
 
 
 ----------------------------------------------

--- a/packages/components/src/html/radio.html
+++ b/packages/components/src/html/radio.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
+    />
+    <title>Stencil Component Starter</title>
+
+    <script type="module" src="/build/scale-components.esm.js"></script>
+    <script nomodule src="/build/scale-components.js"></script>
+    <link rel="stylesheet" href="/build/scale-components.css" />
+    <style type="text/css" media="screen, print">
+      html {
+        margin: 0;
+        padding: 0;
+        --icon-color: black;
+      }
+
+      body {
+        margin: 0;
+        padding: 4rem;
+      }
+
+      .custom-styles {
+        --rating-spacing: 1rem;
+      }
+
+      hr {
+        margin: 3rem 0;
+      }
+    </style>
+  </head>
+
+  <body>
+    <scale-radio-button label="A" value="a" name="letter"></scale-radio-button>
+    <scale-radio-button label="B" value="b" name="letter"></scale-radio-button>
+
+    <script>
+      const radios = [...document.querySelectorAll('scale-radio-button')];
+      radios.forEach((radio) => {
+        radio.addEventListener('scaleChange', () => {
+          console.log('scaleChange', radio);
+          radios.forEach((x) => console.log(x.checked));
+        });
+        radio.addEventListener('click', (event) => {
+          console.log('click', event.path);
+        });
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
With the current radio button implementation, the `scaleChange` event is being fired only once. This makes it impossible to hook with framework's state/models.

This PR fixes that.

(It also fixes the `click` event being fired twice while clicking on the label.)

## Why
`input[type="radio"]` elements only fire `change` events after user input and only when being actually `checked`, not unchecked (there is no `change` event while being unchecked). Since our component relies on this `change` event to update its `checked` property, this remains `true` forever after the first `change` event. And, since the `scaleChange` event gets fired using a watcher on this same `checked` prop, it fires only once: the one time `checked` changes from `false` to `true`.

---

Some inspiration: https://github.com/shoelace-style/shoelace/blob/next/src/components/radio/radio.ts