### PR TITLE
refactor: remove token spacing dash, rename ui token from normal to regular

### DIFF
--- a/packages/components/src/components/tag/tag.css
+++ b/packages/components/src/components/tag/tag.css
@@ -33,8 +33,7 @@
     var(--telekom-color-ui-extra-strong);
   --background-button-dismissable-focus: ;
   --box-shadow-button-dismissable-focus: var(--box-shadow-focus);
-  /* FIXME:TOKEN background color white color-ui-white?? */
-  --background-button-dismissable-hover: var(--scl-color-white);
+  --background-button-dismissable-hover: var(--telekom-color-ui-base);
   --height-button-dismissable-small: 20px;
 
   --spacing-small: 0 var(--telekom-spacing-unit-x2);

--- a/packages/components/src/components/telekom/app-footer/app-footer.css
+++ b/packages/components/src/components/telekom/app-footer/app-footer.css
@@ -12,9 +12,9 @@
 :host {
   --background: var(--telekom-color-background-surface-highlight);
   --color: var(--telekom-color-text-and-icon-inverted-standard: );
-  --spacing-top: var(--telekom-spacing-unit-x-8);
-  --spacing-bottom: var(--telekom-spacing-unit-x-6);
-  --spacing-x: var(--telekom-spacing-unit-x-6);
+  --spacing-top: var(--telekom-spacing-unit-x8);
+  --spacing-bottom: var(--telekom-spacing-unit-x6);
+  --spacing-x: var(--telekom-spacing-unit-x6);
   --background-container: var(
     --telekom-color-background-surface-highlight,
     #fff
@@ -22,21 +22,21 @@
   --radius: var(--telekom-radius-large);
   --max-width: inherit;
 
-  --border-top-minimal: var(--telekom-spacing-unit-x-025) solid
+  --border-top-minimal: var(--telekom-spacing-unit-x025) solid
     var(--telekom-color-ui-subtle);
-  --color-minimal: var(--telekom-color-ui-normal);
+  --color-minimal: var(--telekom-color-ui-regular);
   --background-minimal: var(--telekom-color-background-surface-highlight);
   /* FIXME:TOKEN angular vs minimal same value here*/
-  --spacing-angular: var(--telekom-spacing-unit-x-6);
-  --spacing-minimal: var(--telekom-spacing-unit-x-6);
+  --spacing-angular: var(--telekom-spacing-unit-x6);
+  --spacing-minimal: var(--telekom-spacing-unit-x6);
 
   --background-mask: var(--telekom-color-background-surface-highlight, #fff);
   --radius-mask: 0 0 var(--telekom-radius-large) var(--telekom-radius-large);
 
-  --height-logo: var(--telekom-spacing-unit-x-6);
+  --height-logo: var(--telekom-spacing-unit-x6);
   --font-size-copyright: var(--telekom-typography-font-size-caption);
   --color-link-standard: var(--telekom-color-text-and-icon-inverted-standard);
-  --color-link-minimal: var(--telekom-color-ui-normal);
+  --color-link-minimal: var(--telekom-color-ui-regular);
 
   --font-size-navigation-standard: var(--telekom-typography-font-size-caption);
   --font-family-navigation-standard: var(--telekom-typography-font-family-sans);
@@ -47,7 +47,7 @@
     --telekom-typography-font-weight-medium
   );
 
-  --spacing-navigation-standard: var(--telekom-spacing-unit-x-2);
+  --spacing-navigation-standard: var(--telekom-spacing-unit-x2);
   --color-navigation-standard-hover: var(
     --telekom-color-text-and-icon-inverted-standard
   );
@@ -57,9 +57,8 @@
   --color-navigation-active-focus: var(
     --telekom-color-text-and-icon-primary-pressed
   );
-  --box-shadow-navigation-focus: 0 0 0 var(--telekom-spacing-unit-x-05)
+  --box-shadow-navigation-focus: 0 0 0 var(--telekom-spacing-unit-x05)
     var(--telekom-color-primary-standard);
-  /* FIXME:TOKEN border has white color */
   --border-color-standard-hover: var(
     --telekom-color-text-and-icon-inverted-standard
   );
@@ -141,7 +140,7 @@
   margin: calc(-1 * var(--spacing-navigation-standard)) 0;
 }
 .footer-navigation li span {
-  padding: var(--telekom-spacing-unit-x-1) 0;
+  padding: var(--telekom-spacing-unit-x1) 0;
 }
 
 .footer-navigation li a:hover {
@@ -191,7 +190,7 @@
 
 .footer-navigation svg {
   width: auto;
-  height: var(--telekom-spacing-unit-x-4);
+  height: var(--telekom-spacing-unit-x4);
   margin-right: var(--spacing-navigation-standard);
 }
 
@@ -212,15 +211,15 @@
     margin-bottom: var(--spacing-angular);
   }
   .footer-copyright {
-    margin-bottom: var(--telekom-spacing-unit-x-4);
+    margin-bottom: var(--telekom-spacing-unit-x4);
   }
   .footer-navigation ul {
-    line-height: var(--telekom-spacing-unit-x-8);
+    line-height: var(--telekom-spacing-unit-x8);
   }
   .footer-navigation li a {
-    padding: var(--telekom-spacing-unit-x-1);
+    padding: var(--telekom-spacing-unit-x1);
     margin: calc(-1 * var(--spacing-navigation-standard))
-      calc(-1 * var(--telekom-spacing-unit-x-1));
+      calc(-1 * var(--telekom-spacing-unit-x1));
   }
 }
 

--- a/packages/components/src/components/telekom/app-header/app-header.css
+++ b/packages/components/src/components/telekom/app-header/app-header.css
@@ -28,7 +28,7 @@ scale-app-header {
 
   --color-nav: var(--telekom-color-text-and-icon-standard: );
   --background-nav: var(--telekom-color-background-surface);
-  --spacing-nav: 0 var(--telekom-spacing-unit-x-4);
+  --spacing-nav: 0 var(--telekom-spacing-unit-x4);
 }
 @keyframes keyframes-slideUp {
   from {
@@ -239,7 +239,7 @@ scale-app-header {
   }
   .header .header__brand {
     height: var(--header-brand-height);
-    padding: 0 var(--telekom-spacing-unit-x-6);
+    padding: 0 var(--telekom-spacing-unit-x6);
     transition: height var(--header-transition-speed) ease-in-out;
     justify-content: space-between;
   }
@@ -255,7 +255,7 @@ scale-app-header {
   }
   .header .header__nav {
     height: var(--header-nav-height);
-    padding: 0 var(--telekom-spacing-unit-x-6);
+    padding: 0 var(--telekom-spacing-unit-x6);
     position: relative;
   }
   .header .header__nav-logo {
@@ -263,12 +263,12 @@ scale-app-header {
     opacity: 0;
     transition: none;
     font-weight: var(--telekom-typography-font-weight-bold);
-    margin-right: var(--telekom-spacing-unit-x-4);
+    margin-right: var(--telekom-spacing-unit-x4);
     pointer-events: none;
   }
   .header.header--sticky .header__nav-logo {
     pointer-events: all;
-    margin-right: var(--telekom-spacing-unit-x-8);
+    margin-right: var(--telekom-spacing-unit-x8);
   }
 
   .header scale-nav-main:first-child li {
@@ -283,7 +283,7 @@ scale-app-header {
     list-style: none;
     transition: margin-left var(--header-transition-speed) ease-in-out;
     align-items: center;
-    margin-left: calc(-50px - var(--telekom-spacing-unit-x-4));
+    margin-left: calc(-50px - var(--telekom-spacing-unit-x4));
   }
   .header *[slot='menu-sector'],
   .header *[slot='menu-addon'],
@@ -352,7 +352,7 @@ scale-app-header {
     justify-content: flex-end;
   }
   .header .header__brand app-logo {
-    margin-right: var(--telekom-spacing-unit-x-4);
+    margin-right: var(--telekom-spacing-unit-x4);
   }
 }
 

--- a/packages/components/src/components/telekom/app-mega-menu/app-mega-menu.css
+++ b/packages/components/src/components/telekom/app-mega-menu/app-mega-menu.css
@@ -14,8 +14,8 @@ app-mega-menu {
   --box-shadow: var(--scl-shadow-level-4);
   /*FIXME:TOKEN spacing token needed here?*/
   --spacing-y: 2.125rem;
-  --spacing-right: var(--telekom-spacing-unit-x-4);
-  --spacing-left: var(--telekom-spacing-unit-x-6);
+  --spacing-right: var(--telekom-spacing-unit-x4);
+  --spacing-left: var(--telekom-spacing-unit-x6);
   --background: var(--telekom-color-background-surface);
   --color-active: var(--telekom-color-text-and-icon-primary-standard);
 
@@ -28,7 +28,7 @@ app-mega-menu {
   --line-height-row-item: var(--telekom-typography-line-spacing-loose);
   --font-weight-row-item: var(--telekom-typography-font-weight-medium);
   --color-row-item: var(--telekom-color-text-and-icon-standard);
-  --spacing-bottom-row-item: var(--telekom-spacing-unit-x-2);
+  --spacing-bottom-row-item: var(--telekom-spacing-unit-x2);
 }
 .mega-menu {
   width: 100%;
@@ -56,7 +56,7 @@ app-mega-menu {
   display: grid;
   grid-template-columns: repeat(5, minmax(min-content, 240px));
   list-style: none;
-  padding-left: var(--telekom-spacing-unit-x-8);
+  padding-left: var(--telekom-spacing-unit-x8);
 }
 
 .mega-menu__row-title {

--- a/packages/components/src/components/telekom/app-navigation-main-mobile/app-navigation-main-mobile.css
+++ b/packages/components/src/components/telekom/app-navigation-main-mobile/app-navigation-main-mobile.css
@@ -110,7 +110,7 @@ app-navigation-main-mobile {
 }
 
 .main-navigation-mobile__child-menu-current app-icon {
-  margin-right: var(--telekom-spacing-unit-x-2);
+  margin-right: var(--telekom-spacing-unit-x2);
 }
 
 .main-navigation-mobile__child-menu-current .icon-back {
@@ -153,10 +153,10 @@ app-navigation-main-mobile {
   justify-content: space-between;
   align-items: center;
   border-bottom: var(--border-bottom);
-  margin-left: var(--telekom-spacing-unit-x-16);
+  margin-left: var(--telekom-spacing-unit-x16);
   box-sizing: border-box;
 }
 
 .main-navigation-mobile__child-menu-item-wrapper svg {
-  margin-right: var(--telekom-spacing-unit-x-10);
+  margin-right: var(--telekom-spacing-unit-x10);
 }

--- a/packages/components/src/components/telekom/app-navigation-user-menu/app-navigation-user-menu.css
+++ b/packages/components/src/components/telekom/app-navigation-user-menu/app-navigation-user-menu.css
@@ -10,11 +10,11 @@
  */
 
 :host {
-  --border-width-divider: var(--telekom-spacing-unit-x-025);
+  --border-width-divider: var(--telekom-spacing-unit-x025);
   --color-divider: var(--telekom-color-ui-subtle);
   --color-menu-item-hover: var(--telekom-color-text-and-icon-primary-hovered);
   --color-menu-item-active: var(--telekom-color-text-and-icon-primary-pressed);
-  --box-shadow-focus: 0 0 0 var(--telekom-spacing-unit-x-05)
+  --box-shadow-focus: 0 0 0 var(--telekom-spacing-unit-x05)
     var(--telekom-color-functional-focus);
 }
 
@@ -25,22 +25,22 @@
 }
 
 .app-navigation-user-menu__divider {
-  margin: var(--telekom-spacing-unit-x-4) 0;
+  margin: var(--telekom-spacing-unit-x4) 0;
   border: 0;
   border-top: var(--border-width-divider) solid var(--color-divider);
 }
 
 @media (min-width: 1024px) {
   .app-navigation-user-menu__user-info {
-    margin: var(--telekom-spacing-unit-x-3) var(--telekom-spacing-unit-x-6) 0
-      var(--telekom-spacing-unit-x-6);
+    margin: var(--telekom-spacing-unit-x3) var(--telekom-spacing-unit-x6) 0
+      var(--telekom-spacing-unit-x6);
   }
 }
 
 @media (max-width: 1023px) {
   .app-navigation-user-menu__user-info {
-    margin: var(--telekom-spacing-unit-x-6) var(--telekom-spacing-unit-x-4) 0
-      var(--telekom-spacing-unit-x-4);
+    margin: var(--telekom-spacing-unit-x6) var(--telekom-spacing-unit-x4) 0
+      var(--telekom-spacing-unit-x4);
   }
 }
 
@@ -49,7 +49,7 @@
   font-size: var(--scl-font-variant-heading-5-size);
   line-height: var(--scl-font-variant-heading-5-line-height);
   font-weight: var(--scl-font-variant-heading-5-weight);
-  margin-bottom: var(--telekom-spacing-unit-x-1);
+  margin-bottom: var(--telekom-spacing-unit-x1);
 }
 .app-navigation-user-menu__user-info--email {
   color: var(--telekom-color-text-and-icon-additional);
@@ -61,16 +61,16 @@
   font-size: var(--scl-font-variant-heading-6-size);
   line-height: var(--scl-font-variant-heading-6-line-height);
   font-weight: var(--scl-font-variant-heading-6-weight);
-  padding: var(--telekom-spacing-unit-x-2) var(--telekom-spacing-unit-x-4);
+  padding: var(--telekom-spacing-unit-x2) var(--telekom-spacing-unit-x4);
   /* FIXME:TOKEN should it be radius token 0.125rem */
-  border-radius: var(--telekom-spacing-unit-x-05);
+  border-radius: var(--telekom-spacing-unit-x05);
   color: var(--telekom-color-text-and-icon-standard);
   text-decoration: none;
 }
 
 @media (min-width: 1024px) {
   .app-navigation-user-menu__item {
-    padding: var(--telekom-spacing-unit-x-2) var(--telekom-spacing-unit-x-6);
+    padding: var(--telekom-spacing-unit-x2) var(--telekom-spacing-unit-x6);
   }
 }
 
@@ -88,23 +88,23 @@
 }
 
 .app-navigation-user-menu__item--icon-prefix {
-  margin-right: var(--telekom-spacing-unit-x-2);
+  margin-right: var(--telekom-spacing-unit-x2);
 }
 .app-navigation-user-menu__item--icon-suffix {
-  margin-left: var(--telekom-spacing-unit-x-2);
+  margin-left: var(--telekom-spacing-unit-x2);
 }
 
 .app-navigation-user-menu__button {
-  padding: var(--telekom-spacing-unit-x-2) var(--telekom-spacing-unit-x-4);
+  padding: var(--telekom-spacing-unit-x2) var(--telekom-spacing-unit-x4);
 }
 
 @media (min-width: 1024px) {
   .app-navigation-user-menu__button {
-    padding: var(--telekom-spacing-unit-x-2) var(--telekom-spacing-unit-x-6);
+    padding: var(--telekom-spacing-unit-x2) var(--telekom-spacing-unit-x6);
   }
 }
 @media (min-width: 1024px) {
   .app-navigation-user-menu {
-    padding-bottom: var(--telekom-spacing-unit-x-1);
+    padding-bottom: var(--telekom-spacing-unit-x1);
   }
 }

--- a/packages/components/src/components/telekom/app-shell/app-shell.css
+++ b/packages/components/src/components/telekom/app-shell/app-shell.css
@@ -11,7 +11,7 @@
 
 :host {
   --background: var(--telekom-color-background-canvas, #fff);
-  --spacing-x: var(--telekom-spacing-unit-x-6);
+  --spacing-x: var(--telekom-spacing-unit-x6);
   --min-height: 100vh;
 }
 

--- a/packages/components/src/components/telekom/nav-icon/nav-icon.css
+++ b/packages/components/src/components/telekom/nav-icon/nav-icon.css
@@ -10,12 +10,12 @@
  */
 
 scale-nav-icon {
-  --spacing-mobile: var(--telekom-spacing-unit-x-0) 6px;
+  --spacing-mobile: var(--telekom-spacing-unit-x0) 6px;
   --font-size-mobile: var(--telekom-typography-font-size-footnote);
   --line-height-mobile: var(--telekom-typography-line-spacing-tight);
   --font-weight-mobile: var(--telekom-typography-font-weight-bold);
 
-  --spacing-desktop: 0 0 0 var(--telekom-spacing-unit-x-4);
+  --spacing-desktop: 0 0 0 var(--telekom-spacing-unit-x4);
   --font-size-desktop: var(--telekom-typography-font-size-small);
   --line-height-desktop: var(--telekom-typography-line-spacing-standard);
 

--- a/packages/components/src/components/telekom/nav-segment/nav-segment.css
+++ b/packages/components/src/components/telekom/nav-segment/nav-segment.css
@@ -12,7 +12,7 @@
 scale-nav-segment {
   --transition: all 0.2s ease-in-out;
   --color: var(--telekom-color-text-and-icon-inverted-standard);
-  --spacing-y: var(--telekom-spacing-unit-x-1);
+  --spacing-y: var(--telekom-spacing-unit-x1);
   --font-size: var(--telekom-typography-font-size-caption);
   --font-weight: var(--telekom-typography-font-weight-extra-bold);
   --line-height: var(--telekom-typography-line-spacing-extra-tight);

--- a/packages/components/src/components/text-field/text-field.css
+++ b/packages/components/src/components/text-field/text-field.css
@@ -13,17 +13,17 @@ scale-text-field {
   --transition: all var(--telekom-motion-duration-transition)
     var(--telekom-motion-easing-standard);
   --radius: var(--telekom-radius-standard);
-  --border: var(--telekom-spacing-unit-x-025) solid
+  --border: var(--telekom-spacing-unit-x025) solid
     var(--telekom-color-ui-extra-strong);
-  --border-error: var(--telekom-spacing-unit-x-05) solid
+  --border-error: var(--telekom-spacing-unit-x05) solid
     var(--telekom-color-functional-danger-standard);
   --border-color-hover: var(--telekom-color-primary-hovered, #f90984);
   --border-color-focus: var(--telekom-color-primary-pressed, #f90984);
-  --box-shadow-focus: 0 0 0 var(--telekom-spacing-unit-x-05)
+  --box-shadow-focus: 0 0 0 var(--telekom-spacing-unit-x05)
     var(--telekom-color-functional-focus);
-  --height: var(--telekom-spacing-unit-x-12);
-  --height-small: var(--telekom-spacing-unit-x-10);
-  --spacing-x: var(--telekom-spacing-unit-x-3);
+  --height: var(--telekom-spacing-unit-x12);
+  --height-small: var(--telekom-spacing-unit-x10);
+  --spacing-x: var(--telekom-spacing-unit-x3);
   --color-disabled: var(--telekom-color-ui-disabled);
   --background-disabled: transparent;
   --border-color-readonly: var(--telekom-color-ui-subtle);
@@ -33,12 +33,12 @@ scale-text-field {
   --font-weight-meta: var(--telekom-line-weight-bold);
   --font-size-meta: var(--telekom-typography-font-size-small);
   --line-height-meta: var(--telekom-typography-line-spacing-standard);
-  --spacing-y-meta: var(--telekom-spacing-unit-x-1);
+  --spacing-y-meta: var(--telekom-spacing-unit-x1);
   --color-meta: var(--telekom-color-text-and-icon-standard);
   --color-meta-error: var(--telekom-color-text-and-icon-functional-danger);
 
   /*control*/
-  --spacing-control: var(--telekom-spacing-unit-x-3) var(--spacing-x) 0
+  --spacing-control: var(--telekom-spacing-unit-x3) var(--spacing-x) 0
     calc(var(--spacing-x) - 1px);
   --transition-control: var(--transition);
   --font-size-control: var(--telekom-typography-font-size-body);
@@ -60,10 +60,10 @@ scale-text-field {
 
   /*placeholder*/
   --transition-placeholder: var(--transition);
-  --color-placeholder: var(--telekom-color-ui-normal);
+  --color-placeholder: var(--telekom-color-ui-regular);
 
   /*label*/
-  --color-label: var(--telekom-color-ui-normal);
+  --color-label: var(--telekom-color-ui-regular);
   --color-label-readonly: var(--telekom-color-text-and-icon-standard);
   /* FIXME:TOKEN z-index token is needed */
   --z-index-label: var(--scl-z-index-10);
@@ -163,7 +163,7 @@ scale-text-field {
 .animated .text-field__label {
   /* FIXME:TOKEN line height value original? */
   line-height: var(--scl-font-variant-label-size);
-  transform: translate(var(--spacing-x), var(--telekom-spacing-unit-x-2));
+  transform: translate(var(--spacing-x), var(--telekom-spacing-unit-x2));
   font-size: var(--font-size-label-focus);
   font-weight: var(--font-weight-label-focus);
 }
@@ -192,7 +192,7 @@ scale-text-field {
 .text-field--size-small.animated .text-field__label {
   /* FIXME:TOKEN line height value original? */
   line-height: var(--scl-font-variant-label-size);
-  transform: translate(var(--spacing-x), var(--telekom-spacing-unit-x-1));
+  transform: translate(var(--spacing-x), var(--telekom-spacing-unit-x1));
   font-size: var(--font-size-label-focus);
 }
 .text-field--transparent .text-field__control {

--- a/packages/components/src/components/textarea/textarea.css
+++ b/packages/components/src/components/textarea/textarea.css
@@ -13,16 +13,16 @@ scale-textarea {
   --transition: all var(--telekom-motion-duration-transition)
     var(---telekom-motion-easing-standard);
   --radius: var(--telekom-radius-standard);
-  --border: var(--telekom-spacing-unit-x-025) solid
+  --border: var(--telekom-spacing-unit-x025) solid
     var(--telekom-color-ui-extra-strong);
-  --border-error: var(--telekom-spacing-unit-x-05) solid
+  --border-error: var(--telekom-spacing-unit-x05) solid
     var(--telekom-color-functional-danger-standard);
   /* FIXME:TOKEN do we still need this fallback color? */
   --border-color-hover: var(--telekom-color-primary-hovered, #f90984);
   --border-color-focus: var(--telekom-color-primary-pressed, #f90984);
-  --box-shadow-focus: 0 0 0 var(--telekom-spacing-unit-x-05)
+  --box-shadow-focus: 0 0 0 var(--telekom-spacing-unit-x05)
     var(--telekom-color-functional-focus);
-  --spacing-x: var(--telekom-spacing-unit-x-3);
+  --spacing-x: var(--telekom-spacing-unit-x3);
   --color-disabled: var(--telekom-color-ui-disabled);
   --background-disabled: transparent;
   --border-color-readonly: var(--telekom-color-ui-subtle);
@@ -32,13 +32,13 @@ scale-textarea {
   --font-weight-meta: var(--telekom-typography-font-weight-bold);
   --font-size-meta: var(--telekom-typography-font-size-small);
   --line-height-meta: var(--telekom-typography-line-spacing-standard);
-  --spacing-y-meta: var(--telekom-spacing-unit-x-1);
+  --spacing-y-meta: var(--telekom-spacing-unit-x1);
   --color-meta: var(--telekom-color-text-and-icon-standard);
   --color-meta-error: var(--telekom-color-text-and-icon-functional-danger);
 
   /*control*/
-  --spacing-control: var(--telekom-spacing-unit-x-6) var(--spacing-x)
-    var(--telekom-spacing-unit-x-3) calc(var(--spacing-x) - 1px);
+  --spacing-control: var(--telekom-spacing-unit-x6) var(--spacing-x)
+    var(--telekom-spacing-unit-x3) calc(var(--spacing-x) - 1px);
   --transition-control: var(--transition);
   --font-size-control: var(--telekom-typography-font-size-body);
 
@@ -57,10 +57,10 @@ scale-textarea {
 
   /*placeholder*/
   --transition-placeholder: var(--transition);
-  --color-placeholder: var(--telekom-color-ui-normal);
+  --color-placeholder: var(--telekom-color-ui-regular);
 
   /*label*/
-  --color-label: var(--telekom-color-ui-normal);
+  --color-label: var(--telekom-color-ui-regular);
   --color-label-readonly: var(--telekom-color-text-and-icon-standard);
   /* FIXME:TOKEN z-index token is needed */
   --z-index-label: var(--scl-z-index-10);
@@ -100,7 +100,7 @@ scale-textarea {
   display: flex;
   transition: var(--transition-counter);
   margin-left: auto;
-  padding-right: var(--telekom-spacing-unit-x-3);
+  padding-right: var(--telekom-spacing-unit-x3);
   justify-content: flex-end;
   font-size: var(--telekom-typography-font-size-small);
   line-height: var(--telekom-typography-line-spacing-standard);
@@ -154,12 +154,12 @@ scale-textarea {
   font-weight: var(--font-weight-label);
   transform: translate(
     var(--spacing-x),
-    calc((var(--telekom-spacing-unit-x-12) - var(--font-size-label)) / 2)
+    calc((var(--telekom-spacing-unit-x12) - var(--font-size-label)) / 2)
   );
 }
 .textarea--has-focus .textarea__label,
 .animated .textarea__label {
-  transform: translate(var(--spacing-x), var(--telekom-spacing-unit-x-2));
+  transform: translate(var(--spacing-x), var(--telekom-spacing-unit-x2));
   font-size: var(--font-size-label-focus);
   font-weight: var(--font-weight-label-focus);
 }
@@ -176,13 +176,13 @@ scale-textarea {
   background-color: transparent;
 }
 .textarea__label-safety-background {
-  top: var(--telekom-spacing-unit-x-05);
-  left: var(--telekom-spacing-unit-x-05);
-  right: var(--telekom-spacing-unit-x-05);
+  top: var(--telekom-spacing-unit-x05);
+  left: var(--telekom-spacing-unit-x05);
+  right: var(--telekom-spacing-unit-x05);
   position: absolute;
   pointer-events: none;
   border-radius: var(--telekom-radius-standard);
-  height: var(--telekom-spacing-unit-x-6);
+  height: var(--telekom-spacing-unit-x6);
   background-color: var(--telekom-color-background-surface, #ffffff);
 }
 .textarea--transparent .textarea__label-safety-background,

--- a/packages/components/src/components/toggle-button/toggle-button.css
+++ b/packages/components/src/components/toggle-button/toggle-button.css
@@ -11,25 +11,25 @@
 
 :host {
   --width: auto;
-  --spacing-x: var(--telekom-spacing-unit-x-6);
-  --spacing-x-icon-only: var(--telekom-spacing-unit-x-2);
-  --min-height: var(--telekom-spacing-unit-x-6);
-  --height-xs: var(--telekom-spacing-unit-x-6);
-  --height-small: var(--telekom-spacing-unit-x-8);
-  --height-regular: var(--telekom-spacing-unit-x-10);
-  --height-large: var(--telekom-spacing-unit-x-12);
+  --spacing-x: var(--telekom-spacing-unit-x6);
+  --spacing-x-icon-only: var(--telekom-spacing-unit-x2);
+  --min-height: var(--telekom-spacing-unit-x6);
+  --height-xs: var(--telekom-spacing-unit-x6);
+  --height-small: var(--telekom-spacing-unit-x8);
+  --height-regular: var(--telekom-spacing-unit-x10);
+  --height-large: var(--telekom-spacing-unit-x12);
   --radius: var(--telekom-radius-small);
   --transition: all var(--telekom-motion-duration-transition)
       var(--telekom-motion-easing-standard),
     border-radius var(--telekom-motion-duration-instant);
-  --box-shadow-focus: inset 0 0 0 var(--telekom-spacing-unit-x-05)
+  --box-shadow-focus: inset 0 0 0 var(--telekom-spacing-unit-x05)
     var(--telekom-color-functional-focus);
   --font-weight: var(--telekom-typography-font-weight-bold);
   --font-size-large: var(--telekom-typography-font-size-body);
   --font-size-small: var(--telekom-typography-font-size-caption);
   --font-size-xs: var(--telekom-typography-font-size-small);
-  --line-height: var(--telekom-spacing-unit-x-2);
-  --spacing-icon-x: var(--telekom-spacing-unit-x-2);
+  --line-height: var(--telekom-spacing-unit-x2);
+  --spacing-icon-x: var(--telekom-spacing-unit-x2);
   --vertical-align: middle;
   --border-color: var(--telekom-color-ui-extra-strong);
   --border-color-disabled: var(--telekom-color-ui-disabled);
@@ -37,7 +37,7 @@
   /* size: small */
   --font-size-small: var(--telekom-typography-font-size-small);
   --line-height-small: var(--telekom-typography-line-spacing-standard);
-  --min-height-small: var(--telekom-spacing-unit-x-8);
+  --min-height-small: var(--telekom-spacing-unit-x8);
 
   /* variant: primary */
   --radius-primary: var(--radius);

--- a/packages/components/src/components/toggle-group/toggle-group.css
+++ b/packages/components/src/components/toggle-group/toggle-group.css
@@ -1,8 +1,8 @@
 :host {
   --border-color: var(--telekom-color-ui-extra-strong);
   --border-color-disabled: var(--telekom-color-ui-disabled);
-  --border: var(--telekom-spacing-unit-x-025) solid var(--border-color);
-  --border-disabled: var(--telekom-spacing-unit-x-025) solid
+  --border: var(--telekom-spacing-unit-x025) solid var(--border-color);
+  --border-disabled: var(--telekom-spacing-unit-x025) solid
     var(--border-color-disabled);
   --radius: var(--telekom-radius-standard);
 }

--- a/packages/components/src/components/tooltip/tooltip.css
+++ b/packages/components/src/components/tooltip/tooltip.css
@@ -17,11 +17,11 @@
   --font-weight: var(--telekom-typography-font-weight-regular);
   --font-size: var(--telekom-typography-font-size-body);
   --line-height: var(--telekom-typography-line-spacing-standard);
-  --spacing: var(--telekom-spacing-unit-x-05) var(--telekom-spacing-unit-x-2);
+  --spacing: var(--telekom-spacing-unit-x05) var(--telekom-spacing-unit-x2);
   /*arrow*/
   /*FIXME:TOKEN use telekom-spacing-unit-*?*/
   --arrow-size: 0.31rem;
-  --arrow-offset: var(--telekom-spacing-unit-x-2);
+  --arrow-offset: var(--telekom-spacing-unit-x2);
   /*tooltip hide*/
   --max-width: 20rem;
   --transition-delay-hide: var(--telekom-motion-duration-instant);


### PR DESCRIPTION
I have noticed there are some files which still have wrong spacing tokens (`--telekom-spacing-unit-x*`). So I update them. Also I update the name of `--telekom-color-ui-regular`  as well. But ONLY in those componenets I am working on. I did not update other component in order not to create merge conflict.