### PR TITLE
fix(loading-spinner): center the loading icon in align with text

### DIFF
--- a/packages/components/src/components/loading-spinner/loading-spinner.css
+++ b/packages/components/src/components/loading-spinner/loading-spinner.css
@@ -90,6 +90,11 @@
   text-align: left;
 }
 
+.spinner .spinner__container {
+  align-items: center;
+  display: inline-flex;
+}
+
 .spinner .spinner__container .spinner__circle {
   animation: rotate 2s linear infinite;
   z-index: 2;


### PR DESCRIPTION
center the loading icon (in align with text)