### PR TITLE
refactor(slider): mobile 📱 

### DIFF
--- a/packages/components/src/components/slider/__snapshots__/slider.spec.ts.snap
+++ b/packages/components/src/components/slider/__snapshots__/slider.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`Slider should match snapshot 1`] = `
 <scale-slider value="0" value-from="0" value-to="0">
   <mock:shadow-root>
-    <div part="base false">
+    <div part="base">
       <div part="label-wrapper">
         <div part="value-text">
           0%
@@ -12,12 +12,14 @@ exports[`Slider should match snapshot 1`] = `
       <div part="track-wrapper">
         <div part="track">
           <div part="bar" style="left: 0%; width: 0%;"></div>
-          <div part="thumb-wrapper" style="left: 0%;">
-            <div aria-labelledby="slider-0-label" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" aria-valuetext="0" id="slider-0" part="thumb" role="slider" tabindex="0"></div>
+          <div part="inner-track">
+            <div part="thumb-wrapper" style="left: 0%;">
+              <div aria-labelledby="slider-0-label" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" aria-valuetext="0" id="slider-0" part="thumb" role="slider" tabindex="0"></div>
+            </div>
           </div>
         </div>
-        <input type="hidden" value="0%">
       </div>
+      <input type="hidden" value="0%">
     </div>
   </mock:shadow-root>
   Label
@@ -27,7 +29,7 @@ exports[`Slider should match snapshot 1`] = `
 exports[`Slider should match snapshot 2`] = `
 <scale-slider value="10" value-from="0" value-to="0">
   <mock:shadow-root>
-    <div part="base false">
+    <div part="base">
       <div part="label-wrapper">
         <div part="value-text">
           10%
@@ -36,12 +38,14 @@ exports[`Slider should match snapshot 2`] = `
       <div part="track-wrapper">
         <div part="track">
           <div part="bar" style="left: 0%; width: 10%;"></div>
-          <div part="thumb-wrapper" style="left: 10%;">
-            <div aria-labelledby="slider-1-label" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="10" aria-valuetext="10" id="slider-1" part="thumb" role="slider" tabindex="0"></div>
+          <div part="inner-track">
+            <div part="thumb-wrapper" style="left: 10%;">
+              <div aria-labelledby="slider-1-label" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="10" aria-valuetext="10" id="slider-1" part="thumb" role="slider" tabindex="0"></div>
+            </div>
           </div>
         </div>
-        <input type="hidden" value="10%">
       </div>
+      <input type="hidden" value="10%">
     </div>
   </mock:shadow-root>
   Label

--- a/packages/components/src/components/slider/__snapshots__/slider.spec.ts.snap
+++ b/packages/components/src/components/slider/__snapshots__/slider.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`Slider should match snapshot 1`] = `
     <div part="base">
       <div part="label-wrapper">
         <div part="value-text">
-          0%
+          0
         </div>
       </div>
       <div part="track-wrapper">
@@ -19,7 +19,7 @@ exports[`Slider should match snapshot 1`] = `
           </div>
         </div>
       </div>
-      <input type="hidden" value="0%">
+      <input type="hidden" value="0">
     </div>
   </mock:shadow-root>
   Label
@@ -32,7 +32,7 @@ exports[`Slider should match snapshot 2`] = `
     <div part="base">
       <div part="label-wrapper">
         <div part="value-text">
-          10%
+          10
         </div>
       </div>
       <div part="track-wrapper">
@@ -45,7 +45,7 @@ exports[`Slider should match snapshot 2`] = `
           </div>
         </div>
       </div>
-      <input type="hidden" value="10%">
+      <input type="hidden" value="10">
     </div>
   </mock:shadow-root>
   Label

--- a/packages/components/src/components/slider/__snapshots__/slider.spec.ts.snap
+++ b/packages/components/src/components/slider/__snapshots__/slider.spec.ts.snap
@@ -3,18 +3,20 @@
 exports[`Slider should match snapshot 1`] = `
 <scale-slider value="0" value-from="0" value-to="0">
   <mock:shadow-root>
-    <div class="slider" part="slider">
-      <div class="slider__track-wrapper" part="track-wrapper">
-        <div class="slider__track" part="track">
-          <div class="slider__bar" part="bar" style="left: 0%; width: 0%; background-color: var(--background-bar);"></div>
-          <div class="slider__thumb-wrapper" part="thumb-wrapper" style="left: 0%;">
-            <div aria-labelledby="slider-0-label" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" aria-valuetext="0" class="slider__thumb" id="slider-0" part="thumb" role="slider" tabindex="0"></div>
+    <div part="base false">
+      <div part="label-wrapper">
+        <div part="value-text">
+          0%
+        </div>
+      </div>
+      <div part="track-wrapper">
+        <div part="track">
+          <div part="bar" style="left: 0%; width: 0%;"></div>
+          <div part="thumb-wrapper" style="left: 0%;">
+            <div aria-labelledby="slider-0-label" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" aria-valuetext="0" id="slider-0" part="thumb" role="slider" tabindex="0"></div>
           </div>
         </div>
         <input type="hidden" value="0%">
-        <div class="slider__display-value" part="display-value">
-          0%
-        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -25,18 +27,20 @@ exports[`Slider should match snapshot 1`] = `
 exports[`Slider should match snapshot 2`] = `
 <scale-slider value="10" value-from="0" value-to="0">
   <mock:shadow-root>
-    <div class="slider" part="slider">
-      <div class="slider__track-wrapper" part="track-wrapper">
-        <div class="slider__track" part="track">
-          <div class="slider__bar" part="bar" style="left: 0%; width: 10%; background-color: var(--background-bar);"></div>
-          <div class="slider__thumb-wrapper" part="thumb-wrapper" style="left: 10%;">
-            <div aria-labelledby="slider-1-label" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="10" aria-valuetext="10" class="slider__thumb" id="slider-1" part="thumb" role="slider" tabindex="0"></div>
+    <div part="base false">
+      <div part="label-wrapper">
+        <div part="value-text">
+          10%
+        </div>
+      </div>
+      <div part="track-wrapper">
+        <div part="track">
+          <div part="bar" style="left: 0%; width: 10%;"></div>
+          <div part="thumb-wrapper" style="left: 10%;">
+            <div aria-labelledby="slider-1-label" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="10" aria-valuetext="10" id="slider-1" part="thumb" role="slider" tabindex="0"></div>
           </div>
         </div>
         <input type="hidden" value="10%">
-        <div class="slider__display-value" part="display-value">
-          10%
-        </div>
       </div>
     </div>
   </mock:shadow-root>

--- a/packages/components/src/components/slider/__snapshots__/slider.spec.ts.snap
+++ b/packages/components/src/components/slider/__snapshots__/slider.spec.ts.snap
@@ -6,13 +6,15 @@ exports[`Slider should match snapshot 1`] = `
     <div class="slider" part="slider">
       <div class="slider__track-wrapper" part="track-wrapper">
         <div class="slider__track" part="track">
-          <div class="slider__bar" part="bar" style="width: 0%; background-color: var(--background-bar);"></div>
-          <div class="slider__thumb-wrapper" part="thumb-wrapper" style="left: 0%;">
+          <div class="slider__bar" part="bar" style="left: 0%; width: NaN%; background-color: var(--background-bar);"></div>
+          <div class="slider__thumb-wrapper" part="thumb-wrapper" style="left: NaN%;">
             <div aria-labelledby="slider-0-label" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuetext="undefined" class="slider__thumb" id="slider-0" part="thumb" role="slider" tabindex="0"></div>
           </div>
         </div>
-        <input type="hidden">
-        <div class="slider__display-value" part="display-value"></div>
+        <input type="hidden" value="undefined%">
+        <div class="slider__display-value" part="display-value">
+          undefined%
+        </div>
       </div>
     </div>
   </mock:shadow-root>
@@ -26,12 +28,12 @@ exports[`Slider should match snapshot 2`] = `
     <div class="slider" part="slider">
       <div class="slider__track-wrapper" part="track-wrapper">
         <div class="slider__track" part="track">
-          <div class="slider__bar" part="bar" style="width: 10%; background-color: var(--background-bar);"></div>
+          <div class="slider__bar" part="bar" style="left: 0%; width: 10%; background-color: var(--background-bar);"></div>
           <div class="slider__thumb-wrapper" part="thumb-wrapper" style="left: 10%;">
             <div aria-labelledby="slider-1-label" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="10" aria-valuetext="10" class="slider__thumb" id="slider-1" part="thumb" role="slider" tabindex="0"></div>
           </div>
         </div>
-        <input type="hidden" value="10">
+        <input type="hidden" value="10%">
         <div class="slider__display-value" part="display-value">
           10%
         </div>

--- a/packages/components/src/components/slider/__snapshots__/slider.spec.ts.snap
+++ b/packages/components/src/components/slider/__snapshots__/slider.spec.ts.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Slider should match snapshot 1`] = `
-<scale-slider>
+<scale-slider value="0" value-from="0" value-to="0">
   <mock:shadow-root>
     <div class="slider" part="slider">
       <div class="slider__track-wrapper" part="track-wrapper">
         <div class="slider__track" part="track">
-          <div class="slider__bar" part="bar" style="left: 0%; width: NaN%; background-color: var(--background-bar);"></div>
-          <div class="slider__thumb-wrapper" part="thumb-wrapper" style="left: NaN%;">
-            <div aria-labelledby="slider-0-label" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuetext="undefined" class="slider__thumb" id="slider-0" part="thumb" role="slider" tabindex="0"></div>
+          <div class="slider__bar" part="bar" style="left: 0%; width: 0%; background-color: var(--background-bar);"></div>
+          <div class="slider__thumb-wrapper" part="thumb-wrapper" style="left: 0%;">
+            <div aria-labelledby="slider-0-label" aria-orientation="horizontal" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" aria-valuetext="0" class="slider__thumb" id="slider-0" part="thumb" role="slider" tabindex="0"></div>
           </div>
         </div>
-        <input type="hidden" value="undefined%">
+        <input type="hidden" value="0%">
         <div class="slider__display-value" part="display-value">
-          undefined%
+          0%
         </div>
       </div>
     </div>
@@ -23,7 +23,7 @@ exports[`Slider should match snapshot 1`] = `
 `;
 
 exports[`Slider should match snapshot 2`] = `
-<scale-slider value="10">
+<scale-slider value="10" value-from="0" value-to="0">
   <mock:shadow-root>
     <div class="slider" part="slider">
       <div class="slider__track-wrapper" part="track-wrapper">

--- a/packages/components/src/components/slider/readme.md
+++ b/packages/components/src/components/slider/readme.md
@@ -7,23 +7,26 @@
 
 ## Properties
 
-| Property      | Attribute      | Description                                                                               | Type          | Default     |
-| ------------- | -------------- | ----------------------------------------------------------------------------------------- | ------------- | ----------- |
-| `customColor` | `custom-color` | <span style="color:red">**[DEPRECATED]**</span> - optional) slider custom color<br/><br/> | `string`      | `undefined` |
-| `decimals`    | `decimals`     | (optional) number of decimal places                                                       | `0 \| 1 \| 2` | `0`         |
-| `disabled`    | `disabled`     | (optional) disabled                                                                       | `boolean`     | `false`     |
-| `label`       | `label`        | (optional) slider label                                                                   | `string`      | `undefined` |
-| `max`         | `max`          | (optional) the maximal value of the slider                                                | `number`      | `100`       |
-| `min`         | `min`          | t(optional) he minimal value of the slider                                                | `number`      | `0`         |
-| `name`        | `name`         | (optional) the name of the slider                                                         | `string`      | `undefined` |
-| `showValue`   | `show-value`   | (optional) slider display value                                                           | `boolean`     | `true`      |
-| `sliderId`    | `slider-id`    | (optional) Slider id                                                                      | `string`      | `undefined` |
-| `step`        | `step`         | (optional) the step size to increase or decrease when dragging slider                     | `number`      | `1`         |
-| `styles`      | `styles`       | (optional) Injected CSS styles                                                            | `string`      | `undefined` |
-| `thumbLarge`  | `thumb-large`  | (optional) larger thumb                                                                   | `boolean`     | `false`     |
-| `trackSmall`  | `track-small`  | (optional) smaller track                                                                  | `boolean`     | `false`     |
-| `unit`        | `unit`         | (optional) slider value unit                                                              | `string`      | `'%'`       |
-| `value`       | `value`        | (optional) the display value of the slider                                                | `number`      | `undefined` |
+| Property      | Attribute      | Description                                                                              | Type          | Default     |
+| ------------- | -------------- | ---------------------------------------------------------------------------------------- | ------------- | ----------- |
+| `customColor` | `custom-color` | <span style="color:red">**[DEPRECATED]**</span> (optional) slider custom color<br/><br/> | `string`      | `undefined` |
+| `decimals`    | `decimals`     | (optional) number of decimal places                                                      | `0 \| 1 \| 2` | `0`         |
+| `disabled`    | `disabled`     | (optional) disabled                                                                      | `boolean`     | `false`     |
+| `label`       | `label`        | (optional) slider label                                                                  | `string`      | `undefined` |
+| `max`         | `max`          | (optional) the maximal value of the slider                                               | `number`      | `100`       |
+| `min`         | `min`          | t(optional) he minimal value of the slider                                               | `number`      | `0`         |
+| `name`        | `name`         | (optional) the name of the slider                                                        | `string`      | `undefined` |
+| `range`       | `range`        | (optional) multi-thumb                                                                   | `boolean`     | `false`     |
+| `showValue`   | `show-value`   | (optional) slider display value                                                          | `boolean`     | `true`      |
+| `sliderId`    | `slider-id`    | (optional) Slider id                                                                     | `string`      | `undefined` |
+| `step`        | `step`         | (optional) the step size to increase or decrease when dragging slider                    | `number`      | `1`         |
+| `styles`      | `styles`       | (optional) Injected CSS styles                                                           | `string`      | `undefined` |
+| `thumbLarge`  | `thumb-large`  | <span style="color:red">**[DEPRECATED]**</span> (optional) larger thumb<br/><br/>        | `boolean`     | `undefined` |
+| `trackSmall`  | `track-small`  | <span style="color:red">**[DEPRECATED]**</span> (optional) smaller track<br/><br/>       | `boolean`     | `undefined` |
+| `unit`        | `unit`         | (optional) slider value unit                                                             | `string`      | `'%'`       |
+| `value`       | `value`        | (optional) the value of the slider                                                       | `number`      | `0`         |
+| `valueFrom`   | `value-from`   | (optional) when `range` is true, the "from" value                                        | `number`      | `0`         |
+| `valueTo`     | `value-to`     | (optional) when `range` is true, the "to" value                                          | `number`      | `0`         |
 
 
 ## Events
@@ -42,9 +45,11 @@
 | ----------------- | ----------- |
 | `"bar"`           |             |
 | `"display-value"` |             |
+| `"from"`          |             |
 | `"label"`         |             |
 | `"thumb"`         |             |
 | `"thumb-wrapper"` |             |
+| `"to"`            |             |
 | `"track"`         |             |
 | `"track-wrapper"` |             |
 

--- a/packages/components/src/components/slider/readme.md
+++ b/packages/components/src/components/slider/readme.md
@@ -12,6 +12,7 @@
 | `customColor`   | `custom-color`    | <span style="color:red">**[DEPRECATED]**</span> (optional) slider custom color<br/><br/> | `string`              | `undefined` |
 | `decimals`      | `decimals`        | (optional) number of decimal places                                                      | `0 \| 1 \| 2`         | `0`         |
 | `disabled`      | `disabled`        | (optional) disabled                                                                      | `boolean`             | `false`     |
+| `helperText`    | `helper-text`     | (optional) helper text                                                                   | `string`              | `undefined` |
 | `label`         | `label`           | (optional) slider label                                                                  | `string`              | `undefined` |
 | `max`           | `max`             | (optional) the maximal value of the slider                                               | `number`              | `100`       |
 | `min`           | `min`             | t(optional) he minimal value of the slider                                               | `number`              | `0`         |
@@ -24,7 +25,7 @@
 | `styles`        | `styles`          | (optional) Injected CSS styles                                                           | `string`              | `undefined` |
 | `thumbLarge`    | `thumb-large`     | <span style="color:red">**[DEPRECATED]**</span> (optional) larger thumb<br/><br/>        | `boolean`             | `undefined` |
 | `trackSmall`    | `track-small`     | <span style="color:red">**[DEPRECATED]**</span> (optional) smaller track<br/><br/>       | `boolean`             | `undefined` |
-| `unit`          | `unit`            | (optional) slider value unit                                                             | `string`              | `'%'`       |
+| `unit`          | `unit`            | (optional) slider value unit                                                             | `string`              | `''`        |
 | `unitPosition`  | `unit-position`   | (optional) unit position                                                                 | `"after" \| "before"` | `'after'`   |
 | `value`         | `value`           | (optional) the value of the slider                                                       | `number`              | `0`         |
 | `valueFrom`     | `value-from`      | (optional) when `range` is true, the "from" value                                        | `number`              | `0`         |
@@ -47,11 +48,13 @@
 | ----------------- | ----------- |
 | `"bar"`           |             |
 | `"from"`          |             |
+| `"helper-text"`   |             |
+| `"inner-track"`   |             |
 | `"label"`         |             |
 | `"label-wrapper"` |             |
+| `"meta"`          |             |
 | `"step-mark"`     |             |
 | `"step-marks"`    |             |
-| `"thumb"`         |             |
 | `"thumb-wrapper"` |             |
 | `"to"`            |             |
 | `"track"`         |             |

--- a/packages/components/src/components/slider/readme.md
+++ b/packages/components/src/components/slider/readme.md
@@ -7,27 +7,28 @@
 
 ## Properties
 
-| Property       | Attribute       | Description                                                                              | Type                  | Default     |
-| -------------- | --------------- | ---------------------------------------------------------------------------------------- | --------------------- | ----------- |
-| `customColor`  | `custom-color`  | <span style="color:red">**[DEPRECATED]**</span> (optional) slider custom color<br/><br/> | `string`              | `undefined` |
-| `decimals`     | `decimals`      | (optional) number of decimal places                                                      | `0 \| 1 \| 2`         | `0`         |
-| `disabled`     | `disabled`      | (optional) disabled                                                                      | `boolean`             | `false`     |
-| `label`        | `label`         | (optional) slider label                                                                  | `string`              | `undefined` |
-| `max`          | `max`           | (optional) the maximal value of the slider                                               | `number`              | `100`       |
-| `min`          | `min`           | t(optional) he minimal value of the slider                                               | `number`              | `0`         |
-| `name`         | `name`          | (optional) the name of the slider                                                        | `string`              | `undefined` |
-| `range`        | `range`         | (optional) multi-thumb                                                                   | `boolean`             | `false`     |
-| `showValue`    | `show-value`    | (optional) slider display value                                                          | `boolean`             | `true`      |
-| `sliderId`     | `slider-id`     | (optional) Slider id                                                                     | `string`              | `undefined` |
-| `step`         | `step`          | (optional) the step size to increase or decrease when dragging slider                    | `number`              | `1`         |
-| `styles`       | `styles`        | (optional) Injected CSS styles                                                           | `string`              | `undefined` |
-| `thumbLarge`   | `thumb-large`   | <span style="color:red">**[DEPRECATED]**</span> (optional) larger thumb<br/><br/>        | `boolean`             | `undefined` |
-| `trackSmall`   | `track-small`   | <span style="color:red">**[DEPRECATED]**</span> (optional) smaller track<br/><br/>       | `boolean`             | `undefined` |
-| `unit`         | `unit`          | (optional) slider value unit                                                             | `string`              | `'%'`       |
-| `unitPosition` | `unit-position` | (optional) unit position                                                                 | `"after" \| "before"` | `'after'`   |
-| `value`        | `value`         | (optional) the value of the slider                                                       | `number`              | `0`         |
-| `valueFrom`    | `value-from`    | (optional) when `range` is true, the "from" value                                        | `number`              | `0`         |
-| `valueTo`      | `value-to`      | (optional) when `range` is true, the "to" value                                          | `number`              | `0`         |
+| Property        | Attribute         | Description                                                                              | Type                  | Default     |
+| --------------- | ----------------- | ---------------------------------------------------------------------------------------- | --------------------- | ----------- |
+| `customColor`   | `custom-color`    | <span style="color:red">**[DEPRECATED]**</span> (optional) slider custom color<br/><br/> | `string`              | `undefined` |
+| `decimals`      | `decimals`        | (optional) number of decimal places                                                      | `0 \| 1 \| 2`         | `0`         |
+| `disabled`      | `disabled`        | (optional) disabled                                                                      | `boolean`             | `false`     |
+| `label`         | `label`           | (optional) slider label                                                                  | `string`              | `undefined` |
+| `max`           | `max`             | (optional) the maximal value of the slider                                               | `number`              | `100`       |
+| `min`           | `min`             | t(optional) he minimal value of the slider                                               | `number`              | `0`         |
+| `name`          | `name`            | (optional) the name of the slider                                                        | `string`              | `undefined` |
+| `range`         | `range`           | (optional) multi-thumb                                                                   | `boolean`             | `false`     |
+| `showStepMarks` | `show-step-marks` | (optional) show a mark for each step                                                     | `boolean`             | `false`     |
+| `showValue`     | `show-value`      | (optional) slider display value                                                          | `boolean`             | `true`      |
+| `sliderId`      | `slider-id`       | (optional) Slider id                                                                     | `string`              | `undefined` |
+| `step`          | `step`            | (optional) the step size to increase or decrease when dragging slider                    | `number`              | `1`         |
+| `styles`        | `styles`          | (optional) Injected CSS styles                                                           | `string`              | `undefined` |
+| `thumbLarge`    | `thumb-large`     | <span style="color:red">**[DEPRECATED]**</span> (optional) larger thumb<br/><br/>        | `boolean`             | `undefined` |
+| `trackSmall`    | `track-small`     | <span style="color:red">**[DEPRECATED]**</span> (optional) smaller track<br/><br/>       | `boolean`             | `undefined` |
+| `unit`          | `unit`            | (optional) slider value unit                                                             | `string`              | `'%'`       |
+| `unitPosition`  | `unit-position`   | (optional) unit position                                                                 | `"after" \| "before"` | `'after'`   |
+| `value`         | `value`           | (optional) the value of the slider                                                       | `number`              | `0`         |
+| `valueFrom`     | `value-from`      | (optional) when `range` is true, the "from" value                                        | `number`              | `0`         |
+| `valueTo`       | `value-to`        | (optional) when `range` is true, the "to" value                                          | `number`              | `0`         |
 
 
 ## Events
@@ -48,6 +49,8 @@
 | `"from"`          |             |
 | `"label"`         |             |
 | `"label-wrapper"` |             |
+| `"step-mark"`     |             |
+| `"step-marks"`    |             |
 | `"thumb"`         |             |
 | `"thumb-wrapper"` |             |
 | `"to"`            |             |

--- a/packages/components/src/components/slider/readme.md
+++ b/packages/components/src/components/slider/readme.md
@@ -7,26 +7,27 @@
 
 ## Properties
 
-| Property      | Attribute      | Description                                                                              | Type          | Default     |
-| ------------- | -------------- | ---------------------------------------------------------------------------------------- | ------------- | ----------- |
-| `customColor` | `custom-color` | <span style="color:red">**[DEPRECATED]**</span> (optional) slider custom color<br/><br/> | `string`      | `undefined` |
-| `decimals`    | `decimals`     | (optional) number of decimal places                                                      | `0 \| 1 \| 2` | `0`         |
-| `disabled`    | `disabled`     | (optional) disabled                                                                      | `boolean`     | `false`     |
-| `label`       | `label`        | (optional) slider label                                                                  | `string`      | `undefined` |
-| `max`         | `max`          | (optional) the maximal value of the slider                                               | `number`      | `100`       |
-| `min`         | `min`          | t(optional) he minimal value of the slider                                               | `number`      | `0`         |
-| `name`        | `name`         | (optional) the name of the slider                                                        | `string`      | `undefined` |
-| `range`       | `range`        | (optional) multi-thumb                                                                   | `boolean`     | `false`     |
-| `showValue`   | `show-value`   | (optional) slider display value                                                          | `boolean`     | `true`      |
-| `sliderId`    | `slider-id`    | (optional) Slider id                                                                     | `string`      | `undefined` |
-| `step`        | `step`         | (optional) the step size to increase or decrease when dragging slider                    | `number`      | `1`         |
-| `styles`      | `styles`       | (optional) Injected CSS styles                                                           | `string`      | `undefined` |
-| `thumbLarge`  | `thumb-large`  | <span style="color:red">**[DEPRECATED]**</span> (optional) larger thumb<br/><br/>        | `boolean`     | `undefined` |
-| `trackSmall`  | `track-small`  | <span style="color:red">**[DEPRECATED]**</span> (optional) smaller track<br/><br/>       | `boolean`     | `undefined` |
-| `unit`        | `unit`         | (optional) slider value unit                                                             | `string`      | `'%'`       |
-| `value`       | `value`        | (optional) the value of the slider                                                       | `number`      | `0`         |
-| `valueFrom`   | `value-from`   | (optional) when `range` is true, the "from" value                                        | `number`      | `0`         |
-| `valueTo`     | `value-to`     | (optional) when `range` is true, the "to" value                                          | `number`      | `0`         |
+| Property       | Attribute       | Description                                                                              | Type                  | Default     |
+| -------------- | --------------- | ---------------------------------------------------------------------------------------- | --------------------- | ----------- |
+| `customColor`  | `custom-color`  | <span style="color:red">**[DEPRECATED]**</span> (optional) slider custom color<br/><br/> | `string`              | `undefined` |
+| `decimals`     | `decimals`      | (optional) number of decimal places                                                      | `0 \| 1 \| 2`         | `0`         |
+| `disabled`     | `disabled`      | (optional) disabled                                                                      | `boolean`             | `false`     |
+| `label`        | `label`         | (optional) slider label                                                                  | `string`              | `undefined` |
+| `max`          | `max`           | (optional) the maximal value of the slider                                               | `number`              | `100`       |
+| `min`          | `min`           | t(optional) he minimal value of the slider                                               | `number`              | `0`         |
+| `name`         | `name`          | (optional) the name of the slider                                                        | `string`              | `undefined` |
+| `range`        | `range`         | (optional) multi-thumb                                                                   | `boolean`             | `false`     |
+| `showValue`    | `show-value`    | (optional) slider display value                                                          | `boolean`             | `true`      |
+| `sliderId`     | `slider-id`     | (optional) Slider id                                                                     | `string`              | `undefined` |
+| `step`         | `step`          | (optional) the step size to increase or decrease when dragging slider                    | `number`              | `1`         |
+| `styles`       | `styles`        | (optional) Injected CSS styles                                                           | `string`              | `undefined` |
+| `thumbLarge`   | `thumb-large`   | <span style="color:red">**[DEPRECATED]**</span> (optional) larger thumb<br/><br/>        | `boolean`             | `undefined` |
+| `trackSmall`   | `track-small`   | <span style="color:red">**[DEPRECATED]**</span> (optional) smaller track<br/><br/>       | `boolean`             | `undefined` |
+| `unit`         | `unit`          | (optional) slider value unit                                                             | `string`              | `'%'`       |
+| `unitPosition` | `unit-position` | (optional) unit position                                                                 | `"after" \| "before"` | `'after'`   |
+| `value`        | `value`         | (optional) the value of the slider                                                       | `number`              | `0`         |
+| `valueFrom`    | `value-from`    | (optional) when `range` is true, the "from" value                                        | `number`              | `0`         |
+| `valueTo`      | `value-to`      | (optional) when `range` is true, the "to" value                                          | `number`              | `0`         |
 
 
 ## Events
@@ -44,14 +45,15 @@
 | Part              | Description |
 | ----------------- | ----------- |
 | `"bar"`           |             |
-| `"display-value"` |             |
 | `"from"`          |             |
 | `"label"`         |             |
+| `"label-wrapper"` |             |
 | `"thumb"`         |             |
 | `"thumb-wrapper"` |             |
 | `"to"`            |             |
 | `"track"`         |             |
 | `"track-wrapper"` |             |
+| `"value-text"`    |             |
 
 
 ----------------------------------------------

--- a/packages/components/src/components/slider/slider.css
+++ b/packages/components/src/components/slider/slider.css
@@ -42,9 +42,13 @@
   align-items: flex-start;
 }
 
-[part='label'],
+[part='label'] {
+  font: var(--font-label);
+}
+
 [part='value-text'] {
   font: var(--font-label);
+  font-variant-numeric: tabular-nums;
 }
 
 [part='track-wrapper'] {

--- a/packages/components/src/components/slider/slider.css
+++ b/packages/components/src/components/slider/slider.css
@@ -107,6 +107,7 @@
   z-index: 2;
   display: flex;
   justify-content: space-between;
+  /* FIXME use token? */
   padding: 0 8px;
 }
 

--- a/packages/components/src/components/slider/slider.css
+++ b/packages/components/src/components/slider/slider.css
@@ -26,18 +26,18 @@
   --color-label-disabled: var(--telekom-color-text-and-icon-disabled);
 }
 
-.slider {
+[part='base'] {
   width: 100%;
   display: block;
   align-items: center;
 }
 
-.slider .slider__track-wrapper {
+[part='track-wrapper'] {
   display: flex;
   align-items: center;
 }
 
-.slider .slider__track {
+[part='track'] {
   width: 303px;
   border: var(--border);
   height: 6px;
@@ -49,7 +49,7 @@
   border-radius: 100px;
 }
 
-.slider .slider__bar {
+[part='bar'] {
   height: 6px;
   z-index: -1;
   position: absolute;
@@ -58,7 +58,7 @@
   z-index: var(--scl-z-index-10);
 }
 
-.slider .slider__thumb-wrapper {
+[part~='thumb-wrapper'] {
   width: 32px;
   height: 32px;
   display: flex;
@@ -71,7 +71,7 @@
   background-color: transparent;
 }
 
-.slider .slider__thumb {
+[part~='thumb'] {
   width: 16px;
   border: 1px solid;
   height: 16px;
@@ -83,73 +83,54 @@
   box-shadow: var(--telekom-shadow-resting-standard);
 }
 
-.slider .slider__display-value {
+[part='display-value'] {
   color: var(--color-display-value);
   margin-left: 24px;
   font-weight: var(--font-weight-display-value);
   font-size: var(--font-size-display-value);
 }
 
-.slider .slider__thumb:hover {
+[part~='thumb']:hover {
   border-color: var(--border-color-thumb-hover);
 }
 
-.slider .slider__thumb:active {
+[part~='thumb']:active {
   border-color: var(--border-color-thumb-active);
 }
 
-.slider .slider__thumb:focus {
+[part~='thumb']:focus {
   box-shadow: var(--box-shadow-thumb-focus);
 }
 
-.slider .slider__thumb-wrapper:hover {
+[part~='thumb-wrapper']:hover {
   cursor: grab;
 }
 
-.slider .slider__thumb-wrapper:active {
+[part~='thumb-wrapper']:active {
   cursor: grabbing;
 }
 
-.slider--track-small .slider__track {
-  border: none;
-  height: 1px;
-  border-top: 1px solid transparent;
-  background-color: var(--background-track);
-}
-
-.slider--track-small .slider__bar {
-  border: 1px solid transparent;
-  height: 3px;
-  z-index: 1;
-  box-sizing: border-box;
-}
-
-.slider--thumb-large .slider__thumb {
-  width: 24px;
-  height: 24px;
-}
-
-.slider--disabled .slider__track-wrapper {
+[part~='disabled'] [part='track-wrapper'] {
   cursor: not-allowed;
 }
 
-.slider--disabled .slider__bar {
+[part~='disabled'] [part='bar'] {
   background-color: var(--background-bar-disabled);
   z-index: var(--scl-z-index-10);
 }
 
-.slider--disabled .slider__track {
+[part~='disabled'] [part='track'] {
   border-color: var(--telekom-color-ui-border-disabled);
 }
 
-.slider--disabled .slider__thumb {
+[part~='disabled'] [part~='thumb'] {
   display: none;
 }
 
-.slider--disabled .slider__label {
+[part~='disabled'] [part='label'] {
   color: var(--color-label-disabled);
 }
 
-.slider--disabled .slider__thumb-wrapper:hover {
+[part~='disabled'] [part~='thumb-wrapper']:hover {
   cursor: not-allowed;
 }

--- a/packages/components/src/components/slider/slider.css
+++ b/packages/components/src/components/slider/slider.css
@@ -20,6 +20,9 @@
   --border-color-thumb: rgba(0, 0, 0, 0.05);
   --background-thumb: var(--telekom-color-ui-white);
   --color-focus: var(--telekom-color-functional-focus);
+  --color-step-mark: var(--telekom-color-text-and-icon-additional);
+  --radius-step-mark: var(--telekom-radius-circle);
+  --size-step-mark: 4px;
 }
 
 [part='base'] {
@@ -57,13 +60,14 @@
 [part='bar'] {
   height: 100%;
   position: absolute;
+  z-index: 1;
   border-radius: var(--radius-track);
   background-color: var(--background-bar);
 }
 
 [part~='thumb-wrapper'] {
   position: absolute;
-  z-index: 1;
+  z-index: 3;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -95,6 +99,22 @@
 [part~='thumb']:focus {
   outline: var(--telekom-line-weight-highlight) solid var(--color-focus);
   outline-offset: 1px;
+}
+
+[part='step-marks'] {
+  width: 100%;
+  position: relative;
+  z-index: 2;
+  display: flex;
+  justify-content: space-between;
+  padding: 0 8px;
+}
+
+[part='step-mark'] {
+  width: var(--size-step-mark);
+  height: var(--size-step-mark);
+  background: var(--color-step-mark);
+  border-radius: var(--telekom-radius-circle);
 }
 
 /* disabled */
@@ -131,6 +151,7 @@
 :host-context([data-platform='ios']) {
   --height-track: 4px;
   --size-thumb: 26px;
+  --size-step-mark: 2px;
 }
 
 /* PLATFORM Android */

--- a/packages/components/src/components/slider/slider.css
+++ b/packages/components/src/components/slider/slider.css
@@ -16,12 +16,14 @@
   --radius-track: var(--telekom-radius-pill);
   --spacing-track: var(--telekom-spacing-unit-x5) 0
     var(--telekom-spacing-unit-x4);
+  --spacing-x-inner-track: 10px;
   --background-bar: var(--telekom-color-primary-standard);
   --radius-thumb: var(--telekom-radius-circle);
   --size-thumb: 24px;
   --border-color-thumb: rgba(0, 0, 0, 0.05);
   --background-thumb: var(--telekom-color-ui-white);
   --color-focus: var(--telekom-color-functional-focus);
+  --spacing-x-step-marks: 8px;
   --color-step-mark: var(--telekom-color-text-and-icon-additional);
   --radius-step-mark: var(--telekom-radius-circle);
   --size-step-mark: 4px;
@@ -47,6 +49,7 @@
 
 [part='track-wrapper'] {
   display: flex;
+  position: relative;
   align-items: center;
 }
 
@@ -60,6 +63,16 @@
   height: var(--height-track);
   background: var(--background-track);
   border-radius: var(--radius-track);
+}
+
+/* Really holds the thumb, adding some spacing on the sides */
+[part='inner-track'] {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  left: var(--spacing-x-inner-track);
+  width: calc(100% - var(--spacing-x-inner-track) * 2);
+  height: 100%;
 }
 
 [part='bar'] {
@@ -112,8 +125,7 @@
   z-index: 2;
   display: flex;
   justify-content: space-between;
-  /* FIXME use token? */
-  padding: 0 8px;
+  padding: 0 var(--spacing-x-step-marks);
 }
 
 [part='step-mark'] {

--- a/packages/components/src/components/slider/slider.css
+++ b/packages/components/src/components/slider/slider.css
@@ -10,26 +10,31 @@
  */
 
 :host {
-  --border: 1px solid var(--telekom-color-ui-border-standard);
-  --background-bar: var(--telekom-color-primary-standard);
-  --border-color-thumb: var(--telekom-color-ui-border-standard);
-  --box-shadow-thumb: var(--telekom-shadow-resting-standard);
-  --border-color-thumb-hover: var(--telekom-color-ui-border-hovered);
-  --border-color-thumb-active: var(--telekom-color-ui-border-pressed);
-  --box-shadow-thumb-focus: 0 0 0 var(--telekom-line-weight-highlight)
-    var(--telekom-color-functional-focus);
-  --color-display-value: var(--telekom-color-text-and-icon-additional);
-  --font-weight-display-value: var(--telekom-typography-font-weight-bold);
-  --font-size-display-value: var(--telekom-typography-font-size-small);
+  --width-track: 362px;
+  --height-track: 6px;
   --background-track: var(--telekom-color-ui-faint);
-  --background-bar-disabled: var(--telekom-color-ui-disabled);
-  --color-label-disabled: var(--telekom-color-text-and-icon-disabled);
+  --radius-track: var(--telekom-radius-pill);
+  --background-bar: var(--telekom-color-primary-standard);
+  --radius-thumb: var(--telekom-radius-circle);
+  --size-thumb: 24px;
+  --border-color-thumb: rgba(0, 0, 0, 0.05);
+  --background-thumb: var(--telekom-color-ui-white);
+  --color-focus: var(--telekom-color-functional-focus);
 }
 
 [part='base'] {
-  width: 100%;
-  display: block;
-  align-items: center;
+  /*  */
+}
+
+[part='label-wrapper'] {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+[part='label'],
+[part='value-text'] {
+  font: var(--telekom-text-style-ui);
 }
 
 [part='track-wrapper'] {
@@ -38,69 +43,76 @@
 }
 
 [part='track'] {
-  width: 303px;
-  border: var(--border);
-  height: 6px;
-  margin: 16px 0;
-  display: flex;
   position: relative;
   box-sizing: border-box;
+  display: flex;
   align-items: center;
-  border-radius: 100px;
+  margin: var(--telekom-spacing-unit-x5) 0;
+  width: var(--width-track);
+  height: var(--height-track);
+  background: var(--background-track);
+  border-radius: var(--radius-track);
 }
 
 [part='bar'] {
-  height: 6px;
-  z-index: -1;
+  height: 100%;
   position: absolute;
-  border-radius: 100px;
+  border-radius: var(--radius-track);
   background-color: var(--background-bar);
-  z-index: var(--scl-z-index-10);
 }
 
 [part~='thumb-wrapper'] {
+  position: absolute;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 32px;
   height: 32px;
-  display: flex;
-  z-index: var(--scl-z-index-20);
-  position: absolute;
-  text-align: center;
-  align-items: center;
   margin-left: -16px;
-  justify-content: center;
   background-color: transparent;
 }
 
 [part~='thumb'] {
-  width: 16px;
-  border: 1px solid;
-  height: 16px;
+  --_border: 0 0 0 var(--telekom-spacing-unit-x025) var(--border-color-thumb);
+  width: var(--size-thumb);
+  height: var(--size-thumb);
   outline: none;
   box-sizing: border-box;
-  border-color: var(--border-color-thumb);
-  border-radius: 50%;
-  background-color: #fff;
-  box-shadow: var(--telekom-shadow-resting-standard);
+  border-radius: var(--radius-thumb);
+  background-color: var(--background-thumb);
+  box-shadow: var(--_border), var(--telekom-shadow-raised-standard);
 }
 
-[part='display-value'] {
-  color: var(--color-display-value);
-  margin-left: 24px;
-  font-weight: var(--font-weight-display-value);
-  font-size: var(--font-size-display-value);
+[part~='thumb-wrapper']:hover [part~='thumb'] {
+  box-shadow: var(--_border), var(--telekom-shadow-raised-hover);
 }
 
-[part~='thumb']:hover {
-  border-color: var(--border-color-thumb-hover);
-}
-
-[part~='thumb']:active {
-  border-color: var(--border-color-thumb-active);
+[part~='thumb-wrapper']:active [part~='thumb'] {
+  box-shadow: var(--_border), var(--telekom-shadow-raised-pressed);
 }
 
 [part~='thumb']:focus {
-  box-shadow: var(--box-shadow-thumb-focus);
+  outline: var(--telekom-line-weight-highlight) solid var(--color-focus);
+  outline-offset: 1px;
 }
+
+/* disabled */
+
+/* TODO can this be overwritten? it should... */
+[part~='disabled'] [part='label-wrapper'] {
+  color: var(--telekom-color-text-and-icon-disabled);
+}
+
+[part~='disabled'] [part='bar'] {
+  background-color: var(--telekom-color-ui-border-disabled);
+}
+
+[part~='disabled'] [part~='thumb-wrapper'] {
+  display: none;
+}
+
+/* cursor */
 
 [part~='thumb-wrapper']:hover {
   cursor: grab;
@@ -114,23 +126,15 @@
   cursor: not-allowed;
 }
 
-[part~='disabled'] [part='bar'] {
-  background-color: var(--background-bar-disabled);
-  z-index: var(--scl-z-index-10);
+/* PLATFORM iOS */
+
+:host-context([data-platform='ios']) {
+  --height-track: 4px;
+  --size-thumb: 26px;
 }
 
-[part~='disabled'] [part='track'] {
-  border-color: var(--telekom-color-ui-border-disabled);
-}
+/* PLATFORM Android */
 
-[part~='disabled'] [part~='thumb'] {
-  display: none;
-}
-
-[part~='disabled'] [part='label'] {
-  color: var(--color-label-disabled);
-}
-
-[part~='disabled'] [part~='thumb-wrapper']:hover {
-  cursor: not-allowed;
+:host-context([data-platform='android']) {
+  --background-thumb: var(--telekom-color-primary-standard);
 }

--- a/packages/components/src/components/slider/slider.css
+++ b/packages/components/src/components/slider/slider.css
@@ -10,10 +10,12 @@
  */
 
 :host {
-  --width-track: 362px;
+  --width: 368px;
   --height-track: 6px;
   --background-track: var(--telekom-color-ui-faint);
   --radius-track: var(--telekom-radius-pill);
+  --spacing-track: var(--telekom-spacing-unit-x5) 0
+    var(--telekom-spacing-unit-x4);
   --background-bar: var(--telekom-color-primary-standard);
   --radius-thumb: var(--telekom-radius-circle);
   --size-thumb: 24px;
@@ -23,10 +25,13 @@
   --color-step-mark: var(--telekom-color-text-and-icon-additional);
   --radius-step-mark: var(--telekom-radius-circle);
   --size-step-mark: 4px;
+  --font-label: var(--telekom-text-style-ui);
+  --font-helper-text: var(--telekom-text-style-small-bold);
+  --color-helper-text: var(--telekom-color-text-and-icon-additional);
 }
 
-[part='base'] {
-  /*  */
+[part~='base'] {
+  width: var(--width);
 }
 
 [part='label-wrapper'] {
@@ -37,7 +42,7 @@
 
 [part='label'],
 [part='value-text'] {
-  font: var(--telekom-text-style-ui);
+  font: var(--font-label);
 }
 
 [part='track-wrapper'] {
@@ -50,8 +55,8 @@
   box-sizing: border-box;
   display: flex;
   align-items: center;
-  margin: var(--telekom-spacing-unit-x5) 0;
-  width: var(--width-track);
+  margin: var(--spacing-track);
+  width: 100%;
   height: var(--height-track);
   background: var(--background-track);
   border-radius: var(--radius-track);
@@ -118,10 +123,21 @@
   border-radius: var(--telekom-radius-circle);
 }
 
+[part='meta'] {
+  display: flex;
+  justify-content: space-between;
+}
+
+[part='helper-text'] {
+  font: var(--font-helper-text);
+  color: var(--color-helper-text);
+}
+
 /* disabled */
 
 /* TODO can this be overwritten? it should... */
-[part~='disabled'] [part='label-wrapper'] {
+[part~='disabled'] [part='label-wrapper'],
+[part~='disabled'] [part='helper-text'] {
   color: var(--telekom-color-text-and-icon-disabled);
 }
 

--- a/packages/components/src/components/slider/slider.spec.ts
+++ b/packages/components/src/components/slider/slider.spec.ts
@@ -59,18 +59,6 @@ describe('Slider', () => {
     expect(page.root).toMatchSnapshot();
   });
 
-  describe('classes', () => {
-    it('should handle getCssClassMap() and getBasePartMap()', () => {
-      const element = new Slider();
-      element.disabled = true;
-      expect(element.getCssClassMap()).toContain('slider');
-      expect(element.getCssClassMap()).toContain('slider--disabled');
-
-      expect(element.getBasePartMap()).toContain('slider');
-      expect(element.getBasePartMap()).toContain('disabled');
-    });
-  });
-
   describe('props', () => {
     it('check default props', async () => {
       const page = await newSpecPage({
@@ -120,13 +108,13 @@ describe('Slider', () => {
     });
   });
 
-  it('keydown .slider__thumb with ArrowRight', async () => {
+  it('keydown [part="thumb"] with ArrowRight', async () => {
     const page = await newSpecPage({
       components: [Slider],
       html: `<scale-slider></scale-slider>`,
     });
     page.root.value = 50;
-    simulateKeyboardEvent(page, 'keydown', '.slider__thumb', 'ArrowRight');
+    simulateKeyboardEvent(page, 'keydown', '[part="thumb"]', 'ArrowRight');
     expect(await page.rootInstance.value).toBe(51);
   });
 
@@ -139,31 +127,31 @@ describe('Slider', () => {
     const inputSpyLegacy = jest.fn();
     page.doc.addEventListener('scale-input', inputSpy);
     page.doc.addEventListener('scaleInput', inputSpyLegacy);
-    const element = page.root.shadowRoot.querySelector('.slider__thumb');
+    const element = page.root.shadowRoot.querySelector('[part="thumb"]');
     element.dispatchEvent(new Event('keydown'));
     await page.waitForChanges();
     expect(inputSpy).toHaveBeenCalled();
     expect(inputSpyLegacy).toHaveBeenCalled();
   });
 
-  it('keydown .slider__thumb with ArrowUp', async () => {
+  it('keydown [part="thumb"] with ArrowUp', async () => {
     const page = await newSpecPage({
       components: [Slider],
       html: `<scale-slider></scale-slider>`,
     });
     page.root.value = 50;
-    simulateKeyboardEvent(page, 'keydown', '.slider__thumb', 'ArrowUp');
+    simulateKeyboardEvent(page, 'keydown', '[part="thumb"]', 'ArrowUp');
     expect(await page.rootInstance.value).toBe(60);
   });
 
-  it('mousedown .slider__thumb-wrapper', async () => {
+  it('mousedown [part="thumb-wrapper"]', async () => {
     const page = await newSpecPage({
       components: [Slider],
       html: `<scale-slider></scale-slider>`,
     });
     page.root.dragging = false;
     expect(await page.rootInstance.dragging).toBe(undefined);
-    simulateMouseEvent(page, 'mousedown', '.slider__thumb-wrapper');
+    simulateMouseEvent(page, 'mousedown', '[part="thumb-wrapper"]');
     expect(await page.rootInstance.dragging).toBe(true);
   });
 });

--- a/packages/components/src/components/slider/slider.spec.ts
+++ b/packages/components/src/components/slider/slider.spec.ts
@@ -68,7 +68,7 @@ describe('Slider', () => {
       expect(page.rootInstance.min).toBe(0);
       expect(page.rootInstance.max).toBe(100);
       expect(page.rootInstance.step).toBe(1);
-      expect(page.rootInstance.unit).toBe('%');
+      expect(page.rootInstance.unit).toBe('');
       expect(page.rootInstance.decimals).toBe(0);
       expect(page.rootInstance.showValue).toBe(true);
       expect(page.rootInstance.disabled).toBe(false);

--- a/packages/components/src/components/slider/slider.spec.ts
+++ b/packages/components/src/components/slider/slider.spec.ts
@@ -63,17 +63,11 @@ describe('Slider', () => {
     it('should handle getCssClassMap() and getBasePartMap()', () => {
       const element = new Slider();
       element.disabled = true;
-      element.trackSmall = true;
-      element.thumbLarge = true;
       expect(element.getCssClassMap()).toContain('slider');
       expect(element.getCssClassMap()).toContain('slider--disabled');
-      expect(element.getCssClassMap()).toContain('slider--track-small');
-      expect(element.getCssClassMap()).toContain('slider--thumb-large');
 
       expect(element.getBasePartMap()).toContain('slider');
-      expect(element.getBasePartMap()).toContain('track-small');
       expect(element.getBasePartMap()).toContain('disabled');
-      expect(element.getBasePartMap()).toContain('thumb-large');
     });
   });
 
@@ -91,8 +85,6 @@ describe('Slider', () => {
       expect(page.rootInstance.showValue).toBe(true);
       expect(page.rootInstance.customColor).toBe(undefined);
       expect(page.rootInstance.disabled).toBe(false);
-      expect(page.rootInstance.trackSmall).toBe(false);
-      expect(page.rootInstance.thumbLarge).toBe(false);
     });
 
     it('check props being set', async () => {
@@ -110,8 +102,6 @@ describe('Slider', () => {
       page.root.showValue = false;
       page.root.customColor = 'magenta';
       page.root.disabled = 'true';
-      page.root.trackSmall = 'true';
-      page.root.thumbLarge = 'true';
       page.root.sliderId = 'sliderID';
       page.root.styles = 'background : red';
       await page.waitForChanges();
@@ -125,8 +115,6 @@ describe('Slider', () => {
       expect(page.rootInstance.showValue).toBe(false);
       expect(page.rootInstance.customColor).toBe('magenta');
       expect(page.rootInstance.disabled).toBe(true);
-      expect(page.rootInstance.trackSmall).toBe(true);
-      expect(page.rootInstance.thumbLarge).toBe(true);
       expect(page.rootInstance.sliderId).toBe('sliderID');
       expect(page.rootInstance.styles).toBe('background : red');
     });

--- a/packages/components/src/components/slider/slider.spec.ts
+++ b/packages/components/src/components/slider/slider.spec.ts
@@ -71,7 +71,6 @@ describe('Slider', () => {
       expect(page.rootInstance.unit).toBe('%');
       expect(page.rootInstance.decimals).toBe(0);
       expect(page.rootInstance.showValue).toBe(true);
-      expect(page.rootInstance.customColor).toBe(undefined);
       expect(page.rootInstance.disabled).toBe(false);
     });
 
@@ -87,8 +86,8 @@ describe('Slider', () => {
       page.root.unit = '';
       page.root.decimals = 2;
       page.root.label = 'slider label';
+      page.root.helperText = 'helper text';
       page.root.showValue = false;
-      page.root.customColor = 'magenta';
       page.root.disabled = 'true';
       page.root.sliderId = 'sliderID';
       page.root.styles = 'background : red';
@@ -100,8 +99,8 @@ describe('Slider', () => {
       expect(page.rootInstance.unit).toBe('');
       expect(page.rootInstance.decimals).toBe(2);
       expect(page.rootInstance.label).toBe('slider label');
+      expect(page.rootInstance.helperText).toBe('helper text');
       expect(page.rootInstance.showValue).toBe(false);
-      expect(page.rootInstance.customColor).toBe('magenta');
       expect(page.rootInstance.disabled).toBe(true);
       expect(page.rootInstance.sliderId).toBe('sliderID');
       expect(page.rootInstance.styles).toBe('background : red');

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -26,7 +26,7 @@
   - [x] show "hash marks" https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range#a_range_control_with_hash_marks
   - [x] fix spacing on the sides, thumb position (so marks match too)
   - [x] helper text
-  - [ ] update storybook
+  - [x] update storybook
 */
 
 import {
@@ -83,7 +83,7 @@ export class Slider {
   /** (optional) slider display value */
   @Prop() showValue?: boolean = true;
   /** (optional) slider value unit */
-  @Prop() unit?: string = '%';
+  @Prop() unit?: string = '';
   /** (optional) unit position */
   @Prop() unitPosition?: 'before' | 'after' = 'after';
   /** (optional) number of decimal places */

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -9,26 +9,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-/*
-  TODO
-  - [x] multi-range
-    - [x] basic implementation
-    - [x] keyboard support
-    - [x] text value
-    - [x] clamp to each other
-    - [x] fix bug: TO won't clamp with FROM on first drag
-  - [x] deprecate props `trackSmall`, etc.
-  - [x] use part selector [attr~=value]
-  - [x] update styles
-    - [x] disabled
-    - [x] styles for android
-    - [x] styles for iOS
-  - [x] show "hash marks" https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range#a_range_control_with_hash_marks
-  - [x] fix spacing on the sides, thumb position (so marks match too)
-  - [x] helper text
-  - [x] update storybook
-*/
-
 import {
   Component,
   h,

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -252,11 +252,11 @@ export class Slider {
 
   getTextValue = () => {
     if (this.range) {
-      const from = this.valueFrom.toFixed(this.decimals);
-      const to = this.valueTo.toFixed(this.decimals);
-      return `${from}—${to}${this.unit}`;
+      const from = this.valueFrom?.toFixed(this.decimals);
+      const to = this.valueTo?.toFixed(this.decimals);
+      return `${from}–${to}${this.unit}`;
     }
-    return `${this.value.toFixed(this.decimals)}${this.unit}`;
+    return `${this.value?.toFixed(this.decimals)}${this.unit}`;
   };
 
   clamp = (val: number) => {

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -17,12 +17,14 @@
     - [x] text value
     - [x] clamp to each other
     - [x] fix bug: TO won't clamp with FROM on first drag
-  - [x] use part selector [attr~=value]
-  - [ ] update styles
-  - [ ] styles for android
-  - [ ] styles for iOS
-  - [ ] show "hash marks" https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range#a_range_control_with_hash_marks
   - [x] deprecate props `trackSmall`, etc.
+  - [x] use part selector [attr~=value]
+  - [x] update styles
+    - [x] disabled
+    - [x] styles for android
+    - [x] styles for iOS
+  - [ ] show "hash marks" https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range#a_range_control_with_hash_marks
+  - [ ] helper text
   - [ ] update storybook
 */
 
@@ -76,6 +78,8 @@ export class Slider {
   @Prop() showValue?: boolean = true;
   /** (optional) slider value unit */
   @Prop() unit?: string = '%';
+  /** (optional) unit position */
+  @Prop() unitPosition?: 'before' | 'after' = 'after';
   /** (optional) number of decimal places */
   @Prop() decimals?: 0 | 1 | 2 = 0;
   /** @deprecated (optional) slider custom color */
@@ -279,9 +283,13 @@ export class Slider {
     if (this.range) {
       const from = this.valueFrom?.toFixed(this.decimals);
       const to = this.valueTo?.toFixed(this.decimals);
-      return `${from}–${to}${this.unit}`;
+      return this.unitPosition === 'before'
+        ? `${this.unit}${from} - ${this.unit}${to}`
+        : `${from}${this.unit} - ${to}${this.unit}`;
     }
-    return `${this.value?.toFixed(this.decimals)}${this.unit}`;
+    return this.unitPosition === 'before'
+      ? `${this.unit}${this.value?.toFixed(this.decimals)}`
+      : `${this.value?.toFixed(this.decimals)}${this.unit}`;
   };
 
   clamp = (val: number) => {
@@ -330,7 +338,7 @@ export class Slider {
               </label>
             )}
             {this.showValue && (
-              <div part="display-value">{this.getTextValue()}</div>
+              <div part="value-text">{this.getTextValue()}</div>
             )}
           </div>
           <div part="track-wrapper">
@@ -347,11 +355,6 @@ export class Slider {
                       ? this.positionTo - this.positionFrom
                       : this.position
                   }%`,
-                  backgroundColor: this.customColor
-                    ? this.customColor
-                    : this.disabled
-                    ? `var(--background-bar-disabled)`
-                    : `var(--background-bar)`,
                 }}
               ></div>
               {/* Two thumbs or one */}

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -25,7 +25,7 @@
     - [x] styles for iOS
   - [x] show "hash marks" https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range#a_range_control_with_hash_marks
   - [ ] fix spacing on the sides, thumb position (so marks match too)
-  - [ ] helper text
+  - [x] helper text
   - [ ] update storybook
 */
 
@@ -41,6 +41,7 @@ import {
   Element,
   Fragment,
 } from '@stencil/core';
+import classNames from 'classnames';
 import { emitEvent } from '../../utils/utils';
 import statusNote from '../../utils/status-note';
 
@@ -77,6 +78,8 @@ export class Slider {
   @Prop() showStepMarks?: boolean = false;
   /** (optional) slider label */
   @Prop() label?: string;
+  /** (optional) helper text */
+  @Prop() helperText?: string;
   /** (optional) slider display value */
   @Prop() showValue?: boolean = true;
   /** (optional) slider value unit */
@@ -330,11 +333,14 @@ export class Slider {
   }
 
   render() {
+    const helperTextId = `slider-helper-message-${i}`;
+    const ariaDescribedByAttr = { 'aria-describedBy': helperTextId };
+
     return (
       <Host>
         {this.styles && <style>{this.styles}</style>}
 
-        <div part={`base ${this.disabled && 'disabled'}`}>
+        <div part={classNames('base', this.disabled && 'disabled')}>
           <div part="label-wrapper">
             {!!this.label && (
               <label
@@ -393,6 +399,7 @@ export class Slider {
                       aria-labelledby={`${this.sliderId}-label`}
                       aria-orientation="horizontal"
                       aria-disabled={this.disabled}
+                      {...(this.helperText ? ariaDescribedByAttr : {})}
                       onKeyDown={this.onKeyDown}
                     />
                   </div>
@@ -414,6 +421,7 @@ export class Slider {
                       aria-labelledby={`${this.sliderId}-label`}
                       aria-orientation="horizontal"
                       aria-disabled={this.disabled}
+                      {...(this.helperText ? ariaDescribedByAttr : {})}
                       onKeyDown={this.onKeyDown}
                     />
                   </div>
@@ -437,14 +445,25 @@ export class Slider {
                     aria-labelledby={`${this.sliderId}-label`}
                     aria-orientation="horizontal"
                     aria-disabled={this.disabled}
+                    {...(this.helperText ? ariaDescribedByAttr : {})}
                     onKeyDown={this.onKeyDown}
                   />
                 </div>
               )}
             </div>
-            {/* (a11y) Not sure about this being only one input, or its value */}
+            {/* (a11y) Not sure about this being only one input, or its value, or useful at all… */}
             <input type="hidden" value={this.getTextValue()} name={this.name} />
           </div>
+          {this.helperText && (
+            <div
+              part="meta"
+              id={helperTextId}
+              aria-live="polite"
+              aria-relevant="additions removals"
+            >
+              <div part="helper-text">{this.helperText}</div>
+            </div>
+          )}
         </div>
       </Host>
     );

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -23,7 +23,8 @@
     - [x] disabled
     - [x] styles for android
     - [x] styles for iOS
-  - [ ] show "hash marks" https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range#a_range_control_with_hash_marks
+  - [x] show "hash marks" https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range#a_range_control_with_hash_marks
+  - [ ] fix spacing on the sides, thumb position (so marks match too)
   - [ ] helper text
   - [ ] update storybook
 */
@@ -72,6 +73,8 @@ export class Slider {
   @Prop() max?: number = 100;
   /** (optional) the step size to increase or decrease when dragging slider */
   @Prop() step?: number = 1;
+  /** (optional) show a mark for each step */
+  @Prop() showStepMarks?: boolean = false;
   /** (optional) slider label */
   @Prop() label?: string;
   /** (optional) slider display value */
@@ -292,6 +295,11 @@ export class Slider {
       : `${this.value?.toFixed(this.decimals)}${this.unit}`;
   };
 
+  getNumberOfSteps = () => {
+    const n = (this.max - this.min) / this.step + 1;
+    return [...Array(n).keys()];
+  };
+
   clamp = (val: number) => {
     let min = this.min;
     let max = this.max;
@@ -357,6 +365,13 @@ export class Slider {
                   }%`,
                 }}
               ></div>
+              {this.showStepMarks && (
+                <div part="step-marks">
+                  {this.getNumberOfSteps().map(() => (
+                    <span part="step-mark"></span>
+                  ))}
+                </div>
+              )}
               {/* Two thumbs or one */}
               {this.range ? (
                 <Fragment>

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -9,8 +9,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-// ((input - min) * 100) / (max - min)
-
 /*
   TODO
   - [x] multi-range
@@ -18,12 +16,12 @@
     - [x] keyboard support
     - [x] text value
     - [x] clamp to each other
-    - [ ] fix bug: TO won't clamp with FROM on first drag
+    - [x] fix bug: TO won't clamp with FROM on first drag
   - [ ] update styles (use part selector)
   - [ ] show "hash marks" https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range#a_range_control_with_hash_marks
   - [ ] styles for android
   - [ ] styles for iOS
-  - [ ] deprecate props `trackSmall`, etc.
+  - [x] deprecate props `trackSmall`, etc.
   - [ ] update storybook
 */
 
@@ -80,14 +78,14 @@ export class Slider {
   @Prop() unit?: string = '%';
   /** (optional) number of decimal places */
   @Prop() decimals?: 0 | 1 | 2 = 0;
-  /** @deprecated - optional) slider custom color */
+  /** @deprecated (optional) slider custom color */
   @Prop() customColor?: string;
   /** (optional) disabled  */
   @Prop() disabled?: boolean = false;
-  /** (optional) smaller track */
-  @Prop() trackSmall?: boolean = false;
-  /** (optional) larger thumb */
-  @Prop() thumbLarge?: boolean = false;
+  /** @deprecated (optional) smaller track */
+  @Prop() trackSmall?: boolean;
+  /** @deprecated (optional) larger thumb */
+  @Prop() thumbLarge?: boolean;
   /** (optional) Slider id */
   @Prop({ mutable: true }) sliderId?: string;
   /** (optional) Injected CSS styles */
@@ -149,6 +147,22 @@ export class Slider {
         message: `Property "customColor" is deprecated. 
           Please use css variable "--background-bar" to set the slider-bar color;
           e.g. <scale-slider value="20" style="--background-bar: green"></scale-slider>`,
+        type: 'warn',
+        source: this.hostElement,
+      });
+    }
+    if (this.thumbLarge !== undefined) {
+      statusNote({
+        tag: 'deprecated',
+        message: `Property "thumbLarge" is deprecated.`,
+        type: 'warn',
+        source: this.hostElement,
+      });
+    }
+    if (this.trackSmall !== undefined) {
+      statusNote({
+        tag: 'deprecated',
+        message: `Property "trackSmall" is deprecated.`,
         type: 'warn',
         source: this.hostElement,
       });
@@ -240,6 +254,7 @@ export class Slider {
     const positionKey = this.getKeyFor('position', thumb);
     const clampedValue = this.clamp(this[valueKey]);
     // https://stackoverflow.com/a/25835683
+    // ((input - min) * 100) / (max - min)
     this[positionKey] =
       ((clampedValue - this.min) * 100) / (this.max - this.min);
   };

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -199,6 +199,11 @@ export class Slider {
     }
     const valueKey = this.getKeyFor('value');
     this.setValue(this[valueKey] + steps, valueKey);
+    emitEvent(
+      this,
+      'scaleChange',
+      this.range ? [this.valueFrom, this.valueTo] : this.value
+    );
   };
 
   onDragStart = () => {
@@ -319,10 +324,10 @@ export class Slider {
   };
 
   addGlobalListeners() {
-    window.addEventListener('mousemove', this.onDragging.bind(this));
-    window.addEventListener('mouseup', this.onDragEnd.bind(this));
-    window.addEventListener('touchmove', this.onDragging.bind(this));
-    window.addEventListener('touchend', this.onDragEnd.bind(this));
+    window.addEventListener('mousemove', this.onDragging);
+    window.addEventListener('mouseup', this.onDragEnd);
+    window.addEventListener('touchmove', this.onDragging);
+    window.addEventListener('touchend', this.onDragEnd);
   }
 
   removeGlobalListeners() {

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -17,10 +17,11 @@
     - [x] text value
     - [x] clamp to each other
     - [x] fix bug: TO won't clamp with FROM on first drag
-  - [ ] update styles (use part selector)
-  - [ ] show "hash marks" https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range#a_range_control_with_hash_marks
+  - [x] use part selector [attr~=value]
+  - [ ] update styles
   - [ ] styles for android
   - [ ] styles for iOS
+  - [ ] show "hash marks" https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range#a_range_control_with_hash_marks
   - [x] deprecate props `trackSmall`, etc.
   - [ ] update storybook
 */
@@ -37,7 +38,6 @@ import {
   Element,
   Fragment,
 } from '@stencil/core';
-import classNames from 'classnames';
 import { emitEvent } from '../../utils/utils';
 import statusNote from '../../utils/status-note';
 
@@ -318,26 +318,28 @@ export class Slider {
       <Host>
         {this.styles && <style>{this.styles}</style>}
 
-        <div part={this.getBasePartMap()} class={this.getCssClassMap()}>
-          {!!this.label && (
-            <label
-              part="label"
-              class="slider__label"
-              id={`${this.sliderId}-label`}
-              htmlFor={this.sliderId}
-            >
-              {this.label}
-            </label>
-          )}
-          <div part="track-wrapper" class="slider__track-wrapper">
+        <div part={`base ${this.disabled && 'disabled'}`}>
+          <div part="label-wrapper">
+            {!!this.label && (
+              <label
+                part="label"
+                id={`${this.sliderId}-label`}
+                htmlFor={this.sliderId}
+              >
+                {this.label}
+              </label>
+            )}
+            {this.showValue && (
+              <div part="display-value">{this.getTextValue()}</div>
+            )}
+          </div>
+          <div part="track-wrapper">
             <div
               part="track"
-              class="slider__track"
               ref={(el) => (this.sliderTrack = el as HTMLDivElement)}
             >
               <div
                 part="bar"
-                class="slider__bar"
                 style={{
                   left: (this.range ? this.positionFrom : 0) + '%',
                   width: `${
@@ -357,14 +359,12 @@ export class Slider {
                 <Fragment>
                   <div
                     part="thumb-wrapper from"
-                    class="slider__thumb-wrapper"
                     style={{ left: `${this.positionFrom}%` }}
                     onMouseDown={this.onButtonDown}
                     onTouchStart={this.onButtonDown}
                   >
                     <div
                       part="thumb from"
-                      class="slider__thumb"
                       tabindex="0"
                       role="slider"
                       id={this.sliderId + '-from'}
@@ -380,14 +380,12 @@ export class Slider {
                   </div>
                   <div
                     part="thumb-wrapper to"
-                    class="slider__thumb-wrapper"
                     style={{ left: `${this.positionTo}%` }}
                     onMouseDown={this.onButtonDown}
                     onTouchStart={this.onButtonDown}
                   >
                     <div
                       part="thumb to"
-                      class="slider__thumb"
                       tabindex="0"
                       role="slider"
                       id={this.sliderId + '-to'}
@@ -405,14 +403,12 @@ export class Slider {
               ) : (
                 <div
                   part="thumb-wrapper"
-                  class="slider__thumb-wrapper"
                   style={{ left: `${this.position}%` }}
                   onMouseDown={this.onButtonDown}
                   onTouchStart={this.onButtonDown}
                 >
                   <div
                     part="thumb"
-                    class="slider__thumb"
                     tabindex="0"
                     role="slider"
                     id={this.sliderId}
@@ -430,34 +426,9 @@ export class Slider {
             </div>
             {/* (a11y) Not sure about this being only one input, or its value */}
             <input type="hidden" value={this.getTextValue()} name={this.name} />
-            {this.showValue && (
-              <div part="display-value" class="slider__display-value">
-                {this.getTextValue()}
-              </div>
-            )}
           </div>
         </div>
       </Host>
-    );
-  }
-
-  getBasePartMap() {
-    return this.getCssOrBasePartMap('basePart');
-  }
-
-  getCssClassMap() {
-    return this.getCssOrBasePartMap('css');
-  }
-
-  getCssOrBasePartMap(mode: 'basePart' | 'css') {
-    const component = 'slider';
-    const prefix = mode === 'basePart' ? '' : `${component}--`;
-
-    return classNames(
-      component,
-      this.disabled && `${prefix}disabled`,
-      this.trackSmall && `${prefix}track-small`,
-      this.thumbLarge && `${prefix}thumb-large`
     );
   }
 }

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -24,7 +24,7 @@
     - [x] styles for android
     - [x] styles for iOS
   - [x] show "hash marks" https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range#a_range_control_with_hash_marks
-  - [ ] fix spacing on the sides, thumb position (so marks match too)
+  - [x] fix spacing on the sides, thumb position (so marks match too)
   - [x] helper text
   - [ ] update storybook
 */
@@ -378,20 +378,67 @@ export class Slider {
                   ))}
                 </div>
               )}
-              {/* Two thumbs or one */}
-              {this.range ? (
-                <Fragment>
+              <div part="inner-track">
+                {/* Two thumbs or one */}
+                {this.range ? (
+                  <Fragment>
+                    <div
+                      part="thumb-wrapper from"
+                      style={{ left: `${this.positionFrom}%` }}
+                      onMouseDown={this.onButtonDown}
+                      onTouchStart={this.onButtonDown}
+                    >
+                      <div
+                        part="thumb from"
+                        tabindex="0"
+                        role="slider"
+                        id={this.sliderId + '-from'}
+                        aria-valuemin={this.min}
+                        aria-valuenow={this.value}
+                        aria-valuemax={this.max}
+                        aria-valuetext={`${this.value}`}
+                        aria-labelledby={`${this.sliderId}-label`}
+                        aria-orientation="horizontal"
+                        aria-disabled={this.disabled}
+                        {...(this.helperText ? ariaDescribedByAttr : {})}
+                        onKeyDown={this.onKeyDown}
+                      />
+                    </div>
+                    <div
+                      part="thumb-wrapper to"
+                      style={{ left: `${this.positionTo}%` }}
+                      onMouseDown={this.onButtonDown}
+                      onTouchStart={this.onButtonDown}
+                    >
+                      <div
+                        part="thumb to"
+                        tabindex="0"
+                        role="slider"
+                        id={this.sliderId + '-to'}
+                        aria-valuemin={this.min}
+                        aria-valuenow={this.value}
+                        aria-valuemax={this.max}
+                        aria-valuetext={`${this.value}`}
+                        aria-labelledby={`${this.sliderId}-label`}
+                        aria-orientation="horizontal"
+                        aria-disabled={this.disabled}
+                        {...(this.helperText ? ariaDescribedByAttr : {})}
+                        onKeyDown={this.onKeyDown}
+                      />
+                    </div>
+                  </Fragment>
+                ) : (
                   <div
-                    part="thumb-wrapper from"
-                    style={{ left: `${this.positionFrom}%` }}
+                    part="thumb-wrapper"
+                    style={{ left: `${this.position}%` }}
                     onMouseDown={this.onButtonDown}
                     onTouchStart={this.onButtonDown}
                   >
                     <div
-                      part="thumb from"
+                      part="thumb"
                       tabindex="0"
                       role="slider"
-                      id={this.sliderId + '-from'}
+                      id={this.sliderId}
                       aria-valuemin={this.min}
                       aria-valuenow={this.value}
                       aria-valuemax={this.max}
@@ -403,57 +450,12 @@ export class Slider {
                       onKeyDown={this.onKeyDown}
                     />
                   </div>
-                  <div
-                    part="thumb-wrapper to"
-                    style={{ left: `${this.positionTo}%` }}
-                    onMouseDown={this.onButtonDown}
-                    onTouchStart={this.onButtonDown}
-                  >
-                    <div
-                      part="thumb to"
-                      tabindex="0"
-                      role="slider"
-                      id={this.sliderId + '-to'}
-                      aria-valuemin={this.min}
-                      aria-valuenow={this.value}
-                      aria-valuemax={this.max}
-                      aria-valuetext={`${this.value}`}
-                      aria-labelledby={`${this.sliderId}-label`}
-                      aria-orientation="horizontal"
-                      aria-disabled={this.disabled}
-                      {...(this.helperText ? ariaDescribedByAttr : {})}
-                      onKeyDown={this.onKeyDown}
-                    />
-                  </div>
-                </Fragment>
-              ) : (
-                <div
-                  part="thumb-wrapper"
-                  style={{ left: `${this.position}%` }}
-                  onMouseDown={this.onButtonDown}
-                  onTouchStart={this.onButtonDown}
-                >
-                  <div
-                    part="thumb"
-                    tabindex="0"
-                    role="slider"
-                    id={this.sliderId}
-                    aria-valuemin={this.min}
-                    aria-valuenow={this.value}
-                    aria-valuemax={this.max}
-                    aria-valuetext={`${this.value}`}
-                    aria-labelledby={`${this.sliderId}-label`}
-                    aria-orientation="horizontal"
-                    aria-disabled={this.disabled}
-                    {...(this.helperText ? ariaDescribedByAttr : {})}
-                    onKeyDown={this.onKeyDown}
-                  />
-                </div>
-              )}
+                )}
+              </div>
             </div>
-            {/* (a11y) Not sure about this being only one input, or its value, or useful at all… */}
-            <input type="hidden" value={this.getTextValue()} name={this.name} />
           </div>
+          {/* (a11y) Not sure about this being only one input, or its value, or useful at all… */}
+          <input type="hidden" value={this.getTextValue()} name={this.name} />
           {this.helperText && (
             <div
               part="meta"

--- a/packages/components/src/html/slider.html
+++ b/packages/components/src/html/slider.html
@@ -24,6 +24,15 @@
   </head>
   <body>
     <h1 class="scl-font-variant-heading-3">Color thingy</h1>
+
+    <p>
+      <scale-slider
+        label="Hello World"
+        value="22"
+        helper-text="It's a movie"
+      ></scale-slider>
+    </p>
+
     <demo-hue>
       <demo-color-display
         style="--h: 110deg; --s: 100%; --l: 44.3%; --a: 1"
@@ -65,6 +74,7 @@
             min="0"
             max="100"
             unit-position="before"
+            helper-text="This is madness"
             step="10"
           ></scale-slider>
         </div>

--- a/packages/components/src/html/slider.html
+++ b/packages/components/src/html/slider.html
@@ -96,6 +96,14 @@
     </demo-hue>
 
     <script>
+      const slider = document.querySelector('[label="Hello World"]')
+      slider.addEventListener('scale-change', (event) => {
+        console.log('scale-change', event.detail)
+      })
+      slider.addEventListener('scale-input', (event) => {
+        console.log('scale-input', event.detail)
+      })
+
       const h = document.getElementById('h');
       const s = document.getElementById('s');
       const l = document.getElementById('l');

--- a/packages/components/src/html/slider.html
+++ b/packages/components/src/html/slider.html
@@ -32,11 +32,13 @@
         <scale-slider
           id="h"
           label="Hue"
-          value="110"
+          value-from="25"
+          value-to="250"
           max="360"
-          step="0.1"
-          decimals="1"
+          step="1"
+          decimals="0"
           unit="deg"
+          range
         ></scale-slider>
         <scale-slider id="s" label="Saturation" value="100"></scale-slider>
         <scale-slider
@@ -67,7 +69,7 @@
       const display = document.querySelector('demo-color-display');
 
       h.addEventListener('scaleInput', () => {
-        display.style.setProperty('--h', h.value + 'deg');
+        display.style.setProperty('--h', h.valueTo + 'deg');
       });
       s.addEventListener('scaleInput', () => {
         display.style.setProperty('--s', s.value + '%');

--- a/packages/components/src/html/slider.html
+++ b/packages/components/src/html/slider.html
@@ -28,8 +28,10 @@
     <p>
       <scale-slider
         label="Hello World"
-        value="22"
+        value="20"
+        step="10"
         helper-text="It's a movie"
+        show-step-marks
       ></scale-slider>
     </p>
 

--- a/packages/components/src/html/slider.html
+++ b/packages/components/src/html/slider.html
@@ -40,24 +40,34 @@
           unit="deg"
           range
         ></scale-slider>
-        <scale-slider id="s" label="Saturation" value="100"></scale-slider>
+        <div data-platform="android">
+          <scale-slider
+            id="s"
+            label="Saturation (Android)"
+            value="100"
+          ></scale-slider>
+        </div>
         <scale-slider
           id="l"
           label="Lightness"
           value="44.3"
           step="0.1"
+          disabled
           decimals="1"
         ></scale-slider>
-        <scale-slider
-          id="a"
-          label="Alpha"
-          unit=""
-          decimals="2"
-          value="1"
-          min="0"
-          max="1"
-          step="0.01"
-        ></scale-slider>
+        <div data-platform="ios">
+          <scale-slider
+            id="a"
+            label="Alpha (iOS)"
+            unit="$ "
+            decimals="2"
+            value="1"
+            min="0"
+            max="1"
+            unit-position="before"
+            step="0.01"
+          ></scale-slider>
+        </div>
       </demo-controls>
     </demo-hue>
 

--- a/packages/components/src/html/slider.html
+++ b/packages/components/src/html/slider.html
@@ -60,14 +60,26 @@
             id="a"
             label="Alpha (iOS)"
             unit="$ "
-            decimals="2"
-            value="1"
+            show-step-marks
+            value="50"
             min="0"
-            max="1"
+            max="100"
             unit-position="before"
-            step="0.01"
+            step="10"
           ></scale-slider>
         </div>
+        <scale-slider
+          id="a"
+          label="Testing steps"
+          unit="$ "
+          show-step-marks
+          value="0"
+          decimals="2"
+          min="0"
+          max="1"
+          unit-position="before"
+          step="0.25"
+        ></scale-slider>
       </demo-controls>
     </demo-hue>
 

--- a/packages/storybook-vue/stories/components/slider/ScaleSlider.vue
+++ b/packages/storybook-vue/stories/components/slider/ScaleSlider.vue
@@ -1,55 +1,27 @@
-<template>
-  <scale-slider
-    :custom-color="customColor"
-    :disabled="disabled"
-    :name="name"
-    :label="label"
-    :max="max"
-    :min="min"
-    :show-value="showValue"
-    :track-small="trackSmall"
-    :thumb-large="thumbLarge"
-    :step="step"
-    :value="value"
-    @scaleChange="scaleChange"
-    @scaleInput="scaleInput"
-  >
-  </scale-slider>
-</template>
-
 <script>
-import { action } from "@storybook/addon-actions";
 export default {
   props: {
-    customColor: String,
-    disabled: { type: Boolean, default: false },
-    label: String,
-    name: String,
-    max: { type: Number, default: 100 },
+    label: { type: String },
+    value: { type: Number, default: 0 },
+    range: { type: Boolean, default: false },
+    valueFrom: { type: Number, default: 0 },
+    valueTo: { type: Number, default: 0 },
     min: { type: Number, default: 0 },
-    showValue: { type: Boolean, default: true },
-    trackSmall: { type: Boolean, default: false },
-    thumbLarge: { type: Boolean, default: false },
+    max: { type: Number, default: 100 },
     step: { type: Number, default: 1 },
-    value: Number
+    showStepMarks: { type: Boolean, default: false },
+    unit: { type: String, default: '' },
+    unitPosition: { type: 'before' | 'after', default: 'after' },
+    decimals: { type: Number, default: 0 },
+    disabled: { type: Boolean, default: false },
+    showValue: { type: Boolean, default: true },
+    name: { type: String },
+    sliderId: { type: String },
+    helperText: String,
+    styles: { type: String },
   },
-  methods: {
-    scaleChange($event) {
-      action("scaleChange");
-      this.$emit("scaleChange", $event);
-    },
-    'scale-change'($event) {
-      action("scale-change");
-      this.$emit("scale-change", $event);
-    },
-    scaleInput($event) {
-      action("scaleInput");
-      this.$emit("scaleInput", $event);
-    },
-    'scale-input'($event) {
-      action("scale-input");
-      this.$emit("scale-input", $event);
-    },
+  render() {
+    return this.$slots.default;
   }
 };
 </script>

--- a/packages/storybook-vue/stories/components/slider/Slider.stories.mdx
+++ b/packages/storybook-vue/stories/components/slider/Slider.stories.mdx
@@ -19,76 +19,36 @@ import { action } from '@storybook/addon-actions';
 />
 
 export const Template = (args, { argTypes }) => ({
-  components: { ScaleSlider },
   props: {
     ...ScaleSlider.props,
   },
   template: `
     <scale-slider
-        :custom-color="customColor"
-        :disabled="disabled"
-        :name="name"
-        :label="label"
-        :max="max"
-        :min="min"
-        :show-value="showValue"
-        :track-small="trackSmall"
-        :thumb-large="thumbLarge"
-        :step="step"
-        :value="value"
-        @scaleButtonDown="scaleButtonDown"
-        @scaleDragStart="scaleDragStart"
-        @scaleDragging="scaleDragging"
-        @scaleDragEnd="scaleDragEnd"
-        @scaleSetPosition="scaleSetPosition"
-        @scaleCurrentPosition="scaleCurrentPosition"
-        >
+      :label="label"
+      :value="value"
+      :range="range"
+      :value-from="valueFrom"
+      :value-to="valueTo"
+      :min="min"
+      :max="max"
+      :step="step"
+      :show-step-marks="showStepMarks"
+      :unit="unit"
+      :unit-position="unitPosition"
+      :decimals="decimals"
+      :disabled="disabled"
+      :show-value="String(showValue)"
+      :name="name"
+      :slider-id="sliderId"
+      :helper-text="helperText"
+      @scale-change="handleScaleChange"
+      @scale-input="handleScaleInput"
+      >
     </scale-slider>
-    `,
+  `,
   methods: {
-    scaleButtonDown: action('scaleButtonDown'),
-    scaleDragStart: action('scaleDragStart'),
-    scaleDragging: action('scaleDragging'),
-    scaleDragEnd: action('scaleDragEnd'),
-    scaleSetPosition: action('scaleSetPosition'),
-    scaleCurrentPosition: action('scaleCurrentPosition'),
-  },
-});
-
-export const TemplateCustomColor = (args, { argTypes }) => ({
-  components: { ScaleSlider },
-  props: {
-    ...ScaleSlider.props,
-  },
-  template: `
-    <scale-slider style="--background-bar: green"
-        :custom-color="customColor"
-        :disabled="disabled"
-        :name="name"
-        :label="label"
-        :max="max"
-        :min="min"
-        :show-value="showValue"
-        :track-small="trackSmall"
-        :thumb-large="thumbLarge"
-        :step="step"
-        :value="value"
-        @scaleButtonDown="scaleButtonDown"
-        @scaleDragStart="scaleDragStart"
-        @scaleDragging="scaleDragging"
-        @scaleDragEnd="scaleDragEnd"
-        @scaleSetPosition="scaleSetPosition"
-        @scaleCurrentPosition="scaleCurrentPosition"
-        >
-    </scale-slider>
-    `,
-  methods: {
-    scaleButtonDown: action('scaleButtonDown'),
-    scaleDragStart: action('scaleDragStart'),
-    scaleDragging: action('scaleDragging'),
-    scaleDragEnd: action('scaleDragEnd'),
-    scaleSetPosition: action('scaleSetPosition'),
-    scaleCurrentPosition: action('scaleCurrentPosition'),
+    handleScaleChange: action('scale-change'),
+    handleScaleInput: action('scale-input'),
   },
 });
 
@@ -111,7 +71,7 @@ export const TemplateCustomColor = (args, { argTypes }) => ({
     name="Standard"
     args={{
       label: 'Standard',
-      value: 20,
+      value: 42,
     }}
   >
     {Template.bind({})}
@@ -124,94 +84,123 @@ export const TemplateCustomColor = (args, { argTypes }) => ({
 
 ```css
 :host {
-  --border: 1px solid var(--telekom-color-ui-border-standard);
-  --background-bar: var(--telekom-color-primary-standard);
-  --border-color-thumb: var(--telekom-color-ui-border-standard);
-  --box-shadow-thumb: var(--telekom-shadow-resting-standard);
-  --border-color-thumb-hover: var(--telekom-color-ui-border-hovered);
-  --border-color-thumb-active: var(--telekom-color-ui-border-pressed);
-  --box-shadow-thumb-focus: 0 0 0 var(--telekom-line-weight-highlight) var(
-      --telekom-color-functional-focus
-    );
-  --color-display-value: var(--telekom-color-text-and-icon-additional);
-  --font-weight-display-value: var(--telekom-typography-font-weight-bold);
-  --font-size-display-value: var(--telekom-typography-font-size-small);
+  --width: 368px;
+  --height-track: 6px;
   --background-track: var(--telekom-color-ui-faint);
-  --background-bar-disabled: var(--telekom-color-ui-disabled);
-  --color-label-disabled: var(--telekom-color-text-and-icon-disabled);
+  --radius-track: var(--telekom-radius-pill);
+  --spacing-track: var(--telekom-spacing-unit-x5) 0
+    var(--telekom-spacing-unit-x4);
+  --spacing-x-inner-track: 10px;
+  --background-bar: var(--telekom-color-primary-standard);
+  --radius-thumb: var(--telekom-radius-circle);
+  --size-thumb: 24px;
+  --border-color-thumb: rgba(0, 0, 0, 0.05);
+  --background-thumb: var(--telekom-color-ui-white);
+  --color-focus: var(--telekom-color-functional-focus);
+  --spacing-x-step-marks: 8px;
+  --color-step-mark: var(--telekom-color-text-and-icon-additional);
+  --radius-step-mark: var(--telekom-radius-circle);
+  --size-step-mark: 4px;
+  --font-label: var(--telekom-text-style-ui);
+  --font-helper-text: var(--telekom-text-style-small-bold);
+  --color-helper-text: var(--telekom-color-text-and-icon-additional);
 }
 ```
 
 For Shadow Parts, please inspect the element's #shadow.
 
-## Slider track small
+## Range
 
 <Canvas withSource="none">
   <Story
-    name="Slider track small"
+    name="Range"
     args={{
-      label: 'Slider track small',
-      value: 20,
-      trackSmall: true,
+      label: 'Temperature',
+      range: true,
+      valueFrom: 180,
+      valueTo: 330,
+      max: 500,
+      unit: 'ºC'
     }}
   >
     {Template.bind({})}
-  </Story>
-</Canvas>
-
-```html
-<scale-slider label="Slider track small" value="20" track-small></scale-slider>
-```
-
-## Slider thumb large
-
-<Canvas withSource="none">
-  <Story
-    name="Slider thumb large"
-    args={{
-      label: 'Slider thumb large',
-      value: 20,
-      thumbLarge: true,
-    }}
-  >
-    {Template.bind({})}
-  </Story>
-</Canvas>
-
-```html
-<scale-slider label="Slider thumb large" value="20" thumb-large></scale-slider>
-```
-
-## Slider with custom color
-
-<Canvas withSource="none">
-  <Story
-    name="Slider with custom color"
-    args={{
-      label: 'Slider with custom color',
-      value: 20,
-    }}
-  >
-    {TemplateCustomColor.bind({})}
   </Story>
 </Canvas>
 
 ```html
 <scale-slider
-  label="Slider with custom color"
-  value="20"
-  style="--background-bar: green"
-></scale-slider>
+  label="Temperature"
+  range
+  valueFrom="100"
+  valueTo="300"
+  max="500"
+  unit="ºC">
+</scale-slider>
 ```
 
-## Disabled slider
+## Step Marks
 
 <Canvas withSource="none">
   <Story
-    name="Disabled Slider"
+    name="Step Marks"
     args={{
-      label: 'Disabled Slider',
-      value: 40,
+      label: 'Step Marks',
+      step: 25,
+      showStepMarks: true,
+      value: 50,
+      max: 200,
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+```html
+<scale-slider
+  label="Step Marks"
+  step="25"
+  show-step-marks
+  value="50"
+  max="200">
+</scale-slider>
+```
+
+## Helper Text
+
+<Canvas withSource="none">
+  <Story
+    name="Helper Text"
+    args={{
+      label: 'Alpha',
+      value: 0.66,
+      step: 0.01,
+      decimals: 2,
+      max: 1,
+      helperText: 'Between 0 and 1',
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+```html
+<scale-slider
+  label="Alpha"
+  value="0.66"
+  step="0.01"
+  max="1"
+  helper-text="Between 0 and 1">
+</scale-slider>
+```
+
+## Disabled
+
+<Canvas withSource="none">
+  <Story
+    name="Disabled"
+    args={{
+      label: 'Disabled',
+      value: 13,
       disabled: true,
     }}
   >
@@ -220,5 +209,49 @@ For Shadow Parts, please inspect the element's #shadow.
 </Canvas>
 
 ```html
-<scale-slider label="Disabled Slider" value="40" disabled></scale-slider>
+<scale-slider
+  label="Disabled"
+  value="13"
+  disabled>
+</scale-slider>
+```
+
+## Platform iOS
+
+<Canvas withSource="none">
+  <Story name="Platform iOS">
+    {{
+      template: `
+        <div data-platform="ios">
+          <scale-slider label="iOS" value="25"></scale-slider>
+        </div>
+      `
+    }}
+  </Story>
+</Canvas>
+
+```html
+<div data-platform="ios">
+  <scale-slider label="Apple" value="25"></scale-slider>
+</div>
+```
+
+## Platform Android
+
+<Canvas withSource="none">
+  <Story name="Platform Android">
+    {{
+      template: `
+        <div data-platform="android">
+          <scale-slider label="Android" value="75"></scale-slider>
+        </div>
+      `
+    }}
+  </Story>
+</Canvas>
+
+```html
+<div data-platform="android">
+  <scale-slider label="Android" value="75"></scale-slider>
+</div>
 ```


### PR DESCRIPTION
Replaces #1174

- [x] multi-thumb aka range
- [x] deprecate props `trackSmall`, etc.
- [x] update styles (use part selector [attr~=value])
- [x] styles for Android and iOS
- [x] show ["hash marks"](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range#a_range_control_with_hash_marks)
- [x] helper text
- [x] storybook
- [ ] visual tests update 😵‍💫