### PR TITLE
fix: spacing control is never applied on checkbox

### DIFF
--- a/packages/components/src/components/checkbox/checkbox.css
+++ b/packages/components/src/components/checkbox/checkbox.css
@@ -88,7 +88,7 @@ scale-checkbox [part='checkbox'] {
   flex: 0 0 auto;
   justify-content: center;
   align-items: center;
-  margin: var(--scl-spacing-2) 0;
+  margin: var(--spacing-control) 0;
   width: var(--width-control);
   height: var(--height-control);
   border-radius: var(--radius-control);


### PR DESCRIPTION
The CSS Variable `--spacing-control` on the Checkbox is never applied instead it directly applies a design token variable.
I think this was the intended way the variable should work.