### PR TITLE
feat: adding possibility to use a tags with scale-link inside breadcrumbs

### DIFF
--- a/packages/components/src/components/breadcrumb/breadcrumb.tsx
+++ b/packages/components/src/components/breadcrumb/breadcrumb.tsx
@@ -91,7 +91,7 @@ export class Breadcrumb {
                 );
               return (
                 <li class="breadcrumb__list-item" part="list-item">
-                  {element.href || element.tagName == 'SCALE-LINK' ? (
+                  {element.href || element.tagName === 'SCALE-LINK' ? (
                     <a
                       href={element.href}
                       class={classNames(


### PR DESCRIPTION
fix: <scale-link> is not compatible with <scale-breadcrumb> #1016 

@acstll (we talked about this before at Basecamp)