### PR TITLE
fix: no value is set in DropdownSelect and SegmentedButton when using vue-router

### DIFF
--- a/packages/components/src/components/dropdown-select/dropdown-select.tsx
+++ b/packages/components/src/components/dropdown-select/dropdown-select.tsx
@@ -29,12 +29,15 @@ enum Actions {
   Type = 'Type',
 }
 
+const isElementValue = (x: unknown):x is Element & {value: string} => typeof (x as {value: unknown}).value === 'string'
+const readValue = (element: Element) => isElementValue(element) ? element.value : null
+
 const readOptions = (
   hostElement: HTMLElement
 ): Array<{ label: string; value: any; ItemElement: VNode }> => {
   return Array.from(hostElement.children).map((x) => ({
     label: x.textContent.trim(),
-    value: x.getAttribute('value'),
+    value: x.getAttribute('value') ?? readValue(x),
     ItemElement: <span innerHTML={x.outerHTML}></span>,
   }));
 };

--- a/packages/components/src/components/segmented-button/segmented-button.tsx
+++ b/packages/components/src/components/segmented-button/segmented-button.tsx
@@ -126,8 +126,8 @@ export class SegmentedButton {
     segments.forEach((segment) => {
       this.position++;
       tempState.push({
-        id: segment.getAttribute('segment-id'),
-        selected: segment.hasAttribute('selected'),
+        id: segment.getAttribute('segment-id') || segment.segmentId,
+        selected: segment.hasAttribute('selected') || segment.selected,
       });
       segment.setAttribute('position', this.position.toString());
       segment.setAttribute(


### PR DESCRIPTION
Like mentonied in an issue before, the vue-router package make some problems with Scale (#1194).

In our project we have found two new problems:
1. The DropdownSelect have no value set, when setting some default.
2. The SegmentedButton ist not selected it default inside ScaleModal (#1580).

For the first point I have two Sandboxes, one with using vue-router and one without it.
[Sandbox 1: DropdownSelect with using vue-router](https://stackblitz.com/edit/vitejs-vite-dlcfr4?file=src%2FApp.vue)
[Sandbox 1: DropdownSelect without vue-router](https://stackblitz.com/edit/vitejs-vite-atvrmi?file=src%2FApp.vue)

For the second point, there is one Sandbox in my linked issue (#1580).

The behaviour is by both the same. It looks like the vue-router package don't allow using the method `getAttribute()` and `hasAttribute()`, so the return value for it is `null` or `""` (empty string). With the code in this PR the problem is fixed for our project and potentially all users who use the vue-router package or something similiar.