### PR TITLE
fix(checkbox): do not emit change from watching `disabled`

### DIFF
--- a/packages/components/src/components/checkbox/checkbox.tsx
+++ b/packages/components/src/components/checkbox/checkbox.tsx
@@ -17,7 +17,6 @@ import {
   h,
   Host,
   Prop,
-  Watch,
 } from '@stencil/core';
 import { emitEvent } from '../../utils/utils';
 import statusNote from '../../utils/status-note';
@@ -83,13 +82,6 @@ export class Checkbox {
         source: this.host,
       });
     }
-  }
-
-  @Watch('disabled')
-  handleDisabledChange() {
-    const { checked, indeterminate, value, disabled } = this;
-
-    emitEvent(this, 'scaleChange', { checked, indeterminate, value, disabled });
   }
 
   handleChange = (ev) => {


### PR DESCRIPTION
Fixes #817 

(Emitting `scaleChange` when `disabled` changes doesn't make much sense. I guess it was there to support the Checkbox Group?)