### PR TITLE
fix: windows firefox problem with fit-content

### DIFF
--- a/packages/components/src/components/checkbox/checkbox.css
+++ b/packages/components/src/components/checkbox/checkbox.css
@@ -57,7 +57,6 @@ scale-checkbox {
 :host,
 scale-checkbox {
   display: flex;
-  width: fit-content;
   padding: 0 2px 0 2px;
   flex-direction: column;
   color: var(--color-text);

--- a/packages/components/src/components/checkbox/checkbox.css
+++ b/packages/components/src/components/checkbox/checkbox.css
@@ -54,9 +54,9 @@ scale-checkbox {
   --stroke-width: var(--stroke-width-checkbox, 0.5px);
 }
 
-:host,
 scale-checkbox {
   display: flex;
+  width: fit-content;
   padding: 0 2px 0 2px;
   flex-direction: column;
   color: var(--color-text);

--- a/packages/components/src/components/data-grid/data-grid.css
+++ b/packages/components/src/components/data-grid/data-grid.css
@@ -312,6 +312,10 @@
   justify-content: center;
 }
 
+.tbody__cell scale-checkbox {
+  width: auto;
+}
+
 .tbody__nested {
   white-space: nowrap;
   padding: 0px;


### PR DESCRIPTION
I tried to use the -moz- prefix but that didn't fix the issue. Removing the property completely solves it

checked the history looks like the property was added to fix some pagination problem, but pagination seems fine even without it @marvinLaubenstein maybe you remember https://github.com/telekom/scale/commit/3507aa24d37bcdf6c2ea5781e5669c517e358072 ?