### PR TITLE
chore: replace deprecated `dist-custom-elements-bundle` dist

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -51,14 +51,9 @@ To use the components, you need to load a CSS file and some JavaScript. The CSS 
 
 ```javascript
 import '@telekom/scale-components-neutral/dist/scale-components/scale-components.css';
-import {
-  applyPolyfills,
-  defineCustomElements,
-} from '@telekom/scale-components-neutral/loader';
+import { defineCustomElements } from '@telekom/scale-components-neutral/loader';
 
-applyPolyfills().then(() => {
-  defineCustomElements(window);
-});
+defineCustomElements();
 ```
 
 ### NPM packages
@@ -119,13 +114,11 @@ npm install @telekom/scale-components@next
 
 ### Setup with a bundler or ES modules
 
-```
+```js
 import "@telekom/scale-components/dist/scale-components/scale-components.css";
-import { applyPolyfills, defineCustomElements } from "@telekom/scale-components/loader";
+import { defineCustomElements } from "@telekom/scale-components/loader";
 
-applyPolyfills().then(() => {
-  defineCustomElements(window);
-});
+defineCustomElements();
 ```
 
 ### NPM packages

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -11,9 +11,9 @@
     "access": "public"
   },
   "main": "dist/index.cjs.js",
-  "module": "dist/custom-elements/index.js",
+  "module": "dist/components/index.js",
   "unpkg": "dist/scale-components/scale-components.esm.js",
-  "types": "dist/types/components.d.ts",
+  "types": "dist/components/index.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
   "files": [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -13,7 +13,7 @@
   "main": "dist/index.cjs.js",
   "module": "dist/components/index.js",
   "unpkg": "dist/scale-components/scale-components.esm.js",
-  "types": "dist/components/index.d.ts",
+  "types": "dist/types/components.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
   "files": [

--- a/packages/components/stencil.config.ts
+++ b/packages/components/stencil.config.ts
@@ -52,7 +52,8 @@ export const config: Config = {
       ],
     },
     {
-      type: 'dist-custom-elements-bundle',
+      type: 'dist-custom-elements',
+      generateTypeDeclarations: true,
     },
     {
       type: 'www',

--- a/packages/storybook-vue/stories/setup_and_info/GettingStartedForDevelopers_de.md
+++ b/packages/storybook-vue/stories/setup_and_info/GettingStartedForDevelopers_de.md
@@ -16,23 +16,19 @@ Um die Komponenten zu verwenden, lade die CSS-Datei sowie JavaScript. Die CSS-Da
 
 ### Plain HTML
 
-```bash
+```html
 <link rel="stylesheet" href="node_modules/@telekom/scale-components/dist/scale-components/scale-components.css">
 <script type="module" src="node_modules/@telekom/scale-components/dist/scale-components/scale-components.esm.js"></script>
 ```
 
 ### Mit Bundler oder ES-Modulen
 
-```bash
+```js
 import "@telekom/scale-components/dist/scale-components/scale-components.css";
-import { applyPolyfills, defineCustomElements } from "@telekom/scale-components/loader";
+import { defineCustomElements } from "@telekom/scale-components/loader";
 
-applyPolyfills().then(() => {
-  defineCustomElements(window);
-});
+defineCustomElements();
 ```
-
-> Ab Juli 2021 unterstützen moderne Build-Tools wie Vite oder Snowpack diesen Lazy-Loading-Mechanismus nicht (siehe [GitHub-Problem im Stencil-Repository](https://github.com/ionic-team/stencil/issues/2827)). Um diese Einschränkung zu umgehen, laden Sie die Bibliothek mit Link- und Skript-Tags wie im "einfachen HTML"-Code weiter oben auf dieser Seite.
 
 ### NPM Packages
 

--- a/packages/storybook-vue/stories/setup_and_info/GettingStartedForDevelopers_en.md
+++ b/packages/storybook-vue/stories/setup_and_info/GettingStartedForDevelopers_en.md
@@ -18,21 +18,19 @@ To use the components, you need to load a CSS file and some JavaScript. The CSS 
 
 ### Plain HTML
 
-```bash
+```html
 <link rel="stylesheet" href="node_modules/@telekom/scale-components/dist/scale-components/scale-components.css">
 <script type="module" src="node_modules/@telekom/scale-components/dist/scale-components/scale-components.esm.js"></script>
 ```
 
 ### With a bundler or ES modules
 
-```bash
+```js
 import "@telekom/scale-components/dist/scale-components/scale-components.css";
 import { defineCustomElements } from "@telekom/scale-components/loader";
 
-defineCustomElements(window);
+defineCustomElements();
 ```
-
-> As of July 2021, modern build tools like Vite or Snowpack will break with this lazy-loading mechanism ([see GitHub issue in Stencil's repo](https://github.com/ionic-team/stencil/issues/2827)). To work around this issue, please load the library via `link` and `script` tags as in the "Plain HTML" snippet above.
 
 ### NPM Packages
 


### PR DESCRIPTION
…with the new [`dist-custom-elements`](https://stenciljs.com/docs/custom-elements#distributing-custom-elements).

This dist allows bypassing Stencil's lazy loading, and import only a specific set of components programatically (no magic), e.g.

```js
import { defineCustomElementScaleButton } from '@telekom/scale-components'

defineCustomElementScaleButton() // only `<scale-button>` is loaded
```

See https://github.com/telekom/scale/issues/1167