### PR TITLE
fix(text-field): solving wrong helper-text id after rerendering

### DIFF
--- a/packages/components/src/components/checkbox/checkbox.tsx
+++ b/packages/components/src/components/checkbox/checkbox.tsx
@@ -70,7 +70,7 @@ export class Checkbox {
   /** @deprecated in v3 in favor of kebab-case event names */
   @Event({ eventName: 'scaleChange' }) scaleChangeLegacy: EventEmitter;
 
-  private id = i++;
+  private readonly internalId = i++;
 
   componentDidRender() {
     if (this.status !== '') {
@@ -109,7 +109,7 @@ export class Checkbox {
 
   connectedCallback() {
     if (!this.inputId) {
-      this.inputId = 'input-checkbox-' + this.id;
+      this.inputId = 'input-checkbox-' + this.internalId;
     }
   }
 
@@ -139,7 +139,7 @@ export class Checkbox {
       return (
         <div
           part="helper-text"
-          id={text.id}
+          id={text.internalId}
           aria-live="polite"
           aria-relevant="additions removals"
         >
@@ -151,7 +151,7 @@ export class Checkbox {
 
   render() {
     const helperText = {
-      id: this.helperText ? `helper-text-${this.id}` : null,
+      id: this.helperText ? `helper-text-${this.internalId}` : null,
       content: this.helperText,
     };
 

--- a/packages/components/src/components/date-picker/date-picker.tsx
+++ b/packages/components/src/components/date-picker/date-picker.tsx
@@ -186,7 +186,7 @@ export class DatePicker {
   @Event({ eventName: 'scaleFocus' })
   scaleFocusLegacy: EventEmitter<DuetDatePickerFocusEvent>;
 
-  private helperTextId = `helper-message-${i}`;
+  private readonly internalId = i++;
 
   private mo: MutationObserver;
 
@@ -289,7 +289,10 @@ export class DatePicker {
     }
 
     if (input && this.helperText) {
-      input.setAttribute('aria-describedby', this.helperTextId);
+      input.setAttribute(
+        'aria-describedby',
+        `helper-message-${this.internalId}`
+      );
     }
 
     if (input && (this.status === 'error' || this.invalid)) {
@@ -399,6 +402,7 @@ export class DatePicker {
   }
 
   render() {
+    const helperTextId = `helper-message-${this.internalId}`;
     return (
       <Host>
         {this.styles && <style>{this.styles}</style>}
@@ -448,7 +452,7 @@ export class DatePicker {
           {!!this.helperText && (
             <div
               class="date-picker__meta"
-              id={this.helperTextId}
+              id={helperTextId}
               aria-live="polite"
               aria-relevant="additions removals"
             >

--- a/packages/components/src/components/dropdown-select/dropdown-select.tsx
+++ b/packages/components/src/components/dropdown-select/dropdown-select.tsx
@@ -29,6 +29,8 @@ enum Actions {
   Type = 'Type',
 }
 
+let i = 0;
+
 const readOptions = (
   hostElement: HTMLElement
 ): Array<{ label: string; value: any; ItemElement: VNode }> => {
@@ -206,6 +208,7 @@ export class DropdownSelect {
   private comboEl: HTMLElement;
   private listboxEl: HTMLElement;
   private listboxPadEl: HTMLElement;
+  private readonly internalId = i++;
 
   @Watch('value')
   valueChange(newValue) {
@@ -380,7 +383,7 @@ export class DropdownSelect {
       readOptions(this.hostElement).find(({ value }) => value === this.value) ||
       ({} as any)
     ).ItemElement;
-    const helperTextId = `helper-message`;
+    const helperTextId = `helper-message-${this.internalId}`;
     const ariaDescribedByAttr = { 'aria-describedBy': helperTextId };
 
     return (

--- a/packages/components/src/components/dropdown/dropdown.tsx
+++ b/packages/components/src/components/dropdown/dropdown.tsx
@@ -103,11 +103,13 @@ export class Dropdown {
 
   hasSlotIcon: boolean;
 
+  private readonly internalId = i++;
+
   componentWillLoad() {
     this.hasSlotIcon = !!this.hostElement.querySelector('[slot="icon"]');
 
     if (this.inputId == null) {
-      this.inputId = 'input-dropdown' + i++;
+      this.inputId = 'input-dropdown' + this.internalId;
     }
   }
 
@@ -230,7 +232,7 @@ export class Dropdown {
   render() {
     const ariaInvalidAttr =
       this.status === 'error' || this.invalid ? { 'aria-invalid': true } : {};
-    const helperTextId = `helper-message-${i}`;
+    const helperTextId = `helper-message-${this.internalId}`;
     const ariaDescribedByAttr = { 'aria-describedBy': helperTextId };
 
     return (

--- a/packages/components/src/components/input/input.tsx
+++ b/packages/components/src/components/input/input.tsx
@@ -140,9 +140,11 @@ export class Input {
   /** "forceUpdate" hack, set it to trigger and re-render */
   @State() forceUpdate: string;
 
+  private readonly internalId = i++;
+
   componentWillLoad() {
     if (this.inputId == null) {
-      this.inputId = 'input-' + i++;
+      this.inputId = 'input-' + this.internalId;
     }
     // Default icon for `select` type
     if (this.type === 'select' && this.icon == null) {
@@ -308,7 +310,7 @@ export class Input {
 
     const ariaInvalidAttr =
       this.status === 'error' || this.invalid ? { 'aria-invalid': true } : {};
-    const helperTextId = `helper-message-${i}`;
+    const helperTextId = `helper-message-${this.internalId}`;
     const ariaDescribedByAttr = { 'aria-describedBy': helperTextId };
 
     if (this.type === 'checkbox') {

--- a/packages/components/src/components/radio-button-group/radio-button-group.tsx
+++ b/packages/components/src/components/radio-button-group/radio-button-group.tsx
@@ -2,6 +2,8 @@ import { Component, Element, h, Prop } from '@stencil/core';
 import classNames from 'classnames';
 import statusNote from '../../utils/status-note';
 
+let i = 0;
+
 @Component({
   tag: 'scale-radio-button-group',
   styleUrl: './radio-button-group.css',
@@ -18,6 +20,8 @@ export class RadioButtonGroup {
   /** (optional) Input status */
   @Prop() invalid?: boolean = false;
 
+  private readonly internalId = i++;
+
   componentDidRender() {
     if (this.status !== '') {
       statusNote({
@@ -31,6 +35,7 @@ export class RadioButtonGroup {
   }
 
   render() {
+    const helperTextId = `helper-message-${this.internalId}`;
     return (
       <fieldset class="radio-button-group">
         <legend class="radio-button-group__title">
@@ -43,6 +48,7 @@ export class RadioButtonGroup {
           {this.helperText ? (
             <div
               role="text"
+              id={helperTextId}
               class={this.getCssClassMap()}
               aria-label={this.helperText}
             >

--- a/packages/components/src/components/radio-button/radio-button.tsx
+++ b/packages/components/src/components/radio-button/radio-button.tsx
@@ -62,9 +62,11 @@ export class RadioButton {
   @Event({ eventName: 'scaleChange' })
   scaleChangeLegacy!: EventEmitter<InputChangeEventDetail>;
 
+  private readonly internalId = i++;
+
   componentWillLoad() {
     if (this.inputId == null) {
-      this.inputId = 'input-' + i++;
+      this.inputId = 'input-' + this.internalId;
     }
   }
 
@@ -115,7 +117,7 @@ export class RadioButton {
   render() {
     const ariaInvalidAttr =
       this.status === 'error' || this.invalid ? { 'aria-invalid': true } : {};
-    const helperTextId = `helper-message-${i}`;
+    const helperTextId = `helper-message-${this.internalId}`;
     const ariaDescribedByAttr = { 'aria-describedBy': helperTextId };
 
     return (

--- a/packages/components/src/components/text-field/text-field.tsx
+++ b/packages/components/src/components/text-field/text-field.tsx
@@ -129,17 +129,11 @@ export class TextField {
   /** "forceUpdate" hack, set it to trigger and re-render */
   @State() forceUpdate: string;
 
-  /*remember helper text id number, in case the helper text is shown later on*/
-  private helperTextIdNumber: number;
-  private firstLoad: boolean = true;
+  private readonly internalId = i++;
 
   componentWillLoad() {
     if (this.inputId == null) {
-      this.inputId = 'input-text-field' + i++;
-    }
-    if (this.firstLoad === true) {
-      this.helperTextIdNumber = i;
-      this.firstLoad = false;
+      this.inputId = 'input-text-field' + this.internalId;
     }
   }
 
@@ -211,7 +205,7 @@ export class TextField {
   render() {
     const ariaInvalidAttr =
       this.status === 'error' || this.invalid ? { 'aria-invalid': true } : {};
-    const helperTextId = `helper-message-${this.helperTextIdNumber}`;
+    const helperTextId = `helper-message-${this.internalId}`;
     const ariaDescribedByAttr = { 'aria-describedBy': helperTextId };
     const numericTypes = [
       'number',
@@ -221,6 +215,7 @@ export class TextField {
       'time',
       'datetime-local',
     ];
+
     return (
       <Host>
         {this.styles && <style>{this.styles}</style>}

--- a/packages/components/src/components/text-field/text-field.tsx
+++ b/packages/components/src/components/text-field/text-field.tsx
@@ -129,9 +129,17 @@ export class TextField {
   /** "forceUpdate" hack, set it to trigger and re-render */
   @State() forceUpdate: string;
 
+  /*remember helper text id number, in case the helper text is shown later on*/
+  private helperTextIdNumber: number;
+  private firstLoad: boolean = true;
+
   componentWillLoad() {
     if (this.inputId == null) {
       this.inputId = 'input-text-field' + i++;
+    }
+    if (this.firstLoad === true) {
+      this.helperTextIdNumber = i;
+      this.firstLoad = false;
     }
   }
 
@@ -203,7 +211,7 @@ export class TextField {
   render() {
     const ariaInvalidAttr =
       this.status === 'error' || this.invalid ? { 'aria-invalid': true } : {};
-    const helperTextId = `helper-message-${i}`;
+    const helperTextId = `helper-message-${this.helperTextIdNumber}`;
     const ariaDescribedByAttr = { 'aria-describedBy': helperTextId };
     const numericTypes = [
       'number',
@@ -213,7 +221,6 @@ export class TextField {
       'time',
       'datetime-local',
     ];
-
     return (
       <Host>
         {this.styles && <style>{this.styles}</style>}

--- a/packages/components/src/components/textarea/textarea.tsx
+++ b/packages/components/src/components/textarea/textarea.tsx
@@ -107,10 +107,11 @@ export class Textarea {
   @State() hasFocus: boolean = false;
 
   private focusableElement: HTMLElement;
+  private readonly internalId = i++;
 
   componentWillLoad() {
     if (this.inputId == null) {
-      this.inputId = 'input-textarea' + i++;
+      this.inputId = 'input-textarea' + this.internalId;
     }
   }
 
@@ -170,7 +171,7 @@ export class Textarea {
   render() {
     const ariaInvalidAttr =
       this.status === 'error' || this.invalid ? { 'aria-invalid': true } : {};
-    const helperTextId = `helper-message-${i}`;
+    const helperTextId = `helper-message-${this.internalId}`;
     const ariaDescribedByAttr = { 'aria-describedBy': helperTextId };
     const readonlyAttr = this.readonly ? { readonly: 'readonly' } : {};
 


### PR DESCRIPTION
**Preventing/Solving problems with helper-text id**

Affected components:

- text-field
- dropdown
- dropdown-select
- radiobutton
- radiobutton-group
- checkbox
- input
- textarea
- date-picker