### PR TITLE
feat: add link target variables to menu and footer

### DIFF
--- a/packages/components/src/components/telekom/app-footer/app-footer.tsx
+++ b/packages/components/src/components/telekom/app-footer/app-footer.tsx
@@ -87,6 +87,7 @@ export class AppFooter {
                         <a
                           class="footer-navigation__item-link"
                           href={item.href || 'javascript:void(0);'}
+                          target={item.target || '_self'}
                           onClick={(event) => {
                             if (typeof item.onClick === 'function') {
                               item.onClick(event);

--- a/packages/components/src/components/telekom/app-navigation-user-menu/app-navigation-user-menu.tsx
+++ b/packages/components/src/components/telekom/app-navigation-user-menu/app-navigation-user-menu.tsx
@@ -76,6 +76,7 @@ export class AppNavigationUserMenu {
               return (
                 <a
                   href={item.href || 'javascript:void(0);'}
+                  target={item.target || '_self'}
                   tabindex={0}
                   class="app-navigation-user-menu__item"
                   onClick={(e) => {


### PR DESCRIPTION
Hi there, we're using scale in one of the web applications at TelekomCLOUD marketplace and missing a feature to set the target of the links in the header and footer to `_blank`. 

Unfortunately we were unable to test the framework as the build process always failed at certain points, but I hope it works this way.