### PR TITLE
chore: remove `web-animations-js` dep

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -68,12 +68,10 @@
   "dependencies": {
     "@duetds/date-picker": "1.2.0",
     "@floating-ui/dom": "^0.5.4",
-    "@proyecto26/animatable-component": "^1.1.8",
     "@stencil/core": "^2.17.0",
     "@telekom/design-tokens": "^1.0.0-beta.2",
     "@telekom/scale-design-tokens": "^3.0.0-beta.112",
     "classnames": "^2.2.6",
-    "stencil-inline-svg": "^1.0.1",
-    "web-animations-js": "^2.3.2"
+    "stencil-inline-svg": "^1.0.1"
   }
 }

--- a/packages/components/src/global/scale.ts
+++ b/packages/components/src/global/scale.ts
@@ -9,13 +9,4 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-if (
-  typeof window !== 'undefined' &&
-  typeof window.Audio !== 'undefined' &&
-  typeof require !== 'undefined'
-) {
-  // tslint:disable-next-line:no-var-requires
-  require('web-animations-js');
-}
-
-export default () => {};
+// Nothing at the moment

--- a/yarn.lock
+++ b/yarn.lock
@@ -4923,11 +4923,6 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz"
   integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
 
-"@proyecto26/animatable-component@^1.1.8":
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/@proyecto26/animatable-component/-/animatable-component-1.1.8.tgz"
-  integrity sha512-JvnRXBKUvtADqligiNIHr8NG5zI4Y4MbBdrwlFxzXBzgHqRbyQiGIDBReDcO1XNgQFKRxyceJP3NGqrlz/DSuA==
-
 "@sinclair/typebox@^0.24.1":
   version "0.24.28"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.28.tgz#15aa0b416f82c268b1573ab653e4413c965fe794"
@@ -19763,11 +19758,6 @@ wcwidth@^1.0.0:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
-
-web-animations-js@^2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/web-animations-js/-/web-animations-js-2.3.2.tgz"
-  integrity sha512-TOMFWtQdxzjWp8qx4DAraTWTsdhxVSiWa6NkPFSaPtZ1diKUxTn4yTix73A1euG1WbSOMMPcY51cnjTIHrGtDA==
 
 web-namespaces@^1.0.0:
   version "1.1.4"


### PR DESCRIPTION
- Safari is no longer an issue, and [browser support is pretty great imo](https://caniuse.com/web-animation)
- `web-animations-js` is almost [15 kB gzipped](https://bundlephobia.com/package/web-animations-js@2.3.2) 🫣
- we're currently only using the Web Animations API in the Modal, and [it's implemented in a "progressive-enhancement" way](https://github.com/telekom/scale/blob/fdf09ccba8ce9a533ba7b8a1c31174a9f7bc377b/packages/components/src/components/modal/modal.tsx#L209-L224) (it won't animate but it'll open/close normally if the API is not supported)

@nowseemee 👀 🙏 