### PR TITLE
fix: use next release version for working nuxt3 app

### DIFF
--- a/examples/nuxt3-boilerplate/package.json
+++ b/examples/nuxt3-boilerplate/package.json
@@ -10,6 +10,6 @@
     "nuxt": "3.0.0-rc.3"
   },
   "dependencies": {
-    "@telekom/scale-components": "^3.0.0-beta.57"
+    "@telekom/scale-components": "^3.0.0-beta.107"
   }
 }

--- a/examples/nuxt3-boilerplate/package.json
+++ b/examples/nuxt3-boilerplate/package.json
@@ -10,6 +10,6 @@
     "nuxt": "3.0.0-rc.3"
   },
   "dependencies": {
-    "@telekom/scale-components": "^3.0.0-beta.56"
+    "@telekom/scale-components": "^3.0.0-beta.57"
   }
 }


### PR DESCRIPTION
The boilerplate at the moment only works by yarn linking the scale-components using the latest stencil version. Updating its scale-components version to the next release version so that the example will actually work "out of the box"