### PR TITLE
fix: dropdown still has dark background on hover when the app is in lightmode

### DIFF
--- a/packages/components/src/components/dropdown/dropdown.css
+++ b/packages/components/src/components/dropdown/dropdown.css
@@ -222,6 +222,19 @@ scale-dropdown {
 
 /* Tokens exceptionally hard-coded, instead of using the component variables,
 to fix bug in Firefox/Windows, see https://github.com/telekom/scale/issues/1018) */
+
+[data-mode='light']
+  .dropdown:not(.dropdown--disabled):not(.dropdown--variant-danger)
+  .input__dropdown:hover {
+  background-color: var(--telekom-color-ui-state-fill-hovered);
+}
+
+[data-mode='light']
+  .dropdown:not(.dropdown--disabled).dropdown--variant-danger
+  .input__dropdown:hover {
+  background-color: var(--telekom-color-ui-state-fill-hovered);
+}
+
 [data-mode='dark'] .dropdown .input__dropdown {
   background-color: var(--telekom-color-background-canvas);
 }


### PR DESCRIPTION
This fixes an issue where the dropdown still had the dark background on hover even though the app is in lightmode. It occured when the prefered color scheme was set to dark but the app set to light-mode using the `data-mode` attribute.

The issue is fixed by overwriting the styles for this case.