### PR TITLE
fix(tooltip): add z-index

### DIFF
--- a/packages/components/src/components/tooltip/tooltip.css
+++ b/packages/components/src/components/tooltip/tooltip.css
@@ -38,6 +38,7 @@
 
 .tooltip-positioner {
   position: absolute;
+  z-index: var(--z-index);
 }
 
 .slot-container {


### PR DESCRIPTION
The css Variable of the Tooltips adding the z-index is never applied. This leads to behavior described in #818

This fixes this applying it to `tooltip-positioner`.
Can be tested by applying this to the index.html:
```
<scale-tooltip
      content="Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lore"
      title="Some"
  >
  <scale-icon-alert-information size="18" />
</scale-tooltip>
<scale-text-field
  size="small"
  label="Textfield"
  name="Name"
  id="FieldID"
  value="some"
/>
```