### PR TITLE
fix(telekom-footer-extended-navigation): css fixes

### DIFF
--- a/packages/components/src/components/telekom/telekom-footer-extended-navigation/telekom-footer-extended-navigation.css
+++ b/packages/components/src/components/telekom/telekom-footer-extended-navigation/telekom-footer-extended-navigation.css
@@ -43,6 +43,8 @@
   font-size: var(--telekom-typography-font-size-body);
   color: var(--link-color);
   margin-top: var(--telekom-spacing-unit-x5);
+  border: none;
+  line-height: 22px;
 }
 
 [part~='telekom-footer-extended-navigation'] :where(li:first-child) {
@@ -55,13 +57,9 @@
 
 [part~='telekom-footer-extended-navigation'] :where(a):hover {
   color: var(--telekom-color-text-and-icon-primary-hovered);
-  /* need to overwrite <a> border from telekom-footer.css */
-  border-bottom: 1px solid transparent;
 }
 [part~='telekom-footer-extended-navigation'] :where(a):active {
   color: var(--telekom-color-text-and-icon-primary-pressed);
-  /* need to overwrite <a> border from telekom-footer.css */
-  border-bottom: 1px solid transparent;
 }
 
 [part~='telekom-footer-extended-navigation']
@@ -88,7 +86,7 @@ scale-telekom-footer-extended-navigation-column:first-of-type {
 
 @media screen and (--md) {
   [part~='telekom-footer-extended-navigation'] :where(li:first-child) {
-    padding-top: var(--telekom-spacing-unit-x6);
+    padding-top: var(--telekom-spacing-unit-x5);
   }
   [part~='extended-navigation-container'] {
     display: grid;

--- a/packages/components/src/components/telekom/telekom-footer-extended-navigation/telekom-footer-extended-navigation.css
+++ b/packages/components/src/components/telekom/telekom-footer-extended-navigation/telekom-footer-extended-navigation.css
@@ -48,7 +48,7 @@
 }
 
 [part~='telekom-footer-extended-navigation'] :where(li:first-child) {
-  padding-top: 0;
+  padding-top: 1px;
 }
 
 [part~='telekom-footer-extended-navigation'] :where(li:first-child) a {

--- a/packages/components/src/components/telekom/telekom-footer-extended-navigation/telekom-footer-extended-navigation.css
+++ b/packages/components/src/components/telekom/telekom-footer-extended-navigation/telekom-footer-extended-navigation.css
@@ -108,4 +108,8 @@ scale-telekom-footer-extended-navigation-column:first-of-type {
   [part~='telekom-footer-extended-navigation'] :where(ul) {
     padding-bottom: 20px;
   }
+
+  [part~='telekom-footer-extended-navigation'] :where(li:first-child) {
+    padding-top: 0px;
+  }
 }

--- a/packages/components/src/components/telekom/telekom-footer-extended-navigation/telekom-footer-extended-navigation.css
+++ b/packages/components/src/components/telekom/telekom-footer-extended-navigation/telekom-footer-extended-navigation.css
@@ -40,11 +40,10 @@
 }
 
 [part~='telekom-footer-extended-navigation'] :where(a) {
-  font-size: var(--telekom-typography-font-size-body);
+  font: var(--telekom-text-style-body);
   color: var(--link-color);
   margin-top: var(--telekom-spacing-unit-x5);
   border: none;
-  line-height: 22px;
 }
 
 [part~='telekom-footer-extended-navigation'] :where(li:first-child) {
@@ -102,5 +101,11 @@ scale-telekom-footer-extended-navigation-column:first-of-type {
     margin-top: var(--telekom-spacing-unit-x12);
     padding-bottom: 0;
     border-bottom: 0;
+  }
+}
+
+@media screen and (--sm-) {
+  [part~='telekom-footer-extended-navigation'] :where(ul) {
+    padding-bottom: 20px;
   }
 }


### PR DESCRIPTION
Old:

![image (29)](https://github.com/telekom/scale/assets/126784820/62be7326-67bf-4114-9c2e-9ea85a5771a9)
Updated:
<img width="394" alt="Screenshot 2023-06-02 at 5 58 03 PM" src="https://github.com/telekom/scale/assets/126784820/efde378d-b74b-4c8e-b104-462881c391f0">
