### PR TITLE
docs(storybook): add next tag in frameworks pages

### DIFF
--- a/packages/storybook-vue/stories/setup_and_info/ScaleAndAngular_de.md
+++ b/packages/storybook-vue/stories/setup_and_info/ScaleAndAngular_de.md
@@ -9,7 +9,7 @@ Ein Beispiel für eine Boilerplate-App findest du im [GitHub Repository](https:/
 Installiere zuerst das Package:
 
 ```bash
-npm install @telekom/scale-components
+npm install @telekom/scale-components@next
 ```
 
 Lade danach die Komponenten-Bibliothek in `main.ts`:

--- a/packages/storybook-vue/stories/setup_and_info/ScaleAndAngular_en.md
+++ b/packages/storybook-vue/stories/setup_and_info/ScaleAndAngular_en.md
@@ -9,7 +9,7 @@ You can find an example boilerplate app in the "examples" folder in the [GitHub 
 First, install the package:
 
 ```bash
-npm install @telekom/scale-components
+npm install @telekom/scale-components@next
 ```
 
 Then load the component library in `main.ts`:

--- a/packages/storybook-vue/stories/setup_and_info/ScaleAndReact_de.md
+++ b/packages/storybook-vue/stories/setup_and_info/ScaleAndReact_de.md
@@ -9,7 +9,7 @@ Ein Beispiel für eine Boilerplate App findest du im Ordner _Examples_ in unsere
 Installiere zuerst das Package:
 
 ```bash
-npm install @telekom/scale-components
+npm install @telekom/scale-components@next
 ```
 
 Lade danach die Komponenten und das CSS in `index.js`:

--- a/packages/storybook-vue/stories/setup_and_info/ScaleAndReact_en.md
+++ b/packages/storybook-vue/stories/setup_and_info/ScaleAndReact_en.md
@@ -9,7 +9,7 @@ You can find an example boilerplate app in the "examples" folder in the [GitHub 
 First, install the package:
 
 ```bash
-npm install @telekom/scale-components
+npm install @telekom/scale-components@next
 ```
 
 Then load the component library and the CSS in `index.js`:

--- a/packages/storybook-vue/stories/setup_and_info/ScaleAndVue_de.md
+++ b/packages/storybook-vue/stories/setup_and_info/ScaleAndVue_de.md
@@ -9,7 +9,7 @@ Ein Beispiel für eine Boilerplate-App findest du im [GitHub Repository](https:/
 Installiere zuerst das Package:
 
 ```bash
-npm install @telekom/scale-components
+npm install @telekom/scale-components@next
 ```
 
 Lade danach die Komponenten-Bibliothek und das CSS in `main.js`:

--- a/packages/storybook-vue/stories/setup_and_info/ScaleAndVue_en.md
+++ b/packages/storybook-vue/stories/setup_and_info/ScaleAndVue_en.md
@@ -9,7 +9,7 @@ You can find an example boilerplate app in the "examples" folder in the [GitHub 
 First, install the package:
 
 ```bash
-npm install @telekom/scale-components
+npm install @telekom/scale-components@next
 ```
 
 Then load the component library and the CSS in `main.js`:


### PR DESCRIPTION
This add `@next` to npm install snippet in framework pages.