### PR TITLE
fix: remove firstRender attribute and revert to initial autofocus app…

### DIFF
--- a/packages/components/src/components/tab-header/readme.md
+++ b/packages/components/src/components/tab-header/readme.md
@@ -7,13 +7,14 @@
 
 ## Properties
 
-| Property   | Attribute  | Description                                                                           | Type                 | Default     |
-| ---------- | ---------- | ------------------------------------------------------------------------------------- | -------------------- | ----------- |
-| `disabled` | `disabled` | True for a disabled Tabnavigation                                                     | `boolean`            | `false`     |
-| `selected` | `selected` |                                                                                       | `boolean`            | `undefined` |
-| `size`     | `size`     | (optional) size                                                                       | `"large" \| "small"` | `'small'`   |
-| `small`    | `small`    | <span style="color:red">**[DEPRECATED]**</span> - size should replace small<br/><br/> | `boolean`            | `false`     |
-| `styles`   | `styles`   | (optional) Injected CSS styles                                                        | `string`             | `undefined` |
+| Property    | Attribute    | Description                                                                           | Type                 | Default     |
+| ----------- | ------------ | ------------------------------------------------------------------------------------- | -------------------- | ----------- |
+| `autoFocus` | `auto-focus` | (optional) autoFocus                                                                  | `boolean`            | `undefined` |
+| `disabled`  | `disabled`   | True for a disabled Tabnavigation                                                     | `boolean`            | `false`     |
+| `selected`  | `selected`   |                                                                                       | `boolean`            | `undefined` |
+| `size`      | `size`       | (optional) size                                                                       | `"large" \| "small"` | `'small'`   |
+| `small`     | `small`      | <span style="color:red">**[DEPRECATED]**</span> - size should replace small<br/><br/> | `boolean`            | `false`     |
+| `styles`    | `styles`     | (optional) Injected CSS styles                                                        | `string`             | `undefined` |
 
 
 ----------------------------------------------

--- a/packages/components/src/components/tab-header/tab-header.tsx
+++ b/packages/components/src/components/tab-header/tab-header.tsx
@@ -32,11 +32,11 @@ export class TabHeader {
   @Prop() disabled?: boolean = false;
   /** True for smaller height and font size */
   /** @deprecated - size should replace small */
-  @Prop() small?: boolean = false;  
+  @Prop() small?: boolean = false;
   /** (optional) size  */
   @Prop() size: 'small' | 'large' = 'small';
   /** (optional) autoFocus  */
-  @Prop() autoFocus?: boolean;  
+  @Prop() autoFocus?: boolean;
   /** (optional) Injected CSS styles */
   @Prop() styles?: string;
   @Prop() selected: boolean;

--- a/packages/components/src/components/tab-header/tab-header.tsx
+++ b/packages/components/src/components/tab-header/tab-header.tsx
@@ -32,9 +32,11 @@ export class TabHeader {
   @Prop() disabled?: boolean = false;
   /** True for smaller height and font size */
   /** @deprecated - size should replace small */
-  @Prop() small?: boolean = false;
+  @Prop() small?: boolean = false;  
   /** (optional) size  */
   @Prop() size: 'small' | 'large' = 'small';
+  /** (optional) autoFocus  */
+  @Prop() autoFocus?: boolean;  
   /** (optional) Injected CSS styles */
   @Prop() styles?: string;
   @Prop() selected: boolean;
@@ -50,10 +52,7 @@ export class TabHeader {
       if (newValue === true) {
         // Having focus on the host element, and not on inner elements,
         // is required because screen readers.
-        const firstRender = this.hostElement.getAttribute('first-render');
-        if (!firstRender) {
-          this.hostElement.focus();
-        }
+        this.autoFocus && this.hostElement.focus();
       }
       this.updateSlottedIcon();
     }
@@ -101,6 +100,7 @@ export class TabHeader {
   }
 
   render() {
+    console.log('got autofocus', this.autoFocus)
     return (
       <Host
         id={`scale-tab-header-${this.generatedId}`}

--- a/packages/components/src/components/tab-header/tab-header.tsx
+++ b/packages/components/src/components/tab-header/tab-header.tsx
@@ -52,7 +52,9 @@ export class TabHeader {
       if (newValue === true) {
         // Having focus on the host element, and not on inner elements,
         // is required because screen readers.
-        this.autoFocus && this.hostElement.focus();
+        if (this.autoFocus) {
+          this.hostElement.focus();
+        }
       }
       this.updateSlottedIcon();
     }
@@ -100,7 +102,6 @@ export class TabHeader {
   }
 
   render() {
-    console.log('got autofocus', this.autoFocus)
     return (
       <Host
         id={`scale-tab-header-${this.generatedId}`}

--- a/packages/components/src/components/tab-nav/readme.md
+++ b/packages/components/src/components/tab-nav/readme.md
@@ -7,11 +7,12 @@
 
 ## Properties
 
-| Property | Attribute | Description                                                                           | Type                 | Default     |
-| -------- | --------- | ------------------------------------------------------------------------------------- | -------------------- | ----------- |
-| `size`   | `size`    | (optional) size                                                                       | `"large" \| "small"` | `'small'`   |
-| `small`  | `small`   | <span style="color:red">**[DEPRECATED]**</span> - size should replace small<br/><br/> | `boolean`            | `false`     |
-| `styles` | `styles`  | (optional) Injected CSS styles                                                        | `string`             | `undefined` |
+| Property    | Attribute    | Description                                                                           | Type                 | Default     |
+| ----------- | ------------ | ------------------------------------------------------------------------------------- | -------------------- | ----------- |
+| `autoFocus` | `auto-focus` | (optional) autoFocus                                                                  | `boolean`            | `false`     |
+| `size`      | `size`       | (optional) size                                                                       | `"large" \| "small"` | `'small'`   |
+| `small`     | `small`      | <span style="color:red">**[DEPRECATED]**</span> - size should replace small<br/><br/> | `boolean`            | `false`     |
+| `styles`    | `styles`     | (optional) Injected CSS styles                                                        | `string`             | `undefined` |
 
 
 ----------------------------------------------

--- a/packages/components/src/components/tab-nav/tab-nav.tsx
+++ b/packages/components/src/components/tab-nav/tab-nav.tsx
@@ -36,7 +36,7 @@ export class TabNav {
   /** (optional) size  */
   @Prop() size: 'small' | 'large' = 'small';
   /** (optional) autoFocus  */
-  @Prop() autoFocus: boolean = false;  
+  @Prop() autoFocus: boolean = false;
   /** (optional) Injected CSS styles */
   @Prop() styles?: string;
 
@@ -148,7 +148,7 @@ export class TabNav {
 
   getNextTab() {
     const tabs = this.getAllEnabledTabs();
-    const index = tabs.findIndex((tab) => tab.selected) + 1;  
+    const index = tabs.findIndex((tab) => tab.selected) + 1;
     return tabs[index % tabs.length];
   }
 
@@ -165,7 +165,6 @@ export class TabNav {
   linkPanels() {
     const tabs = this.getAllEnabledTabs();
     const selectedTab = tabs.find((x) => x.selected) || tabs[0];
-
 
     tabs.forEach((tab) => {
       const panel = tab.nextElementSibling;

--- a/packages/components/src/components/tab-nav/tab-nav.tsx
+++ b/packages/components/src/components/tab-nav/tab-nav.tsx
@@ -35,13 +35,13 @@ export class TabNav {
   @Prop() small?: boolean = false;
   /** (optional) size  */
   @Prop() size: 'small' | 'large' = 'small';
+  /** (optional) autoFocus  */
+  @Prop() autoFocus: boolean = false;  
   /** (optional) Injected CSS styles */
   @Prop() styles?: string;
 
   @Listen('click')
   handleClick(event: MouseEvent) {
-    this.removeFirstRenderAttr();
-
     // workaround for slotted icons
     const targetHTMLElement = event.target as HTMLElement;
     const targetTag = targetHTMLElement.tagName.toLowerCase();
@@ -69,8 +69,6 @@ export class TabNav {
 
   @Listen('keydown')
   handleKeydown(event: KeyboardEvent) {
-    this.removeFirstRenderAttr();
-
     const target = event.target as HTMLScaleTabHeaderElement;
     let nextTab;
 
@@ -101,13 +99,6 @@ export class TabNav {
 
     event.preventDefault();
     this.selectTab(nextTab);
-  }
-
-  removeFirstRenderAttr() {
-    const tabs = this.getAllEnabledTabs();
-    tabs.forEach((tab) => {
-      tab.removeAttribute('first-render');
-    });
   }
 
   connectedCallback() {
@@ -157,7 +148,7 @@ export class TabNav {
 
   getNextTab() {
     const tabs = this.getAllEnabledTabs();
-    const index = tabs.findIndex((tab) => tab.selected) + 1;
+    const index = tabs.findIndex((tab) => tab.selected) + 1;  
     return tabs[index % tabs.length];
   }
 
@@ -173,22 +164,16 @@ export class TabNav {
 
   linkPanels() {
     const tabs = this.getAllEnabledTabs();
-    const selectedTab = tabs.find((x) => x.selected);
+    const selectedTab = tabs.find((x) => x.selected) || tabs[0];
+
 
     tabs.forEach((tab) => {
       const panel = tab.nextElementSibling;
       tab.setAttribute('aria-controls', panel.id);
+      tab.setAttribute('auto-focus', this.autoFocus.toString());
       panel.setAttribute('aria-labelledby', tab.id);
-      if (!selectedTab) {
-        // we pass this down to tab-header to prevent the first element to be focused on first render (a11y)
-        tab.setAttribute('first-render', 'true');
-      }
     });
-    if (selectedTab) {
-      this.selectTab(selectedTab);
-    } else {
-      this.selectTab(tabs[0]);
-    }
+    this.selectTab(selectedTab);
   }
 
   reset() {
@@ -223,6 +208,7 @@ export class TabNav {
   }
 
   render() {
+    console.log('PARENT autofocus', this.autoFocus)
     return (
       <Host>
         {this.styles && <style>{this.styles}</style>}

--- a/packages/components/src/components/tab-nav/tab-nav.tsx
+++ b/packages/components/src/components/tab-nav/tab-nav.tsx
@@ -208,7 +208,6 @@ export class TabNav {
   }
 
   render() {
-    console.log('PARENT autofocus', this.autoFocus)
     return (
       <Host>
         {this.styles && <style>{this.styles}</style>}


### PR DESCRIPTION
…roach

this should fix https://github.com/telekom/scale/issues/1372. I am not sure anymore why we did not want an `autoFocus` prop initially and replaced that with a private `firstRender` attribute, but i reverted all changes from [this PR](https://github.com/telekom/scale/pull/1383/files) and added an autofocus prop as the issue reporter suggested 