### PR TITLE
fix: remove title attribute from modal window

### DIFF
--- a/packages/components/src/components/modal/modal.tsx
+++ b/packages/components/src/components/modal/modal.tsx
@@ -253,7 +253,6 @@ export class Modal {
             role="dialog"
             aria-modal="true"
             aria-label={this.heading}
-            title={this.heading}
           >
             <div
               class="modal__header"


### PR DESCRIPTION
I have removed the title attribute because we already have `aria-label` attribute.