### PR TITLE
Add vite-support for the package scale-components

### DIFF
--- a/packages/components/stencil.config.ts
+++ b/packages/components/stencil.config.ts
@@ -85,5 +85,6 @@ export const config: Config = {
   ],
   extras: {
     cloneNodeFix: true,
+    experimentalImportInjection: true,
   },
 };


### PR DESCRIPTION
In our Project we have problems to use the Telekom-Scale-Components with vite and get allways Console.Problems with a blank page:
> TypeError: Failed to fetch dynamically imported module: http://localhost:3000/node_modules/.vite/deps/scale-radio-button-group.entry.js?import undefined

> TypeError: Failed to fetch dynamically imported module: http://localhost:3000/node_modules/.vite/deps/scale-button.entry.js?import undefined

> Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'isProxied')
    at initializeComponent (@telekom_scale-components_loader.js?v=6b475f15:2739:17)

---
For this type of problems Stencil have a extra flag named "[experimentalImportInjection](https://stenciljs.com/docs/config-extras#experimentalimportinjection)". 
Setting this `experimentalImportInjection: true,` in the extras-section in packages/components/stencil.config.ts and recompile the package solved the problem in our project.

Regarding to #369, this can reliably integrate vite usage.