### PR TITLE
fix: app-logo not focusable when header is sticky

### DIFF
--- a/packages/components/src/components/telekom/app-header/app-header.tsx
+++ b/packages/components/src/components/telekom/app-header/app-header.tsx
@@ -458,7 +458,7 @@ export class Header {
                     href={this.logoHref}
                     logoTitle={this.logoTitle}
                     onClick={this.logoClick}
-                    focusable={this.scrolled}
+                    focusable={this.scrolled || this.sticky}
                   ></app-logo>
                 </div>
                 <div class="header__nav-menu-wrapper">


### PR DESCRIPTION
This fixes issue app-logo in navbar is not focusable when header is sticky