### PR TITLE
feat(button): forms will submit with Enter key

### DIFF
--- a/packages/components/src/components/button/button.e2e.ts
+++ b/packages/components/src/components/button/button.e2e.ts
@@ -38,4 +38,20 @@ describe('scale-button', () => {
     const element = await page.find('scale-icon-action-search');
     expect(element.getAttribute('size')).toBe('16');
   });
+
+  it('should allow submitting forms with the Enter key', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <form>
+        <input type="text" name="a" />
+        <input type="text" name="b" />
+        <scale-button>Submit</scale-button>
+      </form>
+    `);
+    const form = await page.find('form');
+    const input = await page.find('input[name="a"]');
+    const spy = await form.spyOnEvent('submit');
+    await input.press('Enter');
+    expect(spy).toHaveReceivedEvent();
+  });
 });

--- a/packages/components/src/components/button/button.tsx
+++ b/packages/components/src/components/button/button.tsx
@@ -89,8 +89,8 @@ export class Button {
   handleClick = (ev: Event) => {
     // No need to check for `disabled` because disabled buttons won't emit clicks
     if (hasShadowDom(this.hostElement)) {
-      const form = this.hostElement.closest('form');
-      if (form) {
+      const parentForm = this.hostElement.closest('form');
+      if (parentForm) {
         ev.preventDefault();
 
         const fakeButton = document.createElement('button');
@@ -98,7 +98,7 @@ export class Button {
           fakeButton.type = this.type;
         }
         fakeButton.style.display = 'none';
-        form.appendChild(fakeButton);
+        parentForm.appendChild(fakeButton);
         fakeButton.click();
         fakeButton.remove();
       }
@@ -128,19 +128,21 @@ export class Button {
    * @see https://github.com/telekom/scale/issues/859
    */
   appendEnterKeySubmitFallback() {
-    const parentForm = this.hostElement.closest('form');
-    if (parentForm == null) {
-      return;
+    if (hasShadowDom(this.hostElement)) {
+      const parentForm = this.hostElement.closest('form');
+      if (parentForm == null) {
+        return;
+      }
+      const hasSubmitInputAlready =
+        parentForm.querySelector('input[type="submit"]') != null;
+      if (hasSubmitInputAlready) {
+        return;
+      }
+      this.fallbackSubmitInputElement = document.createElement('input');
+      this.fallbackSubmitInputElement.type = 'submit';
+      this.fallbackSubmitInputElement.hidden = true;
+      parentForm.appendChild(this.fallbackSubmitInputElement);
     }
-    const hasSubmitInputAlready =
-      parentForm.querySelector('input[type="submit"]') != null;
-    if (hasSubmitInputAlready) {
-      return;
-    }
-    this.fallbackSubmitInputElement = document.createElement('input');
-    this.fallbackSubmitInputElement.type = 'submit';
-    this.fallbackSubmitInputElement.hidden = true;
-    parentForm.appendChild(this.fallbackSubmitInputElement);
   }
 
   cleanUpEnterKeySubmitFallback() {

--- a/packages/components/src/components/button/button.tsx
+++ b/packages/components/src/components/button/button.tsx
@@ -64,6 +64,7 @@ export class Button {
   @Prop() innerTabindex?: number;
 
   private focusableElement: HTMLElement;
+  private fallbackSubmitInputElement: HTMLInputElement;
 
   /**
    * Prevent clicks from being emitted from the host
@@ -106,10 +107,49 @@ export class Button {
 
   connectedCallback() {
     this.setIconPositionProp();
+    this.appendEnterKeySubmitFallback();
   }
 
   componentDidLoad() {
     this.setChildrenIconSize();
+  }
+
+  disconnectedCallback() {
+    this.cleanUpEnterKeySubmitFallback();
+  }
+
+  /**
+   * In order for forms to be submitted with the Enter key
+   * there has to be a `button` or an `input[type="submit"]` in the form.
+   * Browsers do not take the <button> inside the Shadow DOM into account for this matter.
+   * So we carefully append an `input[type="submit"]` to overcome this.
+   *
+   * @see https://stackoverflow.com/a/35235768
+   * @see https://github.com/telekom/scale/issues/859
+   */
+  appendEnterKeySubmitFallback() {
+    const parentForm = this.hostElement.closest('form');
+    if (parentForm == null) {
+      return;
+    }
+    const hasSubmitInputAlready =
+      parentForm.querySelector('input[type="submit"]') != null;
+    if (hasSubmitInputAlready) {
+      return;
+    }
+    this.fallbackSubmitInputElement = document.createElement('input');
+    this.fallbackSubmitInputElement.type = 'submit';
+    this.fallbackSubmitInputElement.hidden = true;
+    parentForm.appendChild(this.fallbackSubmitInputElement);
+  }
+
+  cleanUpEnterKeySubmitFallback() {
+    if (this.fallbackSubmitInputElement != null) {
+      try {
+        this.fallbackSubmitInputElement.remove();
+        this.fallbackSubmitInputElement = null;
+      } catch (err) {}
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #859.

- Not a "React wrapper" thing
- Same problem with "generic" web component
- Forms with a single text input will be submitted with the Enter key, even without a button: https://stackoverflow.com/a/35235768

---

- [x] fix
- [x] unit or e2e test
- [ ] find a better word instead of "fallback"?