### PR TITLE
fix: Potential a11y issue with switch #822

### DIFF
--- a/packages/components/src/components/switch/__snapshots__/switch.spec.ts.snap
+++ b/packages/components/src/components/switch/__snapshots__/switch.spec.ts.snap
@@ -7,7 +7,7 @@ exports[`Switch should match snapshot 1`] = `
       <input aria-labelledby="switch-0-label" id="switch-0" type="checkbox">
       <div class="switch__wrapper">
         <div class="switch__toggle"></div>
-        <div class="switch__text"></div>
+        <div aria-hidden="true" class="switch__text"></div>
       </div>
     </label>
   </div>

--- a/packages/components/src/components/switch/switch.tsx
+++ b/packages/components/src/components/switch/switch.tsx
@@ -70,7 +70,7 @@ export class Switch {
             />
             <div class="switch__wrapper">
               <div class="switch__toggle" />
-              <div class="switch__text" />
+              <div class="switch__text" aria-hidden="true" />
             </div>
             {this.label && <span class="switch__label">{this.label}</span>}
           </label>


### PR DESCRIPTION
fix #822 

✅ Cross-checked with different accessibility tested switches with same structure (input [type=checkbox])
✅ Voice Over output checked

👉 Thus I would like to merge the accessibility change wish, since it brings in any case an improvement. 

@nowseemee can you please approve this 🙂