### PR TITLE
fix: datepicker not updating on outside value change

### DIFF
--- a/packages/components/src/components/date-picker/date-picker.tsx
+++ b/packages/components/src/components/date-picker/date-picker.tsx
@@ -18,6 +18,7 @@ import {
   Event,
   EventEmitter,
   State,
+  Watch,
 } from '@stencil/core';
 import { DuetDatePicker as DuetDatePickerCustomElement } from '@duetds/date-picker/custom-element';
 
@@ -181,6 +182,14 @@ export class DatePicker {
    */
   @Method() async hide(moveFocusToButton = true) {
     return this.duetInput.hide(moveFocusToButton);
+  }
+
+  /**
+   * Watch Value property for changes from outside and change hasValue based on that
+   */
+  @Watch('value')
+  onValueChange() {
+    this.hasValue = this.value != null && this.value !== '';
   }
 
   componentWillLoad() {

--- a/packages/components/src/components/date-picker/date-picker.tsx
+++ b/packages/components/src/components/date-picker/date-picker.tsx
@@ -185,7 +185,7 @@ export class DatePicker {
   }
 
   /**
-   * Watch Value property for changes from outside and change hasValue based on that
+   * Watch `value` property for changes and update `hasValue` based on that.
    */
   @Watch('value')
   onValueChange() {


### PR DESCRIPTION
Hi 🧑‍💻

This is a simple fix for: #440 

Added a watcher to the Value for outside changes of `value`. 
Since the `hasValue` State doesn't seem to have reactivity on its own.

I'm not absolutely keen if StencilJS has some way to make States reactive directly, if there is a possibility to handle it directly in the State that might be nicer. But I couldn't find such functionality.

Can be tested like this:
```
<scale-date-picker label="Helper Text" id="Test" value=""></scale-date-picker>
<script>
  setTimeout(()=>{
    document.getElementById('Test').setAttribute("value", "2020-12-31")
  }, 6000)
</script>
```

This also enables Stuff like this:
```
setTimeout(()=>{
  document.getElementById('Test').setAttribute("value", "2020-12-31")
}, 6000)
setTimeout(()=>{
  document.getElementById('Test').setAttribute("value", "")
}, 8000)
setTimeout(()=>{
  document.getElementById('Test').setAttribute("value", "2020-12-31")
}, 10000)
```

Let me know what you think :)