### PR TITLE
chore: add better doc for variant and size to Tags

### DIFF
--- a/packages/components/src/components/tag/readme.md
+++ b/packages/components/src/components/tag/readme.md
@@ -31,16 +31,16 @@
 
 ## Properties
 
-| Property      | Attribute      | Description                    | Type                | Default     |
-| ------------- | -------------- | ------------------------------ | ------------------- | ----------- |
-| `disabled`    | `disabled`     | (optional) Tag disabled        | `boolean`           | `false`     |
-| `dismissText` | `dismiss-text` | (optional) Dismiss label       | `string`            | `'dismiss'` |
-| `dismissable` | `dismissable`  | (optional) Tag dismissable     | `boolean`           | `false`     |
-| `href`        | `href`         | (optional) Tag href            | `string`            | `''`        |
-| `size`        | `size`         | (optional) Tag size            | `"" \| "small"`     | `''`        |
-| `styles`      | `styles`       | (optional) Injected CSS styles | `string`            | `undefined` |
-| `target`      | `target`       | (optional) Tag target          | `string`            | `'_self'`   |
-| `variant`     | `variant`      | (optional) Tag variant         | `"" \| "secondary"` | `''`        |
+| Property      | Attribute      | Description                    | Type          | Default     |
+| ------------- | -------------- | ------------------------------ | ------------- | ----------- |
+| `disabled`    | `disabled`     | (optional) Tag disabled        | `boolean`     | `false`     |
+| `dismissText` | `dismiss-text` | (optional) Dismiss label       | `string`      | `'dismiss'` |
+| `dismissable` | `dismissable`  | (optional) Tag dismissable     | `boolean`     | `false`     |
+| `href`        | `href`         | (optional) Tag href            | `string`      | `''`        |
+| `size`        | `size`         | (optional) Tag size            | `"small"`     | `undefined` |
+| `styles`      | `styles`       | (optional) Injected CSS styles | `string`      | `undefined` |
+| `target`      | `target`       | (optional) Tag target          | `string`      | `'_self'`   |
+| `variant`     | `variant`      | (optional) Tag variant         | `"secondary"` | `undefined` |
 
 
 ## Events

--- a/packages/components/src/components/tag/readme.md
+++ b/packages/components/src/components/tag/readme.md
@@ -31,16 +31,16 @@
 
 ## Properties
 
-| Property      | Attribute      | Description                    | Type      | Default     |
-| ------------- | -------------- | ------------------------------ | --------- | ----------- |
-| `disabled`    | `disabled`     | (optional) Tag disabled        | `boolean` | `false`     |
-| `dismissText` | `dismiss-text` | (optional) Dismiss label       | `string`  | `'dismiss'` |
-| `dismissable` | `dismissable`  | (optional) Tag dismissable     | `boolean` | `false`     |
-| `href`        | `href`         | (optional) Tag href            | `string`  | `''`        |
-| `size`        | `size`         | (optional) Tag size            | `string`  | `''`        |
-| `styles`      | `styles`       | (optional) Injected CSS styles | `string`  | `undefined` |
-| `target`      | `target`       | (optional) Tag target          | `string`  | `'_self'`   |
-| `variant`     | `variant`      | (optional) Tag variant         | `string`  | `''`        |
+| Property      | Attribute      | Description                    | Type                | Default     |
+| ------------- | -------------- | ------------------------------ | ------------------- | ----------- |
+| `disabled`    | `disabled`     | (optional) Tag disabled        | `boolean`           | `false`     |
+| `dismissText` | `dismiss-text` | (optional) Dismiss label       | `string`            | `'dismiss'` |
+| `dismissable` | `dismissable`  | (optional) Tag dismissable     | `boolean`           | `false`     |
+| `href`        | `href`         | (optional) Tag href            | `string`            | `''`        |
+| `size`        | `size`         | (optional) Tag size            | `"" \| "small"`     | `''`        |
+| `styles`      | `styles`       | (optional) Injected CSS styles | `string`            | `undefined` |
+| `target`      | `target`       | (optional) Tag target          | `string`            | `'_self'`   |
+| `variant`     | `variant`      | (optional) Tag variant         | `"" \| "secondary"` | `''`        |
 
 
 ## Events

--- a/packages/components/src/components/tag/tag.tsx
+++ b/packages/components/src/components/tag/tag.tsx
@@ -100,7 +100,7 @@ export class Tag {
   getCssOrBasePartMap(mode: 'basePart' | 'css') {
     const component = 'tag';
     const prefix = mode === 'basePart' ? '' : `${component}--`;
-    
+
     return classNames(
       mode === 'basePart' ? 'base' : component,
       this.size && `${prefix}size-${this.size}`,

--- a/packages/components/src/components/tag/tag.tsx
+++ b/packages/components/src/components/tag/tag.tsx
@@ -18,9 +18,9 @@ import classNames from 'classnames';
 })
 export class Tag {
   /** (optional) Tag size */
-  @Prop() size?: '' | 'small' = '';
+  @Prop() size?: 'small';
   /** (optional) Tag variant */
-  @Prop() variant?: '' | 'secondary' = '';
+  @Prop() variant?: 'secondary';
   /** (optional) Tag href */
   @Prop() href?: string = '';
   /** (optional) Tag target */
@@ -100,7 +100,7 @@ export class Tag {
   getCssOrBasePartMap(mode: 'basePart' | 'css') {
     const component = 'tag';
     const prefix = mode === 'basePart' ? '' : `${component}--`;
-
+    
     return classNames(
       mode === 'basePart' ? 'base' : component,
       this.size && `${prefix}size-${this.size}`,

--- a/packages/components/src/components/tag/tag.tsx
+++ b/packages/components/src/components/tag/tag.tsx
@@ -18,9 +18,9 @@ import classNames from 'classnames';
 })
 export class Tag {
   /** (optional) Tag size */
-  @Prop() size?: string = '';
+  @Prop() size?: '' | 'small' = '';
   /** (optional) Tag variant */
-  @Prop() variant?: string = '';
+  @Prop() variant?: '' | 'secondary' = '';
   /** (optional) Tag href */
   @Prop() href?: string = '';
   /** (optional) Tag target */

--- a/packages/storybook-vue/stories/3_components/tag/Tag.stories.mdx
+++ b/packages/storybook-vue/stories/3_components/tag/Tag.stories.mdx
@@ -11,6 +11,12 @@ import ScaleTag from "./ScaleTag.vue";
   title="Components/Tag"
   component={ScaleTag}
   argTypes={{
+    variant: {
+      control: { type: 'select', options: ['', 'secondary'] }
+    },
+    size: {
+      control: { type: 'select', options: ['', 'small']}
+    },
     label: {
       control: { type: "text" },
     },

--- a/packages/storybook-vue/stories/3_components/tag/Tag.stories.mdx
+++ b/packages/storybook-vue/stories/3_components/tag/Tag.stories.mdx
@@ -12,10 +12,10 @@ import ScaleTag from "./ScaleTag.vue";
   component={ScaleTag}
   argTypes={{
     variant: {
-      control: { type: 'select', options: ['', 'secondary'] }
+      control: { type: 'select', options: ['default', 'secondary'] }
     },
     size: {
-      control: { type: 'select', options: ['', 'small']}
+      control: { type: 'select', options: ['default', 'small']}
     },
     label: {
       control: { type: "text" },


### PR DESCRIPTION
Hey,
I noticed in the Storybook that the Chip/Tags don't have a selector for `variant` and `size` like for example Buttons.

For Buttons it looks like this:
<img width="1100" alt="Bildschirmfoto 2021-06-25 um 16 39 55" src="https://user-images.githubusercontent.com/26364692/123441319-fc248680-d5d3-11eb-9422-6718d33a96ab.png">
vs
<img width="1100" alt="Bildschirmfoto 2021-06-25 um 16 40 31" src="https://user-images.githubusercontent.com/26364692/123441373-10688380-d5d4-11eb-8961-d0433dda90a3.png">
for Tags

Also, I noticed that size and variant is per default not specified and has no enumerating type like Buttons have.
Button.tsx Line 25:
`@Prop() size?: 'small' | 'large' = 'large';`
vs Tag.tsx Line 21:
`@Prop() size?: string = '';`

So I changed that and also added a select field to the Storybook. Now it looks like this:
<img width="1100" alt="Bildschirmfoto 2021-06-25 um 17 00 45" src="https://user-images.githubusercontent.com/26364692/123444618-5f63e800-d5d7-11eb-978b-763f25277e27.png">

I'm thinking of defining the `default` variant/size (or primary) in the component too. It would not be a breaking change but would improve maintainability in my view.
Let me know if this should be added to this PR.