### PR TITLE
refactor: address FIXME:TOKEN

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -70,7 +70,7 @@
     "@popperjs/core": "2.6.0",
     "@proyecto26/animatable-component": "^1.1.8",
     "@stencil/core": "^2.7.1",
-    "@telekom/design-tokens": "^1.0.0-alpha.5",
+    "@telekom/design-tokens": "1.0.0-alpha.5",
     "@telekom/scale-design-tokens": "^3.0.0-beta.46",
     "classnames": "^2.2.6",
     "stencil-inline-svg": "^1.0.1",

--- a/packages/components/src/components/breadcrumb/breadcrumb.css
+++ b/packages/components/src/components/breadcrumb/breadcrumb.css
@@ -19,14 +19,11 @@
   --spacing-y-item: var(--telekom-spacing-unit-x1);
   --spacing-x-item: var(--telekom-spacing-unit-x2);
 
-  /* FIXME:TOKEN --color-link uses ui-normal value as it is the only one that matches the bradcrumb desired color */
   --color-link: var(--telekom-color-ui-regular);
   --radius-link: var(--telekom-radius-standard);
   --color-link-hover: var(--telekom-color-text-and-icon-primary-hovered);
   --color-link-active: var(--telekom-color-text-and-icon-primary-pressed);
-  /* FIXME:TOKEN hardcoded shadow value*/
-  --box-shadow-link-focus: 0 0 0 var(--telekom-spacing-unit-x05)
-    var(--telekom-color-functional-focus);
+  --box-shadow-link-focus: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
 
   --color-current: var(--telekom-color-text-and-icon-standard);
 }

--- a/packages/components/src/components/breadcrumb/breadcrumb.css
+++ b/packages/components/src/components/breadcrumb/breadcrumb.css
@@ -23,7 +23,8 @@
   --radius-link: var(--telekom-radius-standard);
   --color-link-hover: var(--telekom-color-text-and-icon-primary-hovered);
   --color-link-active: var(--telekom-color-text-and-icon-primary-pressed);
-  --box-shadow-link-focus: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
+  --box-shadow-link-focus: 0 0 0 var(--telekom-line-weight-highlight)
+    var(--telekom-color-functional-focus);
 
   --color-current: var(--telekom-color-text-and-icon-standard);
 }

--- a/packages/components/src/components/button/button.css
+++ b/packages/components/src/components/button/button.css
@@ -17,7 +17,8 @@
   --radius: var(--telekom-radius-standard);
   --transition: all var(--telekom-motion-duration-transition)
     cubic-bezier(var(--telekom-motion-easing-standard));
-  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
+  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight)
+    var(--telekom-color-functional-focus);
   --font-weight: var(--telekom-typography-font-weight-bold);
   --font-size: var(--telekom-typography-font-size-body);
   --line-height: var(--telekom-typography-line-spacing-standard);

--- a/packages/components/src/components/button/button.css
+++ b/packages/components/src/components/button/button.css
@@ -17,9 +17,7 @@
   --radius: var(--telekom-radius-standard);
   --transition: all var(--telekom-motion-duration-transition)
     cubic-bezier(var(--telekom-motion-easing-standard));
-  /* FIXME:TOKEN hardcoded shadow value*/
-  --box-shadow-focus: 0 0 0 var(--telekom-spacing-unit-x05)
-    var(--telekom-color-functional-focus);
+  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
   --font-weight: var(--telekom-typography-font-weight-bold);
   --font-size: var(--telekom-typography-font-size-body);
   --line-height: var(--telekom-typography-line-spacing-standard);
@@ -27,7 +25,6 @@
   --vertical-align: middle;
 
   /* size: small */
-  /* FIXME:TOKEN correct lineheight?*/
   --font-size-small: var(--telekom-typography-font-size-small);
   --line-height-small: var(--telekom-typography-line-spacing-standard);
   --min-height-small: var(--telekom-spacing-unit-x8);
@@ -39,7 +36,6 @@
   --background-primary-active: var(--telekom-color-primary-pressed);
   --background-primary-disabled: var(--telekom-color-ui-disabled);
   --color-primary: var(--telekom-color-text-and-icon-inverted-standard);
-  /* FIXME:TOKEN this used to be scl-color-grey-40*/
   --color-primary-disabled: var(--telekom-color-text-and-icon-disabled);
 
   /* variant: secondary */
@@ -49,7 +45,6 @@
   --color-secondary: var(--telekom-color-text-and-icon-standard);
   --color-secondary-hover: var(--telekom-color-text-and-icon-primary-hovered);
   --color-secondary-active: var(--telekom-color-text-and-icon-primary-pressed);
-  /* FIXME:TOKEN this used to be --scl-color-background-disabled  */
   --color-secondary-disabled: var(--telekom-color-text-and-icon-disabled);
 
   /* variant: ghost */

--- a/packages/components/src/components/callout/callout.css
+++ b/packages/components/src/components/callout/callout.css
@@ -7,14 +7,14 @@
   --height-small: 120px;
   --height-large: 160px;
   --width-large: 160px;
-  /* FIXME:TOKEN variable names containing color */
+  /* FIXME variables shouldn't have color names */
   --color-blue: var(--telekom-color-additional-blue-600);
-  /* FIXME:TOKEN variables are used sometimes as background and sometimes as font color */
+  /* FIXME variables are used sometimes as background and sometimes as font color */
   --color-white: var(--telekom-color-background-surface);
   --color-black: var(--telekom-color-text-and-icon-functional-black);
   --color-primary: var(--telekom-color-primary-standard);
   --font-family: var(--telekom-typography-font-family-sans);
-  /* FIXME:TOKEN is this calc necessary? */
+  /* FIXME is this calc necessary? */
   --font-size: calc(var(--telekom-typography-font-size-callout) * 3);
   --font-size-prefix: var(--telekom-typography-font-size-callout);
 }

--- a/packages/components/src/components/card/card.css
+++ b/packages/components/src/components/card/card.css
@@ -16,7 +16,8 @@
   --radius: var(--telekom-radius-large);
   --box-shadow: var(--telekom-shadow-raised-standard);
   --box-shadow-hover: var(--telekom-shadow-raised-hover);
-  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
+  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight)
+    var(--telekom-color-functional-focus);
   --box-shadow-active: var(--telekom-shadow-raised-pressed);
 
   --spacing-body: var(--telekom-spacing-unit-x6);

--- a/packages/components/src/components/card/card.css
+++ b/packages/components/src/components/card/card.css
@@ -16,8 +16,7 @@
   --radius: var(--telekom-radius-large);
   --box-shadow: var(--telekom-shadow-raised-standard);
   --box-shadow-hover: var(--telekom-shadow-raised-hover);
-  --box-shadow-focus: 0 0 0 var(--telekom-spacing-unit-x05)
-    var(--telekom-color-functional-focus);
+  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
   --box-shadow-active: var(--telekom-shadow-raised-pressed);
 
   --spacing-body: var(--telekom-spacing-unit-x6);

--- a/packages/components/src/components/data-grid/data-grid.css
+++ b/packages/components/src/components/data-grid/data-grid.css
@@ -402,7 +402,8 @@
 .info {
   height: 54px;
   position: relative;
-  border-top: var(--telekom-line-weight-standard) solid var(--telekom-color-ui-subtle);
+  border-top: var(--telekom-line-weight-standard) solid
+    var(--telekom-color-ui-subtle);
   display: flex;
   justify-content: center;
 }

--- a/packages/components/src/components/data-grid/data-grid.css
+++ b/packages/components/src/components/data-grid/data-grid.css
@@ -24,7 +24,7 @@
   font-weight: var(--telekom-typography-font-weight-medium);
 }
 
-/* FIXME:TOKEN diffrent heading sizes that are not available in design tokens */
+/* FIXME use --telekom tokens */
 .scl-h1 {
   margin: 0;
   font-size: var(--scl-font-variant-heading-1-size);
@@ -72,7 +72,6 @@
   font-size: var(--telekom-typography-font-size-body);
   font-weight: var(--telekom-typography-font-weight-regular);
   line-height: var(--telekom-typography-line-spacing-standard);
-  /* FIXME:TOKEN this used to be --scl-color-grey-90 */
   color: var(--telekom-color-text-and-icon-standard);
 }
 
@@ -403,8 +402,7 @@
 .info {
   height: 54px;
   position: relative;
-  /* FIXME:TOKEN border-top different than border-bottom, used to be scl-color-grey-20 and scl-color-grey-10 respectively, now both --telekom-color-ui-subtle  */
-  border-top: 1px solid var(--telekom-color-ui-subtle);
+  border-top: var(--telekom-line-weight-standard) solid var(--telekom-color-ui-subtle);
   display: flex;
   justify-content: center;
 }
@@ -488,8 +486,7 @@
   display: block;
   width: 100px;
   flex-shrink: 0;
-  /* FIXME:TOKEN this variable is not defined anywhere */
-  color: var(--scl-color-grey);
+  color: var(--telekom-color-text-and-icon-additional);
   font-size: var(--telekom-typography-font-size-small);
   font-weight: var(--telekom-typography-font-weight-medium);
 }

--- a/packages/components/src/components/date-picker/date-picker.css
+++ b/packages/components/src/components/date-picker/date-picker.css
@@ -67,9 +67,7 @@ duet-date-picker .duet-date__toggle {
 }
 
 duet-date-picker .duet-date__toggle:focus {
-  /* FIXME:TOKEN hardcoded shadow value*/
-  box-shadow: 0 0 0 var(--telekom-spacing-unit-x05)
-    var(--telekom-color-functional-focus);
+  box-shadow: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
 }
 
 duet-date-picker .duet-date__toggle:hover scale-icon-content-calendar {

--- a/packages/components/src/components/date-picker/date-picker.css
+++ b/packages/components/src/components/date-picker/date-picker.css
@@ -40,7 +40,8 @@ duet-date-picker {
 
 duet-date-picker .duet-date__input {
   /* FIXME:TOKEN use ui/border */
-  border: var(--telekom-line-weight-standard) solid var(--telekom-color-text-and-icon-standard);
+  border: var(--telekom-line-weight-standard) solid
+    var(--telekom-color-text-and-icon-standard);
   padding: var(--telekom-spacing-unit-x3) var(--telekom-spacing-unit-x3) 0
     var(--telekom-spacing-unit-x3);
   height: var(--telekom-spacing-unit-x12);
@@ -55,7 +56,8 @@ duet-date-picker .duet-date__input:focus {
   box-shadow: 0 0 0 var(--telekom-line-weight-highlight)
     var(--telekom-color-functional-focus);
   /* FIXME:TOKEN use ui/border (there's no "ui/border/focus" anyway) */
-  border: var(--telekom-line-weight-standard) solid var(--telekom-color-primary-hovered);
+  border: var(--telekom-line-weight-standard) solid
+    var(--telekom-color-primary-hovered);
 }
 
 duet-date-picker .duet-date__toggle {
@@ -64,7 +66,8 @@ duet-date-picker .duet-date__toggle {
 }
 
 duet-date-picker .duet-date__toggle:focus {
-  box-shadow: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
+  box-shadow: 0 0 0 var(--telekom-line-weight-highlight)
+    var(--telekom-color-functional-focus);
 }
 
 duet-date-picker .duet-date__toggle:hover scale-icon-content-calendar {

--- a/packages/components/src/components/date-picker/date-picker.css
+++ b/packages/components/src/components/date-picker/date-picker.css
@@ -63,6 +63,7 @@ duet-date-picker .duet-date__input:focus {
 duet-date-picker .duet-date__toggle {
   border-radius: 0 var(--duet-radius) var(--duet-radius) 0;
   background: transparent;
+  box-shadow: inset 1px 0 0 var(--telekom-color-ui-light);
 }
 
 duet-date-picker .duet-date__toggle:focus {
@@ -245,7 +246,10 @@ duet-date-picker .duet-date__input:focus::placeholder {
   border-color: var(--telekom-color-ui-disabled);
   background: transparent;
 }
-.scale-date-picker.scale-date-picker--disabled .duet-date__toggle,
+.scale-date-picker.scale-date-picker--disabled .duet-date__toggle {
+  color: var(--telekom-color-text-and-icon-disabled);
+  box-shadow: inset 1px 0 0 var(--telekom-color-ui-disabled);
+}
 .scale-date-picker.scale-date-picker--disabled .duet-date__toggle:hover,
 .scale-date-picker.scale-date-picker--disabled
   .duet-date__toggle:hover

--- a/packages/components/src/components/date-picker/date-picker.css
+++ b/packages/components/src/components/date-picker/date-picker.css
@@ -235,21 +235,26 @@ duet-date-picker .duet-date__input:focus::placeholder {
 
 /* Disabled */
 
-.scale-date-picker.scale-date-picker--disabled,
+.scale-date-picker.scale-date-picker--disabled {
+  cursor: not-allowed;
+}
 .scale-date-picker.scale-date-picker--disabled input,
-.scale-date-picker.scale-date-picker--disabled input:hover,
+.scale-date-picker.scale-date-picker--disabled input:hover {
+  color: var(--telekom-color-text-and-icon-disabled);
+  /* FIXME */
+  border-color: var(--telekom-color-ui-disabled);
+  background: transparent;
+}
 .scale-date-picker.scale-date-picker--disabled .duet-date__toggle,
 .scale-date-picker.scale-date-picker--disabled .duet-date__toggle:hover,
 .scale-date-picker.scale-date-picker--disabled
   .duet-date__toggle:hover
-  scale-icon-content-calendar,
-.scale-date-picker.scale-date-picker--disabled .date-picker__helper-text {
-  cursor: not-allowed;
-  border-color: var(--scl-color-grey-20);
+  scale-icon-content-calendar {
   color: var(--telekom-color-text-and-icon-disabled);
-  background: var(--telekom-color-background-surface);
 }
-
+.scale-date-picker.scale-date-picker--disabled .date-picker__helper-text {
+  color: var(--telekom-color-text-and-icon-disabled);
+}
 .scale-date-picker.scale-date-picker--disabled .date-picker__label {
   color: var(--telekom-color-text-and-icon-disabled);
 }
@@ -260,6 +265,8 @@ duet-date-picker .duet-date__input:focus::placeholder {
   text-align: center;
   padding: var(--spacing-heading);
   font-size: var(--font-size-heading);
+  /* FIXME remove !important (fix Storybook?) */
+  color: var(--telekom-color-text-and-icon-standard) !important;
 }
 
 duet-date-picker .duet-date__dialog-content {

--- a/packages/components/src/components/date-picker/date-picker.css
+++ b/packages/components/src/components/date-picker/date-picker.css
@@ -10,29 +10,26 @@
  */
 
 duet-date-picker {
-  /* FIXME:TOKEN are these variable used anywhere? seems only duet-radius is used */
-  --duet-color-primary: var(
-    --telekom-color-text-and-icon-primary-standard,
-    #e20074
-  );
-  --duet-color-text: var(--telekom-color-text-and-icon-standard, #1a1a1a);
-  --duet-color-overlay: var(--telekom-color-background-surface, #ffffff);
+  --duet-color-primary: var(--telekom-color-primary-standard);
+  --duet-color-text: var(--telekom-color-text-and-icon-standard);
+  --duet-color-overlay: var(--telekom-color-background-surface);
   --duet-font: var(--telekom-typography-font-family-sans);
   --duet-font-normal: var(--telekom-typography-font-weight-regular);
   --duet-font-bold: var(--telekom-typography-font-weight-medium);
   --duet-color-placeholder: var(--telekom-color-ui-regular);
   --duet-radius: var(--telekom-radius-standard);
 
+  /* FIXME */
   --duet-color-text-active: var(
     --telekom-color-text-and-icon-inverted-standard,
     #ffffff
   );
+  /* FIXME */
   --duet-color-button: var(--telekom-color-background-surface, #ffffff);
   --duet-color-surface: var(--telekom-color-background-surface, #ffffff);
   --duet-z-index: 600;
 
   --spacing-heading: 0 0 var(--telekom-spacing-unit-x4) 0;
-  /* FIXME:TOKEN should this be called differently?  */
   --font-size-heading: var(--telekom-typography-font-size-callout);
   --font-size-select-label: var(--telekom-typography-font-size-body);
   --radius-day: var(--telekom-radius-large);
@@ -42,8 +39,8 @@ duet-date-picker {
 }
 
 duet-date-picker .duet-date__input {
-  /* FIXME:TOKEN border color is using standard text black, but there is no --telekom-ui- or functional equivalent */
-  border: var(--telekom-spacing-unit-x025) solid var(--scl-color-text-standard);
+  /* FIXME:TOKEN use ui/border */
+  border: var(--telekom-line-weight-standard) solid var(--telekom-color-text-and-icon-standard);
   padding: var(--telekom-spacing-unit-x3) var(--telekom-spacing-unit-x3) 0
     var(--telekom-spacing-unit-x3);
   height: var(--telekom-spacing-unit-x12);
@@ -55,10 +52,10 @@ duet-date-picker .duet-date__input:hover {
 }
 
 duet-date-picker .duet-date__input:focus {
-  box-shadow: 0 0 0 var(--telekom-spacing-unit-x05)
+  box-shadow: 0 0 0 var(--telekom-line-weight-highlight)
     var(--telekom-color-functional-focus);
-  /* FIXME:TOKEN border color is using standard text black, but there is no --telekom-ui- or functional equivalent */
-  border: var(--telekom-spacing-unit-x025) solid var(--scl-color-text-standard);
+  /* FIXME:TOKEN use ui/border (there's no "ui/border/focus" anyway) */
+  border: var(--telekom-line-weight-standard) solid var(--telekom-color-primary-hovered);
 }
 
 duet-date-picker .duet-date__toggle {
@@ -99,7 +96,6 @@ duet-date-picker .duet-date__toggle:active scale-icon-content-calendar {
 .scale-date-picker .date-picker__helper-text {
   font-weight: var(--telekom-typography-font-weight-bold);
   transition: all var(--telekom-motion-duration-transition)
-    /* FIXME:TOKEN update this */
     cubic-bezier(var(--telekom-motion-easing-standard));
   padding-left: var(--telekom-spacing-unit-x3);
   font-size: var(--telekom-typography-font-size-small);
@@ -116,8 +112,7 @@ duet-date-picker .duet-date__toggle:active scale-icon-content-calendar {
 .scale-date-picker .date-picker__label {
   top: 0;
   left: 0;
-  /* FIXME:TOKEN replace */
-  color: var(--telekom-color-text-and-icon-standard);
+  color: var(--telekom-color-text-and-icon-additional);
   display: flex;
   z-index: 10;
   position: absolute;
@@ -141,20 +136,18 @@ duet-date-picker .duet-date__input::placeholder {
   visibility: hidden;
   color: transparent;
   transition: all var(--telekom-motion-duration-transition)
-    /* FIXME:TOKEN update this */
     cubic-bezier(var(--telekom-motion-easing-standard));
 }
 
 .scale-date-picker.scale-date-picker--focus .date-picker__label,
 .scale-date-picker.animated .date-picker__label {
-  color: var(--telekom-color-text-and-icon-standard);
+  color: var(--telekom-color-text-and-icon-additional);
   transform: translate(
     var(--telekom-spacing-unit-x3),
     var(--telekom-spacing-unit-x2)
   );
   transition: all var(--telekom-motion-duration-transition)
     cubic-bezier(var(--telekom-motion-easing-standard));
-  /* FIXME:TOKEN should this be called differently?  */
   font-size: var(--telekom-typography-font-size-footnote);
   font-weight: var(--telekom-typography-font-weight-bold);
 }
@@ -205,7 +198,6 @@ duet-date-picker .duet-date__input:focus::placeholder {
   z-index: 10;
   position: absolute;
   transition: all var(--telekom-motion-duration-transition)
-    /* FIXME:TOKEN update this */
     cubic-bezier(var(--telekom-motion-easing-standard));
   pointer-events: none;
   font-size: var(--telekom-typography-font-size-body);
@@ -228,7 +220,6 @@ duet-date-picker .duet-date__input:focus::placeholder {
     var(--telekom-spacing-unit-x1)
   );
   transition: all var(--telekom-motion-duration-transition)
-    /* FIXME:TOKEN update this */
     cubic-bezier(var(--telekom-motion-easing-standard));
   font-size: var(--telekom-typography-font-size-footnote);
   font-weight: var(--telekom-typography-font-weight-medium);
@@ -252,14 +243,12 @@ duet-date-picker .duet-date__input:focus::placeholder {
 .scale-date-picker.scale-date-picker--disabled .date-picker__helper-text {
   cursor: not-allowed;
   border-color: var(--scl-color-grey-20);
-  /* FIXME:TOKEN --scl-color-grey-20 used for text, is it fine? */
-  color: var(--scl-color-grey-20);
+  color: var(--telekom-color-text-and-icon-disabled);
   background: var(--telekom-color-background-surface);
 }
 
 .scale-date-picker.scale-date-picker--disabled .date-picker__label {
-  /* FIXME:TOKEN --scl-color-grey-20 used for text, is it fine? */
-  color: var(--scl-color-grey-20);
+  color: var(--telekom-color-text-and-icon-disabled);
 }
 
 /* Popover layout */

--- a/packages/components/src/components/divider/divider.css
+++ b/packages/components/src/components/divider/divider.css
@@ -13,7 +13,7 @@
   --width: 100%;
   --height: 100%;
   --spacing: var(--telekom-spacing-unit-x3);
-  /* FIXME:TOKEN this used to be scl-color-grey-20 */
+  /* FIXME this should be called --border-color */
   --color: var(--telekom-color-ui-subtle);
   --border-width: var(--telekom-spacing-unit-x025);
   --min-height-vertical: var(--telekom-spacing-unit-x6);

--- a/packages/components/src/components/dropdown/dropdown.css
+++ b/packages/components/src/components/dropdown/dropdown.css
@@ -16,7 +16,6 @@ scale-dropdown {
   --spacing-x: var(--telekom-spacing-unit-x3);
   --spacing-dropdown: var(--telekom-spacing-unit-x3)
     var(--telekom-spacing-unit-x10) 0 calc(var(--spacing-x) - 1px);
-  /* FIXME:TOKEN update this */
   --transition: all var(--telekom-motion-duration-transition)
     cubic-bezier(var(--telekom-motion-easing-standard));
   --radius: var(--telekom-radius-standard);
@@ -24,12 +23,10 @@ scale-dropdown {
     var(--telekom-color-text-and-icon-standard);
   --border-error: var(--telekom-spacing-unit-x05) solid
     var(--telekom-color-functional-danger-standard);
-  /* FIXME:TOKEN border-hover and border-focus both using primary hover */
-  --border-color-hover: var(--scl-color-primary-hover, #f90984);
-  --border-color-focus: var(--scl-color-primary-hover, #f90984);
-  /* FIXME:TOKEN should this be defined here? */
-  --box-shadow-focus: 0 0 0 var(--telekom-spacing-unit-x05)
-    var(--telekom-color-functional-focus);
+  /* FIXME:TOKEN use ui border… */
+  --border-color-hover: var(--telekom-color-primary-hovered);
+  --border-color-focus: var(--telekom-color-primary-hovered);
+  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
   --color-disabled: var(--telekom-color-text-and-icon-disabled);
   --background-disabled: var(--telekom-color-ui-disabled);
 

--- a/packages/components/src/components/dropdown/dropdown.css
+++ b/packages/components/src/components/dropdown/dropdown.css
@@ -26,7 +26,8 @@ scale-dropdown {
   /* FIXME:TOKEN use ui border… */
   --border-color-hover: var(--telekom-color-primary-hovered);
   --border-color-focus: var(--telekom-color-primary-hovered);
-  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
+  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight)
+    var(--telekom-color-functional-focus);
   --color-disabled: var(--telekom-color-text-and-icon-disabled);
   --background-disabled: var(--telekom-color-ui-disabled);
 

--- a/packages/components/src/components/icon/icon.css
+++ b/packages/components/src/components/icon/icon.css
@@ -12,7 +12,6 @@
 scale-icon {
   --display: inline-flex;
   --transition: all var(--telekom-motion-duration-transition)
-    /* FIXME:TOKEN update this */
     cubic-bezier(var(--telekom-motion-easing-standard));
 
   display: var(--display);

--- a/packages/components/src/components/input/input.css
+++ b/packages/components/src/components/input/input.css
@@ -450,12 +450,14 @@
   -webkit-appearance: none;
   background-color: #fff;
   /* FIXME:TOKEN needs some sort of black */
-  border: var(--telekom-line-weight-standard) solid var(--scl-color-text-standard);
+  border: var(--telekom-line-weight-standard) solid
+    var(--scl-color-text-standard);
   margin: 0 var(--telekom-spacing-unit-x2) 0 0;
 }
 .input--type-radio input:focus {
   outline: none;
-  box-shadow: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
+  box-shadow: 0 0 0 var(--telekom-line-weight-highlight)
+    var(--telekom-color-functional-focus);
 }
 .input--type-radio:hover input:not(:checked):not([disabled]) {
   box-shadow: none;

--- a/packages/components/src/components/input/input.css
+++ b/packages/components/src/components/input/input.css
@@ -27,13 +27,11 @@
   z-index: 1;
   box-sizing: border-box;
   transition: all var(--telekom-motion-duration-transition)
-    /* FIXME:TOKEN update this */
     cubic-bezier(var(--telekom-motion-easing-standard));
   font-family: inherit;
   font-size: var(--telekom-typography-font-size-body);
   border-radius: var(--telekom-radius-standard);
-  /* FIXME:TOKEN this used to be --scl-color-grey-90 */
-  border: var(--telekom-spacing-unit-x025) solid
+  border: var(--telekom-line-weight-standard) solid
     var(--telekom-color-ui-extra-strong);
 }
 .input .input__textarea {
@@ -46,7 +44,6 @@
   z-index: 1;
   box-sizing: border-box;
   transition: all var(--telekom-motion-duration-transition)
-    /* FIXME:TOKEN update this */
     cubic-bezier(var(--telekom-motion-easing-standard));
   font-family: inherit;
   font-size: var(--telekom-typography-font-size-body);
@@ -64,7 +61,6 @@
 .input .input__counter {
   display: flex;
   transition: all var(--telekom-motion-duration-transition)
-    /* FIXME:TOKEN update this */
     cubic-bezier(var(--telekom-motion-easing-standard));
   margin-left: auto;
   padding-right: var(--telekom-spacing-unit-x3);
@@ -75,7 +71,6 @@
 }
 .input .input__helper-text {
   transition: all var(--telekom-motion-duration-transition)
-    /* FIXME:TOKEN update this */
     cubic-bezier(var(--telekom-motion-easing-standard));
   padding-left: var(--telekom-spacing-unit-x3);
   font-size: var(--telekom-typography-font-size-small);
@@ -110,10 +105,8 @@
 .input:not(.input--disabled) .input__input:focus::placeholder,
 .input:not(.input--disabled) .input__select:focus::placeholder,
 .input:not(.input--disabled) .input__textarea:focus::placeholder {
-  /* FIXME:TOKEN what color to use for placeholder, --telekom-color-text-and-icon-additional ?*/
-  color: var(--scl-color-grey-60);
+  color: var(--telekom-color-text-and-icon-additional);
   transition: all var(--telekom-motion-duration-transition)
-    /* FIXME:TOKEN update this */
     cubic-bezier(var(--telekom-motion-easing-standard));
 }
 .input .input__select-wrapper scale-icon {
@@ -129,12 +122,10 @@
 .input ::placeholder {
   color: transparent;
   transition: all var(--telekom-motion-duration-transition)
-    /* FIXME:TOKEN update this */
     cubic-bezier(var(--telekom-motion-easing-standard));
 }
 .input--variant-static .input__label {
-  /* FIXME:TOKEN what color to use for placeholder, --telekom-color-text-and-icon-additional ?*/
-  color: var(--scl-color-grey-60);
+  color: var(--telekom-color-text-and-icon-additional);
   display: flex;
   font-weight: var(--telekom-typography-font-weight-medium);
 }
@@ -149,14 +140,11 @@
 .input--variant-animated .input__label {
   top: 0;
   left: 0;
-  /* FIXME:TOKEN what color to use for placeholder, --telekom-color-text-and-icon-additional ?*/
-  color: var(--scl-color-grey-60);
+  color: var(--telekom-color-text-and-icon-additional);
   display: flex;
-  /* FIXME:TOKEN missing z-index vars */
   z-index: var(--scl-z-index-10);
   position: absolute;
   transition: all var(--telekom-motion-duration-transition)
-    /* FIXME:TOKEN update this */
     cubic-bezier(var(--telekom-motion-easing-standard));
   pointer-events: none;
   font-size: var(--telekom-typography-font-size-body);
@@ -180,7 +168,6 @@
     var(--telekom-spacing-unit-x2)
   );
   transition: all var(--telekom-motion-duration-transition)
-    /* FIXME:TOKEN update this */
     cubic-bezier(var(--telekom-motion-easing-standard));
   font-size: var(--telekom-typography-font-size-footnote);
   font-weight: var(--telekom-typography-font-weight-bold);
@@ -211,7 +198,6 @@
   z-index: var(--scl-z-index-10);
   position: absolute;
   transition: all var(--telekom-motion-duration-transition)
-    /* FIXME:TOKEN update this */
     cubic-bezier(var(--telekom-motion-easing-standard));
   pointer-events: none;
   font-size: var(--telekom-typography-font-size-body);
@@ -232,14 +218,12 @@
 }
 .input--size-small.input--has-focus .input__label,
 .input--size-small.animated .input__label {
-  /* FIXME:TOKEN what color to use for label, --telekom-color-text-and-icon-additional ?*/
-  color: var(--scl-color-grey-60);
+  color: var(--telekom-color-text-and-icon-additional);
   transform: translate(
     var(--telekom-spacing-unit-x3),
     var(--telekom-spacing-unit-x1)
   );
   transition: all var(--telekom-motion-duration-transition)
-    /* FIXME:TOKEN update this */
     cubic-bezier(var(--telekom-motion-easing-standard));
   font-size: var(--telekom-typography-font-size-footnote);
   font-weight: var(--telekom-typography-font-weight-medium);
@@ -413,7 +397,6 @@
   margin: 0;
   box-sizing: border-box;
   transition: all var(--telekom-motion-duration-transition)
-    /* FIXME:TOKEN update this */
     cubic-bezier(var(--telekom-motion-easing-standard));
   border-radius: var(--telekom-radius-standard);
   border: var(--telekom-spacing-unit-x025) solid
@@ -432,7 +415,6 @@
 }
 .input--type-checkbox .input__checkbox-container ~ label {
   transition: all var(--telekom-motion-duration-transition)
-    /* FIXME:TOKEN update this */
     cubic-bezier(var(--telekom-motion-easing-standard));
 }
 .input--type-checkbox.input--status-error
@@ -456,7 +438,6 @@
 .input--type-radio label {
   color: var(--telekom-color-text-and-icon-standard);
   transition: all var(--telekom-motion-duration-transition)
-    /* FIXME:TOKEN update this */
     cubic-bezier(var(--telekom-motion-easing-standard));
   font-weight: var(--telekom-typography-font-weight-medium);
 }
@@ -464,28 +445,24 @@
   width: var(--telekom-spacing-unit-x4);
   height: var(--telekom-spacing-unit-x4);
   transition: all var(--telekom-motion-duration-transition)
-    /* FIXME:TOKEN update this */
     cubic-bezier(var(--telekom-motion-easing-standard));
-  /* FIXME:TOKEN hardcoded values  */
-  border-radius: 50%;
+  border-radius: var(--telekom-radius-circle);
   -webkit-appearance: none;
   background-color: #fff;
-  /* FIXME:TOKEN needs some sort of black  */
-  border: var(--telekom-spacing-unit-x025) solid var(--scl-color-text-standard);
+  /* FIXME:TOKEN needs some sort of black */
+  border: var(--telekom-line-weight-standard) solid var(--scl-color-text-standard);
   margin: 0 var(--telekom-spacing-unit-x2) 0 0;
 }
 .input--type-radio input:focus {
   outline: none;
-  /* FIXME:TOKEN should this be defined here? */
-  box-shadow: 0 0 0 var(--telekom-spacing-unit-x05)
-    var(--telekom-color-functional-focus);
+  box-shadow: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
 }
 .input--type-radio:hover input:not(:checked):not([disabled]) {
   box-shadow: none;
-  border-color: var(--telekom-color-text-and-icon-primary-hovered, #f90984);
+  border-color: var(--telekom-color-text-and-icon-primary-hovered);
 }
 .input--type-radio:hover input:not(:checked):not([disabled]) ~ label {
-  color: var(--telekom-color-text-and-icon-primary-hovered, #f90984);
+  color: var(--telekom-color-text-and-icon-primary-hovered);
 }
 .input--type-radio input:active {
   border: var(--telekom-spacing-unit-x2) solid

--- a/packages/components/src/components/link/link.css
+++ b/packages/components/src/components/link/link.css
@@ -22,32 +22,28 @@
 
   /* initial */
   --color: var(--telekom-color-text-and-icon-link-standard);
-  /* FIXME:TOKEN hardcoded values */
+  /* FIXME:TOKEN hardcoded value */
   --color-line-initial: hsl(219, 100%, 87%);
-  --line-thickness-initial: 0.0625em;
+  --color-line-initial: var(--telekom-color-additional-blue-200);
+  --line-thickness-initial: var(--telekom-line-weight-standard);
   /* visited */
   --color-visited: var(--telekom-color-text-and-icon-link-visited);
-  /* FIXME:TOKEN no -functional-link-visited */
-  --color-line-visited: var(--scl-color-text-link-visited);
+  --color-line-visited: currentColor;
   --line-thickness-visited: var(--line-thickness-initial);
   /* hover */
   --color-hover: var(--telekom-color-text-and-icon-link-hovered);
-  /* FIXME:TOKEN no -functional-link-hovered */
-  --color-line-hover: var(--scl-color-blue-70);
+  --color-line-hover: currentColor;
   --line-thickness-hover: var(--line-thickness-initial);
   /* focus */
-  /* FIXME:TOKEN no -functional-link-active, before this was also scl-color-blue-70 */
   --color-focus: var(--telekom-color-text-and-icon-link-active);
-  --color-line-focus: var(--scl-color-blue-70);
-  --line-thickness-focus: calc(var(--line-thickness-initial) * 2);
+  --color-line-focus: var(--telekom-color-functional-focus);
+  --line-thickness-focus: var(--telekom-line-weight-highlight);
   /* active */
-  /* FIXME:TOKEN no -functional-link-active, before this was also scl-color-blue-70 */
   --color-active: var(--telekom-color-text-and-icon-link-active);
-  --color-line-active: var(--scl-color-blue-60);
+  --color-line-active: currentColor;
   --line-thickness-active: var(--line-thickness-initial);
   /* disabled */
   --color-disabled: var(--telekom-color-text-and-icon-disabled);
-  /* FIXME:TOKEN is this correct for underline */
   --color-line-disabled: var(--telekom-color-ui-disabled);
   --line-thickness-disabled: var(--line-thickness-initial);
 }

--- a/packages/components/src/components/loading-spinner/loading-spinner.css
+++ b/packages/components/src/components/loading-spinner/loading-spinner.css
@@ -11,16 +11,14 @@
   --font-weight: var(--telekom-typography-font-weight-bold);
   --font-size: var(--telekom-typography-font-size-body);
 
+  /* FIXME remove primary and white from variable names */
   --color-circle-primary: var(--telekom-color-primary-standard);
-  /* FIXME:TOKEN this was --scl-color-grey-20  */
-  --color-circle-primary-inner: var(--telekom-color-ui-light);
-  /* FIXME:TOKEN this was --scl-color-grey-60  */
+  --color-circle-primary-inner: var(--telekom-color-ui-subtle);
   --color-text-primary: var(--telekom-color-text-and-icon-additional);
-  /* FIXME:TOKEN this should be the new variable --telekom-color-ui-base ?*/
+  /* FIXME:TOKEN what about these 2 circle-? ?*/
   --color-circle-white: var(--telekom-color-ui-base);
   --color-circle-white-inner: var(--telekom-color-ui-regular);
-  /* FIXME:TOKEN this should be complementary to the new variable --telekom-color-ui-base */
-  --color-text-white: var(--telekom-color-text-and-icon-inverted-standard);
+  --color-text-white: var(--telekom-color-text-and-icon-functional-white);
 }
 
 .sr-only {
@@ -45,7 +43,7 @@
 }
 
 .spinner.spinner--variant-white .spinner__text {
-  color: var(--color-circle-white);
+  color: var(--color-text-white);
 }
 
 .spinner.spinner--alignment-horizontal .spinner__text {

--- a/packages/components/src/components/menu-flyout-divider/menu-flyout-divider.css
+++ b/packages/components/src/components/menu-flyout-divider/menu-flyout-divider.css
@@ -13,11 +13,12 @@
 
 :host {
   display: block;
-  /* FIXME:TOKEN previously scl-color-grey-10 */
+  /* FIXME renamae to --border-color */
   --color: var(--telekom-color-ui-subtle);
 }
 
 .menu-flyout-divider {
-  border-top: 1px solid var(--color);
+  border-top: var(--telekom-line-weight-standard) solid var(--color);
+  /* FIXME use --telekom-spacing-unit-x2 ? */
   margin: 6px 0;
 }

--- a/packages/components/src/components/menu-flyout-item/menu-flyout-item.css
+++ b/packages/components/src/components/menu-flyout-item/menu-flyout-item.css
@@ -10,7 +10,8 @@
  */
 
 :host {
-  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
+  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight)
+    var(--telekom-color-functional-focus);
 
   display: block;
   position: relative;

--- a/packages/components/src/components/menu-flyout-item/menu-flyout-item.css
+++ b/packages/components/src/components/menu-flyout-item/menu-flyout-item.css
@@ -10,8 +10,7 @@
  */
 
 :host {
-  --box-shadow-focus: 0 0 0 var(--telekom-spacing-unit-x05)
-    var(--telekom-color-functional-focus);
+  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
 
   display: block;
   position: relative;
@@ -22,7 +21,6 @@
 }
 
 * {
-  /* FIXME:TOKEN hardcoded value */
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
 }
 
@@ -68,7 +66,6 @@
 
 .menu-flyout-item--disabled {
   outline: none;
-  /* FIXME:TOKEN previously hard coded color: #ccc; */
   color: var(--telekom-color-text-and-icon-disabled);
   cursor: not-allowed;
 }

--- a/packages/components/src/components/menu-flyout-list/menu-flyout-list.css
+++ b/packages/components/src/components/menu-flyout-list/menu-flyout-list.css
@@ -17,7 +17,6 @@
 :host {
   box-sizing: content-box;
   position: fixed;
-  /* FIXME:TOKEN missing z-index */
   z-index: var(--scl-z-index-20);
   pointer-events: none;
 }
@@ -26,7 +25,6 @@
   display: none;
   position: absolute;
   pointer-events: initial;
-  /* FIXME:TOKEN missing z-index */
   z-index: var(--scl-z-index-20);
   background: var(--telekom-color-background-surface);
   border-radius: var(--telekom-radius-large);
@@ -129,13 +127,11 @@
 }
 .menu-flyout-list__scroll-up-indicator {
   top: var(--telekom-spacing-unit-x2);
-  /* FIXME:TOKEN previously --scl-color-grey-40 */
   border-bottom: 5px solid var(--telekom-color-ui-light);
   border-top: 0;
 }
 .menu-flyout-list__scroll-down-indicator {
   bottom: var(--telekom-spacing-unit-x2);
-  /* FIXME:TOKEN previously --scl-color-grey-40 */
   border-top: 5px solid var(--telekom-color-ui-light);
   border-bottom: 0;
 }

--- a/packages/components/src/components/modal/modal.css
+++ b/packages/components/src/components/modal/modal.css
@@ -45,7 +45,6 @@
   --spacing-x-header: var(--telekom-spacing-unit-x6);
   --spacing-y-header: var(--telekom-spacing-unit-x6);
 
-  /* FIXME:TOKEN --telekom-color-ui-border-standard is too dark */
   --border-bottom-header-has-scroll: var(--telekom-line-weight-standard) solid
     var(--telekom-color-ui-general-subtle, var(--telekom-color-ui-subtle));
 
@@ -57,8 +56,7 @@
   --radius-close-button: var(--telekom-radius-standard);
   --transition-close-button: all var(--telekom-motion-duration-transition)
     var(--telekom-motion-easing-standard);
-  --box-shadow-close-button-focus: 0 0 0 var(--telekom-line-weight-highlight)
-    var(--telekom-color-functional-focus);
+  --box-shadow-close-button-focus: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
   --color-close-button: var(--telekom-color-text-and-icon-standard);
   --color-close-button-hover: var(--telekom-color-primary-hovered);
   --color-close-button-active: var(--telekom-color-primary-pressed);

--- a/packages/components/src/components/modal/modal.css
+++ b/packages/components/src/components/modal/modal.css
@@ -30,7 +30,7 @@
     -spacing-56 !== --telekom-spacing-unrelated-sm
   */
   --size-window-small: calc(
-    (6 * var(---telekom-spacing-unit-x14, 3.5rem)) +
+    (6 * var(--telekom-spacing-unit-x14, 3.5rem)) +
       (5 * var(--telekom-spacing-unit-x8))
   );
   --size-window-default: calc(

--- a/packages/components/src/components/modal/modal.css
+++ b/packages/components/src/components/modal/modal.css
@@ -9,7 +9,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
- :host {
+:host {
   --spacing-x: var(--telekom-spacing-unit-x4);
   --background-overlay: var(
     --telekom-color-background-backdrop,
@@ -57,7 +57,8 @@
   --radius-close-button: var(--telekom-radius-standard);
   --transition-close-button: all var(--telekom-motion-duration-transition)
     var(--telekom-motion-easing-standard);
-  --box-shadow-close-button-focus: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
+  --box-shadow-close-button-focus: 0 0 0 var(--telekom-line-weight-highlight)
+    var(--telekom-color-functional-focus);
   --color-close-button: var(--telekom-color-text-and-icon-standard);
   --color-close-button-hover: var(--telekom-color-primary-hovered);
   --color-close-button-active: var(--telekom-color-primary-pressed);

--- a/packages/components/src/components/modal/modal.css
+++ b/packages/components/src/components/modal/modal.css
@@ -9,14 +9,14 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-:host {
-  --spacing-x: var(--telekom-spacing-grouped-md);
+ :host {
+  --spacing-x: var(--telekom-spacing-unit-x4);
   --background-overlay: var(
     --telekom-color-background-backdrop,
     rgba(108, 108, 108, 0.7)
   );
 
-  --max-height-window: calc(100vh - (2 * var(--telekom-spacing-unrelated-lg)));
+  --max-height-window: calc(100vh - (2 * var(--telekom-spacing-unit-x20)));
   --radius-window: var(--telekom-radius-large);
   --box-shadow-window: var(--telekom-shadow-top);
   --background-window: var(--telekom-color-background-surface);
@@ -30,29 +30,30 @@
     -spacing-56 !== --telekom-spacing-unrelated-sm
   */
   --size-window-small: calc(
-    (6 * var(--telekom-spacing-unrelated-sm, 3.5rem)) +
-      (5 * var(--telekom-spacing-related-sm))
+    (6 * var(---telekom-spacing-unit-x14, 3.5rem)) +
+      (5 * var(--telekom-spacing-unit-x8))
   );
   --size-window-default: calc(
-    (8 * var(--telekom-spacing-unrelated-sm, 3.5rem)) +
-      (7 * var(--telekom-spacing-related-sm))
+    (8 * var(--telekom-spacing-unit-x14, 3.5rem)) +
+      (7 * var(--telekom-spacing-unit-x8))
   );
   --size-window-large: calc(
-    (12 * var(--telekom-spacing-unrelated-sm, 3.5rem)) +
-      (11 * var(--telekom-spacing-related-sm))
+    (12 * var(--telekom-spacing-unit-x14, 3.5rem)) +
+      (11 * var(--telekom-spacing-unit-x8))
   );
 
-  --spacing-x-header: var(--telekom-spacing-grouped-lg);
-  --spacing-y-header: var(--telekom-spacing-grouped-lg);
+  --spacing-x-header: var(--telekom-spacing-unit-x6);
+  --spacing-y-header: var(--telekom-spacing-unit-x6);
 
+  /* FIXME:TOKEN --telekom-color-ui-border-standard is too dark */
   --border-bottom-header-has-scroll: var(--telekom-line-weight-standard) solid
-    var(--telekom-color-ui-light); /* could also be --telekom-color-ui-subtle ? */
+    var(--telekom-color-ui-general-subtle, var(--telekom-color-ui-subtle));
 
   --font-family-heading: var(--telekom-typography-font-family-sans);
   --font-size-heading: var(--telekom-typography-font-size-callout);
   --font-weight-heading: var(--telekom-typography-font-weight-extra-bold);
 
-  --spacing-close-button: var(--telekom-spacing-inner-lg);
+  --spacing-close-button: var(--telekom-spacing-unit-x2);
   --radius-close-button: var(--telekom-radius-standard);
   --transition-close-button: all var(--telekom-motion-duration-transition)
     var(--telekom-motion-easing-standard);
@@ -62,12 +63,12 @@
   --color-close-button-hover: var(--telekom-color-primary-hovered);
   --color-close-button-active: var(--telekom-color-primary-pressed);
 
-  --spacing-x-body-wrapper: var(--telekom-spacing-related-sm);
-  --spacing-y-body: var(--telekom-spacing-related-sm);
+  --spacing-x-body-wrapper: var(--telekom-spacing-unit-x6);
+  --spacing-y-body: var(--telekom-spacing-unit-x6);
 
-  --spacing-actions: var(--telekom-spacing-related-sm);
+  --spacing-actions: var(--telekom-spacing-unit-x6);
 
-  --spacing-x-actions-slotted: var(--telekom-spacing-inner-lg);
+  --spacing-x-actions-slotted: var(--telekom-spacing-unit-x2);
   --background-actions-has-scroll: var(
     --telekom-color-background-surface-subtle
   );
@@ -136,7 +137,7 @@
 
 @media (max-height: 30em) {
   .modal__window {
-    max-height: calc(100vh - var(--telekom-spacing-related-sm));
+    max-height: calc(100vh - var(--telekom-spacing-unit-x6));
   }
 }
 
@@ -197,7 +198,6 @@
   appearance: none;
   cursor: pointer;
   user-select: none;
-  color: var(--scl-color-text-standard);
 }
 
 .modal__close-button:focus {

--- a/packages/components/src/components/notification-badge/notification-badge.css
+++ b/packages/components/src/components/notification-badge/notification-badge.css
@@ -16,15 +16,14 @@
 
   /*notification-badge circle*/
   --background-color-circle: var(--telekom-color-primary-standard);
-  /* FIXME:TOKEN add --telekom-color-ui-base */
-  --color-circle: var(--scl-color-white);
-  /* FIXME:TOKEN hardcoded values*/
+  --color-circle: var(--telekom-color-text-and-icon-inverted-standard);
+  /* FIXME? */
   --font-size-circle: 11px;
   --font-weight-circle: bold;
   --border-radius-circle: 20px;
 
   /*border*/
-  /* FIXME:TOKEN  --color-notification-badge-border-focus used for border, --color-notification-badge-border-hover used for font */
+  /* FIXME --color-notification-badge-border-focus used for border, --color-notification-badge-border-hover used for text */
   --color-notification-badge-border-focus: var(
     --telekom-color-functional-focus
   );

--- a/packages/components/src/components/notification-banner/notification-banner.css
+++ b/packages/components/src/components/notification-banner/notification-banner.css
@@ -13,12 +13,10 @@
   --width: 100%;
   --radius: var(--telekom-radius-standard);
 
-  /* Token not available, up for discussion */
-  /* FIXME:TOKEN hardcoded values */
-  --background-error: hsla(353.79999999999995, 100%, 88.6%, 0.35);
-  --background-warning: hsla(33.5, 100%, 75.1%, 0.3);
-  --background-informational: hsla(190.20000000000005, 100%, 92%, 0.75);
-  --background-success: hsl(98.80000000000001, 49.7%, 61%, 0.2);
+  --background-error: var(--telekom-color-functional-danger-subtle);
+  --background-warning: var(--telekom-color-functional-warning-subtle);
+  --background-informational: var(--telekom-color-functional-informational-subtle);
+  --background-success: var(--telekom-color-functional-success-subtle);
 }
 
 .notification-banner {

--- a/packages/components/src/components/notification-banner/notification-banner.css
+++ b/packages/components/src/components/notification-banner/notification-banner.css
@@ -15,7 +15,9 @@
 
   --background-error: var(--telekom-color-functional-danger-subtle);
   --background-warning: var(--telekom-color-functional-warning-subtle);
-  --background-informational: var(--telekom-color-functional-informational-subtle);
+  --background-informational: var(
+    --telekom-color-functional-informational-subtle
+  );
   --background-success: var(--telekom-color-functional-success-subtle);
 }
 

--- a/packages/components/src/components/notification-message/notification-message.css
+++ b/packages/components/src/components/notification-message/notification-message.css
@@ -17,7 +17,9 @@
 
   --background-error: var(--telekom-color-functional-danger-subtle);
   --background-warning: var(--telekom-color-functional-warning-subtle);
-  --background-informational: var(--telekom-color-functional-informational-subtle);
+  --background-informational: var(
+    --telekom-color-functional-informational-subtle
+  );
   --background-success: var(--telekom-color-functional-success-subtle);
 }
 

--- a/packages/components/src/components/notification-message/notification-message.css
+++ b/packages/components/src/components/notification-message/notification-message.css
@@ -12,15 +12,13 @@
 :host {
   --width: 100%;
   --radius: var(--telekom-radius-standard);
-  /* FIXME:TOKEN use ui-base here */
-  --border: 1px solid var(--scl-color-white);
+  /* FIXME:TOKEN what is this really for? */
+  --border: var(--telekom-line-weight-standard) solid var(--scl-color-white);
 
-  /* Token not available, up for discussion */
-  /* FIXME:TOKEN hardcoded values */
-  --background-error: hsla(353.79999999999995, 100%, 88.6%, 0.35);
-  --background-warning: hsla(33.5, 100%, 75.1%, 0.3);
-  --background-informational: hsla(190.20000000000005, 100%, 92%, 0.75);
-  --background-success: hsl(98.80000000000001, 49.7%, 61%, 0.2);
+  --background-error: var(--telekom-color-functional-danger-subtle);
+  --background-warning: var(--telekom-color-functional-warning-subtle);
+  --background-informational: var(--telekom-color-functional-informational-subtle);
+  --background-success: var(--telekom-color-functional-success-subtle);
 }
 
 .notification-message {

--- a/packages/components/src/components/notification-toast/notification-toast.css
+++ b/packages/components/src/components/notification-toast/notification-toast.css
@@ -11,15 +11,13 @@
 
 :host {
   /* toast */
-
   --width: 367px;
   --radius: var(--telekom-radius-standard);
   --background: var(--telekom-color-background-surface);
   /* FIXME:TOKEN not sure what elevation to use here */
-  --box-shadow: var(--scl-shadow-level-0);
+  --box-shadow: var(--telekom-shadow-raised-standard);
 
   /* icon container colors */
-
   --background-success-icon-container: var(
     --telekom-color-functional-success-standard
   );
@@ -34,11 +32,10 @@
   );
 
   /* icon container colors */
-  /* FIXME:TOKEN hardcoded values */
-  --background-success-text-container: #f2f7ef;
-  --background-warning-text-container: #fbf4eb;
-  --background-error-text-container: #fbf3f4;
-  --background-informational-text-container: #eff9fb;
+  --background-success-text-container: var(--telekom-color-functional-success-subtle);
+  --background-warning-text-container: var(--telekom-color-functional-warning-subtle);
+  --background-error-text-container: var(--telekom-color-functional-danger-subtle);
+  --background-informational-text-container: var(--telekom-color-functional-informational-subtle);
 }
 .notification-toast {
   width: var(--width);

--- a/packages/components/src/components/notification-toast/notification-toast.css
+++ b/packages/components/src/components/notification-toast/notification-toast.css
@@ -32,10 +32,18 @@
   );
 
   /* icon container colors */
-  --background-success-text-container: var(--telekom-color-functional-success-subtle);
-  --background-warning-text-container: var(--telekom-color-functional-warning-subtle);
-  --background-error-text-container: var(--telekom-color-functional-danger-subtle);
-  --background-informational-text-container: var(--telekom-color-functional-informational-subtle);
+  --background-success-text-container: var(
+    --telekom-color-functional-success-subtle
+  );
+  --background-warning-text-container: var(
+    --telekom-color-functional-warning-subtle
+  );
+  --background-error-text-container: var(
+    --telekom-color-functional-danger-subtle
+  );
+  --background-informational-text-container: var(
+    --telekom-color-functional-informational-subtle
+  );
 }
 .notification-toast {
   width: var(--width);

--- a/packages/components/src/components/pagination/pagination.css
+++ b/packages/components/src/components/pagination/pagination.css
@@ -10,8 +10,7 @@
  */
 
 :host {
-  /* FIXME:TOKEN previously scl-color-grey-90 */
-  --color: var(--telekom-color-text-and-icon-additional);
+  --color: var(--telekom-color-text-and-icon-standard);
   --radius: var(--telekom-radius-large);
   --font-size: var(--telekom-typography-font-size-small);
   --border: 1px solid var(--telekom-color-ui-subtle);
@@ -19,15 +18,14 @@
   --color-active: var(--telekom-color-primary-pressed);
   --color-button: var(--telekom-color-ui-subtle);
   --border-button: var(--border);
-  --box-shadow-focus: inset 0 0 0 2px var(--telekom-color-functional-focus);
+  --box-shadow-focus: inset 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
   --radius-first-prompt: var(--radius) 0 0 var(--radius);
   --radius-last-prompt: 0 var(--radius) var(--radius) 0;
   --radius-first-prompt-stack: 0 0 0 var(--radius);
   --radius-last-prompt-stack: 0 0 var(--radius) 0;
-  /* FIXME:TOKEN previously scl-color-grey-90 */
   --stroke-svg: var(--telekom-color-ui-extra-strong);
-  /* FIXME:TOKEN high-contrast variable */
-  --stroke-svg-high-contrast: var(--scl-color-white);
+  /* FIXME is this needed? */
+  --stroke-svg-high-contrast: #fff;
   --width-button: 42px;
   --padding-info: var(--telekom-spacing-unit-x2);
   --height-button: 56px;

--- a/packages/components/src/components/pagination/pagination.css
+++ b/packages/components/src/components/pagination/pagination.css
@@ -18,7 +18,8 @@
   --color-active: var(--telekom-color-primary-pressed);
   --color-button: var(--telekom-color-ui-subtle);
   --border-button: var(--border);
-  --box-shadow-focus: inset 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
+  --box-shadow-focus: inset 0 0 0 var(--telekom-line-weight-highlight)
+    var(--telekom-color-functional-focus);
   --radius-first-prompt: var(--radius) 0 0 var(--radius);
   --radius-last-prompt: 0 var(--radius) var(--radius) 0;
   --radius-first-prompt-stack: 0 0 0 var(--radius);

--- a/packages/components/src/components/radio-button-group/radio-button-group.css
+++ b/packages/components/src/components/radio-button-group/radio-button-group.css
@@ -21,7 +21,9 @@
   --margin-top-error-helper-text: var(--telekom-spacing-unit-x1);
   --font-weight-error-helper-text: var(--telekom-typography-font-weight-medium);
   /* FIXME is this needed? */
-  --color-error-helper-text-hcm: var(--telekom-color-text-and-icon-functional-white);
+  --color-error-helper-text-hcm: var(
+    --telekom-color-text-and-icon-functional-white
+  );
 
   /*title*/
   --font-size-title: var(--font-size-label);

--- a/packages/components/src/components/radio-button-group/radio-button-group.css
+++ b/packages/components/src/components/radio-button-group/radio-button-group.css
@@ -20,8 +20,8 @@
   --padding-bottom-error-helper-text: var(--telekom-spacing-unit-x2);
   --margin-top-error-helper-text: var(--telekom-spacing-unit-x1);
   --font-weight-error-helper-text: var(--telekom-typography-font-weight-medium);
-  /* FIXME:TOKEN high contrast variable */
-  --color-error-helper-text-hcm: var(--scl-color-white);
+  /* FIXME is this needed? */
+  --color-error-helper-text-hcm: var(--telekom-color-text-and-icon-functional-white);
 
   /*title*/
   --font-size-title: var(--font-size-label);

--- a/packages/components/src/components/radio-button/radio-button.css
+++ b/packages/components/src/components/radio-button/radio-button.css
@@ -14,13 +14,9 @@ scale-radio-button {
   --background-disabled: var(--telekom-color-ui-disabled);
   --color-error: var(--telekom-color-text-and-icon-functional-danger);
   --transition: all var(--telekom-motion-duration-transition)
-    /* FIXME:TOKEN update this */
     cubic-bezier(var(--telekom-motion-easing-standard));
-  --color-primary: var(--telekom-color-text-and-icon-primary-standard, #e20074);
-  --color-primary-hover: var(
-    --telekom-color-text-and-icon-primary-hovered,
-    #f90984
-  );
+  --color-primary: var(--telekom-color-text-and-icon-primary-standard);
+  --color-primary-hover: var(--telekom-color-text-and-icon-primary-hovered);
   --color-primary-active: var(--telekom-color-text-and-icon-primary-pressed);
   --color-focus: var(--telekom-color-functional-focus);
   --color-text: var(--telekom-color-text-and-icon-standard);

--- a/packages/components/src/components/rating-stars/rating-stars.css
+++ b/packages/components/src/components/rating-stars/rating-stars.css
@@ -14,16 +14,14 @@
   --stars-hover-color: var(--telekom-color-text-and-icon-primary-hovered);
   --stars-active-color: var(--telekom-color-text-and-icon-primary-pressed);
   --stars-inactive-color: transparent;
-  /* FIXME:TOKEN placeholder color */
-  --stars-placeholder-color: var(--scl-color-grey-90);
-  --stars-placeholder-revert-color: var(--scl-color-grey-90);
-  --stars-disabled-color: var(--scl-color-grey-50);
+  --stars-placeholder-color: var(--telekom-color-ui-regular);
+  --stars-placeholder-revert-color: var(--telekom-color-ui-regular);
+  --stars-disabled-color: var(--telekom-color-ui-disabled);
   --stars-spacing: var(--telekom-spacing-unit-x05);
   --stars-transition: color 0.1s;
   --stars-size: 24px;
   --font-weight-medium: var(--telekom-typography-font-weight-medium);
   --font-size-small: var(--telekom-typography-font-size-small);
-  /* FIXME:TOKEN infotext not using blue but gray*/
   --infotext-color: var(--telekom-color-text-and-icon-additional);
 }
 

--- a/packages/components/src/components/sidebar-nav-collapsible/sidebar-nav-collapsible.css
+++ b/packages/components/src/components/sidebar-nav-collapsible/sidebar-nav-collapsible.css
@@ -18,7 +18,8 @@
   --color-primary: var(--telekom-color-text-and-icon-primary-standard);
   --background-color-before-active: var(--color-primary);
   --font-weight-bold: var(--telekom-typography-font-weight-bold);
-  --box-shadow-focus: inset 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
+  --box-shadow-focus: inset 0 0 0 var(--telekom-line-weight-highlight)
+    var(--telekom-color-functional-focus);
 }
 .sidebar-nav-collapsible {
   margin: 0;

--- a/packages/components/src/components/sidebar-nav-collapsible/sidebar-nav-collapsible.css
+++ b/packages/components/src/components/sidebar-nav-collapsible/sidebar-nav-collapsible.css
@@ -11,17 +11,14 @@
 
 :host {
   --opacity-chevron: 1;
-  /* FIXME:TOKEN previously --scl-color-grey-10 */
   --border-bottom-color: var(--telekom-color-ui-subtle);
-  /* FIXME:TOKEN previously --scl-color-grey-70 */
   --border-left-color-third-nesting: var(--telekom-color-ui-strong);
   --color-active: var(--telekom-color-text-and-icon-primary-pressed);
-  /* FIXME:TOKEN this variable is used sometimes for background soetimes for font */
+  /* FIXME this variable is used sometimes for background sometimes for text */
   --color-primary: var(--telekom-color-text-and-icon-primary-standard);
   --background-color-before-active: var(--color-primary);
   --font-weight-bold: var(--telekom-typography-font-weight-bold);
-  --box-shadow-focus: inset 0 0 0 var(--telekom-spacing-unit-x05)
-    var(--telekom-color-functional-focus);
+  --box-shadow-focus: inset 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
 }
 .sidebar-nav-collapsible {
   margin: 0;

--- a/packages/components/src/components/sidebar-nav-item/sidebar-nav-item.css
+++ b/packages/components/src/components/sidebar-nav-item/sidebar-nav-item.css
@@ -17,7 +17,8 @@
   --color-primary: var(--telekom-color-text-and-icon-primary-standard);
   --background-color-before-active: var(--color-primary);
   --font-weight-bold: var(--telekom-typography-font-weight-bold);
-  --box-shadow-focus: inset 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
+  --box-shadow-focus: inset 0 0 0 var(--telekom-line-weight-highlight)
+    var(--telekom-color-functional-focus);
 }
 .sidebar-nav-item {
   border-bottom-style: solid;

--- a/packages/components/src/components/sidebar-nav-item/sidebar-nav-item.css
+++ b/packages/components/src/components/sidebar-nav-item/sidebar-nav-item.css
@@ -10,17 +10,14 @@
  */
 
 :host {
-  /* FIXME:TOKEN previously --scl-color-grey-10 */
   --border-bottom-color: var(--telekom-color-ui-subtle);
-  /* FIXME:TOKEN previously --scl-color-grey-70 */
   --border-left-color-third-nesting: var(--telekom-color-ui-strong);
   --color-active: var(--telekom-color-text-and-icon-primary-pressed);
-  /* FIXME:TOKEN this variable is used sometimes for background soetimes for font */
+  /* FIXME this variable is used sometimes for background sometimes for text */
   --color-primary: var(--telekom-color-text-and-icon-primary-standard);
   --background-color-before-active: var(--color-primary);
   --font-weight-bold: var(--telekom-typography-font-weight-bold);
-  --box-shadow-focus: inset 0 0 0 var(--telekom-spacing-unit-x05)
-    var(--telekom-color-functional-focus);
+  --box-shadow-focus: inset 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
 }
 .sidebar-nav-item {
   border-bottom-style: solid;
@@ -67,7 +64,7 @@
   padding-right: 1rem;
   padding-bottom: 1rem;
   padding-left: var(--spacing-indent);
-  /* FIXME:TOKEN previously --scl-radius-2 no equivalent */
+  /* FIXME:TOKEN previously --scl-radius-2 no equivalent / use scoped variable? */
   border-radius: var(--telekom-radius-small);
   text-decoration: none;
   outline: none;

--- a/packages/components/src/components/sidebar-nav/sidebar-nav.css
+++ b/packages/components/src/components/sidebar-nav/sidebar-nav.css
@@ -18,12 +18,10 @@
 
   --color: var(--telekom-color-text-and-icon-primary-standard);
   --color-active: var(--telekom-color-text-and-icon-primary-pressed);
-  /* FIXME:TOKEN should this be defined hereß */
-  --box-shadow-focus: inset 0 0 0 var(--telekom-spacing-unit-x05)
-    var(--telekom-color-functional-focus);
+  --box-shadow-focus: inset 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
   --color-toggle-button: var(--telekom-color-ui-regular);
   --border-y-toggle-button: 1px solid var(--telekom-color-ui-subtle);
-  /* FIXME:TOKEN used to be --scl-radius-2 doesn't have an equivalent */
+  /* FIXME:TOKEN used to be --scl-radius-2, doesn't have an equivalent */
   --radius-toggle-button: var(--telekom-radius-small);
 }
 

--- a/packages/components/src/components/sidebar-nav/sidebar-nav.css
+++ b/packages/components/src/components/sidebar-nav/sidebar-nav.css
@@ -18,7 +18,8 @@
 
   --color: var(--telekom-color-text-and-icon-primary-standard);
   --color-active: var(--telekom-color-text-and-icon-primary-pressed);
-  --box-shadow-focus: inset 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
+  --box-shadow-focus: inset 0 0 0 var(--telekom-line-weight-highlight)
+    var(--telekom-color-functional-focus);
   --color-toggle-button: var(--telekom-color-ui-regular);
   --border-y-toggle-button: 1px solid var(--telekom-color-ui-subtle);
   /* FIXME:TOKEN used to be --scl-radius-2, doesn't have an equivalent */

--- a/packages/components/src/components/slider/slider.css
+++ b/packages/components/src/components/slider/slider.css
@@ -16,7 +16,8 @@
   --box-shadow-thumb: var(--telekom-shadow-resting-standard);
   --border-color-thumb-hover: var(--telekom-color-primary-hovered);
   --border-color-thumb-active: var(--telekom-color-primary-pressed);
-  --box-shadow-thumb-focus: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
+  --box-shadow-thumb-focus: 0 0 0 var(--telekom-line-weight-highlight)
+    var(--telekom-color-functional-focus);
   --color-display-value: var(--telekom-color-ui-regular);
   --font-weight-display-value: var(--telekom-typography-font-weight-bold);
   --font-size-display-value: var(--telekom-typography-font-size-small);

--- a/packages/components/src/components/slider/slider.css
+++ b/packages/components/src/components/slider/slider.css
@@ -16,9 +16,7 @@
   --box-shadow-thumb: var(--telekom-shadow-resting-standard);
   --border-color-thumb-hover: var(--telekom-color-primary-hovered);
   --border-color-thumb-active: var(--telekom-color-primary-pressed);
-  /* FIXME:TOKEN should this be defined here? */
-  --box-shadow-thumb-focus: 0 0 0 var(--telekom-spacing-unit-x05)
-    var(--telekom-color-functional-focus);
+  --box-shadow-thumb-focus: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
   --color-display-value: var(--telekom-color-ui-regular);
   --font-weight-display-value: var(--telekom-typography-font-weight-bold);
   --font-size-display-value: var(--telekom-typography-font-size-small);

--- a/packages/components/src/components/switch/switch.css
+++ b/packages/components/src/components/switch/switch.css
@@ -35,8 +35,7 @@
   --transition-timing-function: cubic-bezier(
     var(--telekom-motion-easing-standard)
   );
-  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight)
-    var(--telekom-color-functional-focus);
+  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
   --spacing-left: var(--telekom-spacing-unit-x2);
   --font-weight: var(--telekom-typography-font-weight-medium);
 

--- a/packages/components/src/components/switch/switch.css
+++ b/packages/components/src/components/switch/switch.css
@@ -35,7 +35,8 @@
   --transition-timing-function: cubic-bezier(
     var(--telekom-motion-easing-standard)
   );
-  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
+  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight)
+    var(--telekom-color-functional-focus);
   --spacing-left: var(--telekom-spacing-unit-x2);
   --font-weight: var(--telekom-typography-font-weight-medium);
 

--- a/packages/components/src/components/tab-header/tab-header.css
+++ b/packages/components/src/components/tab-header/tab-header.css
@@ -20,8 +20,7 @@
   --background-underline-hover: var(--telekom-color-primary-hovered);
   --background-underline-active: var(--telekom-color-primary-pressed);
   --color-active: var(--telekom-color-text-and-icon-primary-standard);
-  --box-shadow-focus: 0 0 0 var(--telekom-spacing-unit-x05)
-    var(--telekom-color-functional-focus);
+  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
   --spacing-right-slotted: var(--telekom-spacing-unit-x2);
   --color-disabled: var(--telekom-color-text-and-icon-disabled);
   --radius: var(--telekom-radius-standard);

--- a/packages/components/src/components/tab-header/tab-header.css
+++ b/packages/components/src/components/tab-header/tab-header.css
@@ -20,7 +20,8 @@
   --background-underline-hover: var(--telekom-color-primary-hovered);
   --background-underline-active: var(--telekom-color-primary-pressed);
   --color-active: var(--telekom-color-text-and-icon-primary-standard);
-  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
+  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight)
+    var(--telekom-color-functional-focus);
   --spacing-right-slotted: var(--telekom-spacing-unit-x2);
   --color-disabled: var(--telekom-color-text-and-icon-disabled);
   --radius: var(--telekom-radius-standard);

--- a/packages/components/src/components/table/table.css
+++ b/packages/components/src/components/table/table.css
@@ -11,7 +11,7 @@
 
 scale-table {
   --radius: var(--telekom-radius-standard) var(--telekom-radius-standard) 0 0;
-  /* FIXME:TOKEN previously --scl-color-background-light */
+  /* FIXME (used for head background) */
   --background: var(--telekom-color-ui-subtle);
   --color: var(--telekom-color-text-and-icon-standard);
   --color-hover: var(--telekom-color-text-and-icon-primary-hovered);
@@ -21,26 +21,23 @@ scale-table {
 
   --spacing-tbody-td: var(--telekom-spacing-unit-x4)
     var(--telekom-spacing-unit-x2);
-  /*FIXME:TOKEN border color should be different from background color running out of choice? */
-  /* FIXME:TOKEN previously --scl-color-grey-20 */
-  --border-bottom-tbody-td: var(--telekom-spacing-unit-x025) solid
-    var(--telekom-color-ui-subtle);
+  --border-bottom-tbody-td: var(--telekom-spacing-unit-x025) solid var(--telekom-color-ui-subtle);
   --background-tbody: var(--telekom-color-ui-base);
 
-  /* FIXME:TOKEN hardcoded values #ededed */
+  /* FIXME:TOKEN */
   --background-tbody-tr-hover: var(--telekom-color-ui-subtle);
   --background-tfoot: var(--telekom-color-ui-base);
   --border-bottom-tfoot-td: var(--telekom-spacing-unit-x025) solid
     var(--telekom-color-ui-extra-strong);
 
   --spacing-th-sortable: 0 var(--telekom-spacing-unit-x2) 0 0;
-  /* FIXME:TOKEN hardcoded values #ededed */
+  /* FIXME:TOKEN */
   --background-th-sortable-hover: var(--telekom-color-ui-subtle);
   --background-th-sortable-active: var(--telekom-color-ui-light);
   --box-shadow-th-sortable-focus: inset 0 0 0 var(--telekom-spacing-unit-x05)
     var(--telekom-color-functional-focus);
-  /*FIXME:TOKEN --scl-color-grey-0? */
-  --background-tr-striped: var(--scl-color-grey-0);
+  /* FIXME:TOKEN */
+  --background-tr-striped: var(--telekom-color-ui-subtle);
   --padding: var(--telekom-spacing-unit-x0) var(--telekom-spacing-unit-x2);
 }
 .table {

--- a/packages/components/src/components/table/table.css
+++ b/packages/components/src/components/table/table.css
@@ -21,7 +21,8 @@ scale-table {
 
   --spacing-tbody-td: var(--telekom-spacing-unit-x4)
     var(--telekom-spacing-unit-x2);
-  --border-bottom-tbody-td: var(--telekom-spacing-unit-x025) solid var(--telekom-color-ui-subtle);
+  --border-bottom-tbody-td: var(--telekom-spacing-unit-x025) solid
+    var(--telekom-color-ui-subtle);
   --background-tbody: var(--telekom-color-ui-base);
 
   /* FIXME:TOKEN */

--- a/packages/components/src/components/tag/tag.css
+++ b/packages/components/src/components/tag/tag.css
@@ -16,7 +16,8 @@
   --line-height: var(--telekom-typography-line-spacing-standard);
   --font-weight: var(--telekom-typography-font-weight-bold);
   --radius: var(--telekom-radius-small);
-  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
+  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight)
+    var(--telekom-color-functional-focus);
 
   --icon-color: var(--color);
   --icon-color-hover: var(--telekom-color-text-and-icon-primary-hovered);

--- a/packages/components/src/components/tag/tag.css
+++ b/packages/components/src/components/tag/tag.css
@@ -10,15 +10,13 @@
  */
 
 :host {
-  /* FIXME:TOKEN previously --scl-color-text-standard */
   --background: var(--telekom-color-ui-extra-strong);
   --color: var(--telekom-color-text-and-icon-inverted-standard);
   --font-size: var(--telekom-typography-font-size-body);
   --line-height: var(--telekom-typography-line-spacing-standard);
   --font-weight: var(--telekom-typography-font-weight-bold);
   --radius: var(--telekom-radius-small);
-  --box-shadow-focus: 0 0 0 var(--telekom-spacing-unit-x05)
-    var(--telekom-color-functional-focus);
+  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
 
   --icon-color: var(--color);
   --icon-color-hover: var(--telekom-color-text-and-icon-primary-hovered);
@@ -38,7 +36,7 @@
 
   --spacing-small: 0 var(--telekom-spacing-unit-x2);
   --font-size-small: var(--telekom-typography-font-size-small);
-  /* FIXME:TOKEN previously --scl-font-line-height-160 */
+  /* FIXME previously --scl-font-line-height-160 */
   --line-height-small: var(--telekom-typography-line-spacing-loose);
 }
 

--- a/packages/components/src/components/telekom/app-footer/app-footer.css
+++ b/packages/components/src/components/telekom/app-footer/app-footer.css
@@ -23,7 +23,6 @@
     var(--telekom-color-ui-subtle);
   --color-minimal: var(--telekom-color-ui-regular);
   --background-minimal: var(--telekom-color-background-surface);
-  /* FIXME:TOKEN angular vs minimal same value here*/
   --spacing-angular: var(--telekom-spacing-unit-x6);
   --spacing-minimal: var(--telekom-spacing-unit-x6);
 

--- a/packages/components/src/components/telekom/app-header/app-header.css
+++ b/packages/components/src/components/telekom/app-header/app-header.css
@@ -10,13 +10,11 @@
  */
 
 scale-app-header {
-  /*FIXME:TOKEN spacing token needed here?*/
-  --header-nav-height: 3.5rem;
-  --header-brand-height: 4.5rem;
+  --header-nav-height: var(--telekom-spacing-unit-x14);
+  --header-brand-height: var(--telekom-spacing-unit-x18);
   --header-border-radius: var(--telekom-radius-large);
   --header-transition-speed: var(--telekom-motion-duration-transition);
-  /*FIXME:TOKEN spacing token needed here?*/
-  --header-brand-collapsed-height: 0.25rem;
+  --header-brand-collapsed-height: var(--telekom-spacing-unit-x1);
   --header-max-width: inherit;
 
   --background: var(--telekom-color-primary-standard);
@@ -323,7 +321,6 @@ scale-app-header {
   }
   .header .sector-navigation .sector-navigation__portal-name {
     font-weight: var(--telekom-typography-font-weight-extra-bold);
-    /* FIXME:TOKEN original size? */
     font-size: var(--scl-font-variant-body-large-size);
     list-style-type: none;
   }

--- a/packages/components/src/components/telekom/app-mega-menu/app-mega-menu.css
+++ b/packages/components/src/components/telekom/app-mega-menu/app-mega-menu.css
@@ -10,9 +10,7 @@
  */
 
 app-mega-menu {
-  /*FIXME:TOKEN box shadow value */
-  --box-shadow: var(--scl-shadow-level-4);
-  /*FIXME:TOKEN spacing token needed here?*/
+  --box-shadow: var(--telekom-shadow-top);
   --spacing-y: 2.125rem;
   --spacing-right: var(--telekom-spacing-unit-x4);
   --spacing-left: var(--telekom-spacing-unit-x6);
@@ -20,7 +18,6 @@ app-mega-menu {
   --color-active: var(--telekom-color-text-and-icon-primary-standard);
 
   --font-size-row-title: var(--telekom-typography-font-size-body);
-  /*FIXME:TOKEN spacing token needed here?*/
   --spacing-bottom-row-title: 1.125rem;
   --font-weight-row-title: var(--telekom-typography-font-weight-extra-bold);
   --color-row-title: var(--telekom-color-text-and-icon-standard);

--- a/packages/components/src/components/telekom/app-navigation-user-menu/app-navigation-user-menu.css
+++ b/packages/components/src/components/telekom/app-navigation-user-menu/app-navigation-user-menu.css
@@ -14,8 +14,7 @@
   --color-divider: var(--telekom-color-ui-subtle);
   --color-menu-item-hover: var(--telekom-color-text-and-icon-primary-hovered);
   --color-menu-item-active: var(--telekom-color-text-and-icon-primary-pressed);
-  --box-shadow-focus: 0 0 0 var(--telekom-spacing-unit-x05)
-    var(--telekom-color-functional-focus);
+  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
 }
 
 .app-navigation-user-menu {
@@ -57,13 +56,12 @@
 
 .app-navigation-user-menu__item {
   display: flex;
-  /* FIXME:TOKEN original value?  */
   font-size: var(--scl-font-variant-heading-6-size);
   line-height: var(--scl-font-variant-heading-6-line-height);
   font-weight: var(--scl-font-variant-heading-6-weight);
   padding: var(--telekom-spacing-unit-x2) var(--telekom-spacing-unit-x4);
-  /* FIXME:TOKEN should it be radius token 0.125rem */
-  border-radius: var(--telekom-spacing-unit-x05);
+  /* FIXME */
+  border-radius: 0.125rem;
   color: var(--telekom-color-text-and-icon-standard);
   text-decoration: none;
 }

--- a/packages/components/src/components/telekom/app-navigation-user-menu/app-navigation-user-menu.css
+++ b/packages/components/src/components/telekom/app-navigation-user-menu/app-navigation-user-menu.css
@@ -14,7 +14,8 @@
   --color-divider: var(--telekom-color-ui-subtle);
   --color-menu-item-hover: var(--telekom-color-text-and-icon-primary-hovered);
   --color-menu-item-active: var(--telekom-color-text-and-icon-primary-pressed);
-  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
+  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight)
+    var(--telekom-color-functional-focus);
 }
 
 .app-navigation-user-menu {

--- a/packages/components/src/components/telekom/app-navigation-user-menu/app-navigation-user-menu.css
+++ b/packages/components/src/components/telekom/app-navigation-user-menu/app-navigation-user-menu.css
@@ -44,7 +44,6 @@
 }
 
 .app-navigation-user-menu__user-info--name {
-  /* FIXME:TOKEN original value?  */
   font-size: var(--scl-font-variant-heading-5-size);
   line-height: var(--scl-font-variant-heading-5-line-height);
   font-weight: var(--scl-font-variant-heading-5-weight);

--- a/packages/components/src/components/telekom/logo/logo.css
+++ b/packages/components/src/components/telekom/logo/logo.css
@@ -20,12 +20,13 @@
   position: relative;
 }
 
-/* FIXME:TOKEN white background value */
 .logo--variant-magenta {
+  /* FIXME:TOKEN */
   background-color: var(--telekom-color-background-surface);
 }
 
 .logo--variant-white {
+  /* FIXME:TOKEN */
   background-color: var(--telekom-color-primary-standard);
 }
 

--- a/packages/components/src/components/text-field/text-field.css
+++ b/packages/components/src/components/text-field/text-field.css
@@ -21,7 +21,8 @@ scale-text-field {
   --border-color-hover: var(--telekom-color-primary-hovered);
   --border-color-focus: var(--telekom-color-primary-hovered);
   --border-color-disabled: var(--telekom-color-ui-disabled);
-  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
+  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight)
+    var(--telekom-color-functional-focus);
   --height: var(--telekom-spacing-unit-x12);
   --height-small: var(--telekom-spacing-unit-x10);
   --spacing-x: var(--telekom-spacing-unit-x3);

--- a/packages/components/src/components/text-field/text-field.css
+++ b/packages/components/src/components/text-field/text-field.css
@@ -17,12 +17,11 @@ scale-text-field {
     var(--telekom-color-ui-extra-strong);
   --border-error: var(--telekom-spacing-unit-x05) solid
     var(--telekom-color-functional-danger-standard);
-  /*FIXME: replace with ui border hover*/
-  --border-color-hover: var(--telekom-color-primary-hovered, #f90984);
-  --border-color-focus: var(--telekom-color-primary-pressed, #f90984);
+  /* FIXME:TOKEN replace with ui border hover */
+  --border-color-hover: var(--telekom-color-primary-hovered);
+  --border-color-focus: var(--telekom-color-primary-hovered);
   --border-color-disabled: var(--telekom-color-ui-disabled);
-  --box-shadow-focus: 0 0 0 var(--telekom-spacing-unit-x05)
-    var(--telekom-color-functional-focus);
+  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
   --height: var(--telekom-spacing-unit-x12);
   --height-small: var(--telekom-spacing-unit-x10);
   --spacing-x: var(--telekom-spacing-unit-x3);
@@ -31,7 +30,7 @@ scale-text-field {
   --border-color-readonly: var(--telekom-color-ui-subtle);
   --background-readonly: var(--telekom-color-ui-subtle);
 
-  /*meta*/
+  /* meta */
   --font-weight-meta: var(--telekom-line-weight-bold);
   --font-size-meta: var(--telekom-typography-font-size-small);
   --line-height-meta: var(--telekom-typography-line-spacing-standard);
@@ -39,20 +38,20 @@ scale-text-field {
   --color-meta: var(--telekom-color-text-and-icon-standard);
   --color-meta-error: var(--telekom-color-text-and-icon-functional-danger);
 
-  /*control*/
+  /* control */
   --spacing-control: var(--telekom-spacing-unit-x3) var(--spacing-x) 0
     calc(var(--spacing-x) - 1px);
   --transition-control: var(--transition);
   --font-size-control: var(--telekom-typography-font-size-body);
   --background-control: var(--telekom-color-ui-base);
 
-  /*counter*/
+  /* counter */
   --transition-counter: var(--transition);
   --font-size-counter: var(--font-size-meta);
   --line-height-counter: var(--line-height-meta);
   --color-counter-error: var(--color-meta-error);
 
-  /*helper-text*/
+  /* helper-text */
   --transition-helper-text: var(--transition);
   --font-size-helper-text: var(--font-size-meta);
   --line-height-helper-text: var(--line-height-meta);
@@ -61,14 +60,13 @@ scale-text-field {
   );
   --color-helper-text-error: var(--color-meta-error);
 
-  /*placeholder*/
+  /* placeholder */
   --transition-placeholder: var(--transition);
   --color-placeholder: var(--telekom-color-text-and-icon-additional);
 
-  /*label*/
+  /* label */
   --color-label: var(--telekom-color-text-and-icon-additional);
   --color-label-readonly: var(--telekom-color-text-and-icon-additional);
-  /* FIXME:TOKEN z-index token is needed */
   --z-index-label: var(--scl-z-index-10);
   --transition-label: var(--transition);
   --font-size-label: var(--telekom-typography-font-size-body);

--- a/packages/components/src/components/textarea/textarea.css
+++ b/packages/components/src/components/textarea/textarea.css
@@ -11,15 +11,15 @@
 
 scale-textarea {
   --transition: all var(--telekom-motion-duration-transition)
-    var(--telekom-motion-easing-standard);
+    cubic-bezier(var(--telekom-motion-easing-standard));
   --radius: var(--telekom-radius-standard);
-  --border: var(--telekom-spacing-unit-x025) solid
+  /* FIXME:TOKEN replace colors with ui border */
+  --border: var(--telekom-line-weight-standard) solid
     var(--telekom-color-ui-extra-strong);
-  --border-error: var(--telekom-spacing-unit-x05) solid
+  --border-error: var(--telekom-line-weight-highlight) solid
     var(--telekom-color-functional-danger-standard);
-  /* FIXME:TOKEN replace with ui border hover */
-  --border-color-hover: var(--telekom-color-primary-hovered, #f90984);
-  --border-color-focus: var(--telekom-color-primary-pressed, #f90984);
+  --border-color-hover: var(--telekom-color-primary-hovered);
+  --border-color-focus: var(--telekom-color-primary-hovered);
   --border-color-disabled: var(--telekom-color-ui-disabled);
   --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight)
     var(--telekom-color-functional-focus);
@@ -64,7 +64,6 @@ scale-textarea {
   /*label*/
   --color-label: var(--telekom-color-text-and-icon-additional);
   --color-label-readonly: var(--telekom-color-text-and-icon-additional);
-  /* FIXME:TOKEN z-index token is needed */
   --z-index-label: var(--scl-z-index-10);
   --transition-label: var(--transition);
   --font-size-label: var(--telekom-typography-font-size-body);

--- a/packages/components/src/components/textarea/textarea.css
+++ b/packages/components/src/components/textarea/textarea.css
@@ -18,11 +18,10 @@ scale-textarea {
   --border-error: var(--telekom-spacing-unit-x05) solid
     var(--telekom-color-functional-danger-standard);
   /* FIXME:TOKEN replace with ui border hover */
-  --border-color-hover: var(--telekom-color-primary-hovered, #f90984);
-  --border-color-focus: var(--telekom-color-primary-pressed, #f90984);
+  --border-color-hover: var(--telekom-color-primary-hovered);
+  --border-color-focus: var(--telekom-color-primary-hovered);
   --border-color-disabled: var(--telekom-color-ui-disabled);
-  --box-shadow-focus: 0 0 0 var(--telekom-spacing-unit-x05)
-    var(--telekom-color-functional-focus);
+  --box-shadow-focus: 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
   --spacing-x: var(--telekom-spacing-unit-x3);
   --color-disabled: var(--telekom-color-text-and-icon-disabled);
   --background-disabled: transparent;
@@ -63,7 +62,6 @@ scale-textarea {
   /*label*/
   --color-label: var(--telekom-color-text-and-icon-additional);
   --color-label-readonly: var(--telekom-color-text-and-icon-additional);
-  /* FIXME:TOKEN z-index token is needed */
   --z-index-label: var(--scl-z-index-10);
   --transition-label: var(--transition);
   --font-size-label: var(--telekom-typography-font-size-body);

--- a/packages/components/src/components/toggle-button/toggle-button.css
+++ b/packages/components/src/components/toggle-button/toggle-button.css
@@ -22,7 +22,8 @@
   --transition: all var(--telekom-motion-duration-transition)
       var(--telekom-motion-easing-standard),
     border-radius var(--telekom-motion-duration-instant);
-  --box-shadow-focus: inset 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
+  --box-shadow-focus: inset 0 0 0 var(--telekom-line-weight-highlight)
+    var(--telekom-color-functional-focus);
   --font-weight: var(--telekom-typography-font-weight-bold);
   --font-size-large: var(--telekom-typography-font-size-body);
   --font-size-small: var(--telekom-typography-font-size-caption);

--- a/packages/components/src/components/toggle-button/toggle-button.css
+++ b/packages/components/src/components/toggle-button/toggle-button.css
@@ -22,8 +22,7 @@
   --transition: all var(--telekom-motion-duration-transition)
       var(--telekom-motion-easing-standard),
     border-radius var(--telekom-motion-duration-instant);
-  --box-shadow-focus: inset 0 0 0 var(--telekom-spacing-unit-x05)
-    var(--telekom-color-functional-focus);
+  --box-shadow-focus: inset 0 0 0 var(--telekom-line-weight-highlight) var(--telekom-color-functional-focus);
   --font-weight: var(--telekom-typography-font-weight-bold);
   --font-size-large: var(--telekom-typography-font-size-body);
   --font-size-small: var(--telekom-typography-font-size-caption);

--- a/packages/components/src/components/tooltip/tooltip.css
+++ b/packages/components/src/components/tooltip/tooltip.css
@@ -10,7 +10,7 @@
  */
 
 :host {
-  /*tooltip*/
+  /* tooltip */
   --radius: var(--telekom-radius-small);
   --background: var(--telekom-color-ui-extra-strong);
   --color: var(--telekom-color-text-and-icon-inverted-standard);
@@ -18,20 +18,21 @@
   --font-size: var(--telekom-typography-font-size-body);
   --line-height: var(--telekom-typography-line-spacing-standard);
   --spacing: var(--telekom-spacing-unit-x05) var(--telekom-spacing-unit-x2);
-  /*arrow*/
-  /*FIXME:TOKEN use telekom-spacing-unit-*?*/
+
+  /* arrow */
   --arrow-size: 0.31rem;
   --arrow-offset: var(--telekom-spacing-unit-x2);
-  /*tooltip hide*/
+
+  /* tooltip hide */
   --max-width: 20rem;
   --transition-delay-hide: var(--telekom-motion-duration-instant);
   --transition-duration-hide: var(--telekom-motion-duration-immediate);
   --transition-timing-function-hide: var(--telekom-motion-easing-standard);
-  /*tooltip show*/
+
+  /* tooltip show */
   --transition-duration-show: var(--telekom-motion-duration-immediate);
   --transition-timing-function-show: var(--telekom-motion-easing-standard);
-  /*FIXME:TOKEN new token needed*/
-  --z-index: var(--scale-z-index-70);
+  --z-index: var(--scl-z-index-70);
 
   display: contents;
   position: relative;

--- a/packages/components/src/global/scale.css
+++ b/packages/components/src/global/scale.css
@@ -13,3 +13,14 @@
 @import '~@telekom/scale-design-tokens/dist/design-tokens-telekom.css';
 @import '~@telekom/design-tokens/dist/telekom/css/telekom-design-tokens.all.css';
 @import './grid.css';
+
+:root {
+  /* This should be temporary */
+  --scl-z-index-10: 10;
+  --scl-z-index-20: 20;
+  --scl-z-index-30: 30;
+  --scl-z-index-40: 40;
+  --scl-z-index-50: 50;
+  --scl-z-index-60: 60;
+  --scl-z-index-70: 70
+}

--- a/packages/components/src/global/scale.css
+++ b/packages/components/src/global/scale.css
@@ -22,5 +22,5 @@
   --scl-z-index-40: 40;
   --scl-z-index-50: 50;
   --scl-z-index-60: 60;
-  --scl-z-index-70: 70
+  --scl-z-index-70: 70;
 }

--- a/packages/storybook-vue/stories/3_components/loading-spinner/LoadingSpinner.stories.mdx
+++ b/packages/storybook-vue/stories/3_components/loading-spinner/LoadingSpinner.stories.mdx
@@ -24,7 +24,7 @@ export const Template = () => ({
     ...ScaleLoadingSpinner.props,
   },
   template: `
-    <div :style="variant==='primary' ? 'background: white;' : 'background: black;' + ' display: flex; padding: 2em; min-height: 50px; margin: -30px -20px;'">
+    <div :style="variant==='primary' ? 'background: transparent;' : 'background: black;' + ' display: flex; padding: 2em; min-height: 50px; margin: -30px -20px;'">
         <scale-loading-spinner
             :variant='variant'
             :alignment='alignment'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4702,10 +4702,10 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@telekom/design-tokens@^1.0.0-alpha.3":
-  version "1.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/@telekom/design-tokens/-/design-tokens-1.0.0-alpha.3.tgz#9b0ce75ae80472486d1436ef328f9192a7a7c481"
-  integrity sha512-+JrTMVVK7PTX1EyQGLJUmX2Ss5EIC8nt/b0l+aFsE2PCzA6M7196BJcLWJ248xQ6YSKoEIhlyCK80J/bpojrPw==
+"@telekom/design-tokens@1.0.0-alpha.5":
+  version "1.0.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/@telekom/design-tokens/-/design-tokens-1.0.0-alpha.5.tgz#4f0d1d846b3a7efc2e2498516ec5ebe44127110d"
+  integrity sha512-VG7abtPe7xKCCZMO5Y1LrTxtRnFkb+LoaoV7RdLTbEuvoqVansXZxNhh99rVfZp+/p4uyiJCu8aYyM7NVsZbFw==
 
 "@testing-library/jest-dom@^5.8.0":
   version "5.11.4"


### PR DESCRIPTION
Here we go:
- [x] all others
- [x] date-picker
- [x] input
- [x] app-footer
- [x] app-header
- [x] app-mega-menu
- [x] app-navigation-user-menu
- [x] logo

I'm leaving `FIXME:TOKEN` only for those cases I believe we need to double-check with design, others I'm turning into `FIXME` because we can fix later, and others I'm deleting because can be addressed later, later…