### PR TITLE
feat(menu-flyout): pass `originalEvent` in `scale-select` event

### DIFF
--- a/packages/components/src/components/menu-flyout-item/menu-flyout-item.tsx
+++ b/packages/components/src/components/menu-flyout-item/menu-flyout-item.tsx
@@ -59,10 +59,10 @@ export class MenuFlyoutItem {
   // TODO there is lot of room for improving this, aka edge-cases
   @Method()
   async triggerEvent(
-    eventType: 'keydown' | 'click',
-    key?: 'Enter' | ' ' | 'ArrowRight' | null,
+    event: KeyboardEvent | MouseEvent,
     closeOnSelect: boolean = true
   ) {
+    const { key } = event as KeyboardEvent;
     if (this.disabled) {
       return;
     }
@@ -73,7 +73,13 @@ export class MenuFlyoutItem {
       this.openSublist();
       return;
     }
-    const detail = { eventType, key, item: this.hostElement, closeOnSelect };
+    const detail = {
+      eventType: event.type,
+      key,
+      item: this.hostElement,
+      closeOnSelect,
+      originalEvent: event,
+    };
     emitEvent(this, 'scaleSelect', detail);
   }
 

--- a/packages/components/src/components/menu-flyout-item/readme.md
+++ b/packages/components/src/components/menu-flyout-item/readme.md
@@ -28,7 +28,7 @@
 
 ## Methods
 
-### `triggerEvent(eventType: 'keydown' | 'click', key?: 'Enter' | ' ' | 'ArrowRight' | null, closeOnSelect?: boolean) => Promise<void>`
+### `triggerEvent(event: KeyboardEvent | MouseEvent, closeOnSelect?: boolean) => Promise<void>`
 
 
 

--- a/packages/components/src/components/menu-flyout-list/menu-flyout-list.tsx
+++ b/packages/components/src/components/menu-flyout-list/menu-flyout-list.tsx
@@ -166,7 +166,7 @@ export class MenuFlyoutList {
         this.focusedItemIndex
       ] as HTMLScaleMenuFlyoutItemElement;
       if (item != null) {
-        item.triggerEvent('keydown', event.key, this.closeOnSelect);
+        item.triggerEvent(event, this.closeOnSelect);
       }
     }
   }
@@ -183,7 +183,7 @@ export class MenuFlyoutList {
     ) as HTMLScaleMenuFlyoutItemElement;
     if (item != null) {
       event.stopImmediatePropagation();
-      item.triggerEvent('click', null, this.closeOnSelect);
+      item.triggerEvent(event, this.closeOnSelect);
     }
   }
 


### PR DESCRIPTION
Related to https://github.com/telekom/scale/issues/915#issuecomment-1310460002

> We can include the original click event that has ctrlKey inside the details of the emitted scale-select event. That should be an easy fix. We could name it originalEvent (in a jQuery fashion).

@felix-ico could you please review this one 🙏