### PR TITLE
feat(dropdown-select): add `name` prop

### DIFF
--- a/packages/components/src/components/dropdown-select/dropdown-select.tsx
+++ b/packages/components/src/components/dropdown-select/dropdown-select.tsx
@@ -184,6 +184,7 @@ export class DropdownSelect {
 
   @Prop() comboboxId?: string = 'combobox';
   @Prop() label: string;
+  @Prop() name?: string;
   @Prop() helperText?: string = '';
   @Prop() disabled?: boolean;
   @Prop() readonly?: boolean;

--- a/packages/components/src/components/dropdown-select/readme.md
+++ b/packages/components/src/components/dropdown-select/readme.md
@@ -14,6 +14,7 @@
 | `helperText`  | `helper-text` |             | `string`                                                | `''`              |
 | `invalid`     | `invalid`     |             | `boolean`                                               | `false`           |
 | `label`       | `label`       |             | `string`                                                | `undefined`       |
+| `name`        | `name`        |             | `string`                                                | `undefined`       |
 | `readonly`    | `readonly`    |             | `boolean`                                               | `undefined`       |
 | `transparent` | `transparent` |             | `boolean`                                               | `undefined`       |
 | `value`       | `value`       |             | `any`                                                   | `undefined`       |

--- a/packages/components/src/html/dropdown-select.html
+++ b/packages/components/src/html/dropdown-select.html
@@ -31,6 +31,7 @@
       size="small"
       invalid
       value="caspar"
+      name="foo"
     >
       <scale-dropdown-select-item value="caspar">
         <scale-icon-action-add slot="suffix"></scale-icon-action-add>
@@ -132,7 +133,7 @@
     const ChooseDarioBtn = document.getElementById('choose-dario');
 
     Select.addEventListener('scale-change', function (event) {
-      console.log(event.detail.value);
+      console.log(event.target.name, event.detail.value);
     });
 
     ChooseDarioBtn.addEventListener('click', function () {


### PR DESCRIPTION
Fixes #1360.

This is exclusively only adding the prop to `<scale-dropdown-select>`. So when you listen for the `scale-change` event you can use `event.target.name`.

@filipjnc I think a hidden input element would be best added by yourself as a sibling of the Dropdown Select. If we put it inside the shadow DOM it will have no effect on form submission.

In the near future we could use [`ElementInternals`](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals) to make ["form associated" components](https://web.dev/more-capable-form-controls/). It's currently not supported by Safari, thou there's [a polyfill](https://www.npmjs.com/package/element-internals-polyfill). A there's also [other ways to do it](https://github.com/shoelace-style/shoelace/blob/next/src/internal/form.ts). It's —as always— just a matter of prios…

---
@felix-ico would you be so kind to review this one?