### PR TITLE
fix: a11y feedback

### DIFF
--- a/packages/components/src/components/dropdown-select/dropdown-select.css
+++ b/packages/components/src/components/dropdown-select/dropdown-select.css
@@ -285,3 +285,30 @@
 [part~='has-helper-text'] [part~='combobox-container'] {
   margin-bottom: var(--spacing-x-for-helper-text);
 }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+.hcm-disabled {
+  display: none;
+}
+
+@media screen and (forced-colors: active), (-ms-high-contrast: active) {
+  [part='listbox-pad'] {
+    outline: var(--focus-outline);
+    outline-offset: -2px;
+    border-radius: var(--radius);
+  }
+  .hcm-disabled {
+    display: block;
+  }
+}

--- a/packages/components/src/components/dropdown-select/dropdown-select.tsx
+++ b/packages/components/src/components/dropdown-select/dropdown-select.tsx
@@ -204,6 +204,10 @@ export class DropdownSelect {
   @Prop() floatingStrategy: 'absolute' | 'fixed' = 'absolute';
   /** (optional) to hide the label */
   @Prop() hideLabelVisually?: boolean = false;
+  /** (optional) Screen reader text appended to the selected element */
+  @Prop() ariaLabelSelected?: string = 'selected';
+  /** (optional) Text displayed in high contrast mode only to indicate disabled state */
+  @Prop() hcmLabelDisabled?: string = 'this field is disabled';
 
   @Event({ eventName: 'scale-change' }) scaleChange!: EventEmitter<void>;
   @Event({ eventName: 'scale-focus' }) scaleFocus!: EventEmitter<void>;
@@ -476,9 +480,14 @@ export class DropdownSelect {
                       >
                         {ItemElement}
                         {value === this.value ? (
-                          <scale-icon-action-checkmark
-                            size={16}
-                          ></scale-icon-action-checkmark>
+                          <div>
+                            <scale-icon-action-checkmark
+                              size={16}
+                            ></scale-icon-action-checkmark>
+                            <span class="sr-only">
+                              {this.ariaLabelSelected}
+                            </span>
+                          </div>
                         ) : null}
                       </div>
                     )
@@ -506,7 +515,12 @@ export class DropdownSelect {
             <scale-helper-text
               helperText={this.helperText}
               variant={this.invalid ? 'danger' : this.variant}
+              id={helperTextId}
             ></scale-helper-text>
+          )}
+
+          {this.disabled && (
+            <div class="hcm-disabled">{this.hcmLabelDisabled}</div>
           )}
         </div>
       </Host>

--- a/packages/components/src/components/dropdown-select/readme.md
+++ b/packages/components/src/components/dropdown-select/readme.md
@@ -7,20 +7,22 @@
 
 ## Properties
 
-| Property            | Attribute             | Description                  | Type                                                    | Default           |
-| ------------------- | --------------------- | ---------------------------- | ------------------------------------------------------- | ----------------- |
-| `comboboxId`        | `combobox-id`         |                              | `string`                                                | `'combobox'`      |
-| `disabled`          | `disabled`            |                              | `boolean`                                               | `undefined`       |
-| `floatingStrategy`  | `floating-strategy`   |                              | `"absolute" \| "fixed"`                                 | `'absolute'`      |
-| `helperText`        | `helper-text`         |                              | `string`                                                | `''`              |
-| `hideLabelVisually` | `hide-label-visually` | (optional) to hide the label | `boolean`                                               | `false`           |
-| `invalid`           | `invalid`             |                              | `boolean`                                               | `false`           |
-| `label`             | `label`               |                              | `string`                                                | `undefined`       |
-| `name`              | `name`                |                              | `string`                                                | `undefined`       |
-| `readonly`          | `readonly`            |                              | `boolean`                                               | `undefined`       |
-| `transparent`       | `transparent`         |                              | `boolean`                                               | `undefined`       |
-| `value`             | `value`               |                              | `any`                                                   | `undefined`       |
-| `variant`           | `variant`             |                              | `"danger" \| "informational" \| "success" \| "warning"` | `'informational'` |
+| Property            | Attribute             | Description                                                                     | Type                                                    | Default                    |
+| ------------------- | --------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------- | -------------------------- |
+| `ariaLabelSelected` | `aria-label-selected` | (optional) Screen reader text appended to the selected element                  | `string`                                                | `'selected'`               |
+| `comboboxId`        | `combobox-id`         |                                                                                 | `string`                                                | `'combobox'`               |
+| `disabled`          | `disabled`            |                                                                                 | `boolean`                                               | `undefined`                |
+| `floatingStrategy`  | `floating-strategy`   |                                                                                 | `"absolute" \| "fixed"`                                 | `'absolute'`               |
+| `hcmLabelDisabled`  | `hcm-label-disabled`  | (optional) Text displayed in high contrast mode only to indicate disabled state | `string`                                                | `'this field is disabled'` |
+| `helperText`        | `helper-text`         |                                                                                 | `string`                                                | `''`                       |
+| `hideLabelVisually` | `hide-label-visually` | (optional) to hide the label                                                    | `boolean`                                               | `false`                    |
+| `invalid`           | `invalid`             |                                                                                 | `boolean`                                               | `false`                    |
+| `label`             | `label`               |                                                                                 | `string`                                                | `undefined`                |
+| `name`              | `name`                |                                                                                 | `string`                                                | `undefined`                |
+| `readonly`          | `readonly`            |                                                                                 | `boolean`                                               | `undefined`                |
+| `transparent`       | `transparent`         |                                                                                 | `boolean`                                               | `undefined`                |
+| `value`             | `value`               |                                                                                 | `any`                                                   | `undefined`                |
+| `variant`           | `variant`             |                                                                                 | `"danger" \| "informational" \| "success" \| "warning"` | `'informational'`          |
 
 
 ## Events


### PR DESCRIPTION
- [x] tabfocus not visible on error
- [x] selected list item not output by screen reader
    added a span as discussed
- [x] Error message (helper text) not output by screen reader 

HCM 
- [x] disabled element not visible 
- [x] border not visible 

DISABLED
- [ ] operation instruction is output with wrong pronounciation on disabled drodpown-select
- [ ] element is output with 2 roles: "Problem: Disabled: the screen reader outputs the element with 2 roles= “Ausklappliste” (English: dropdown) and “listbox”. More than one role is confusing for screen reader users."
- [ ] disabled screen reader outputs message twice 

These issues I could not reproduce, there is some label for a disabled dropdown-select referenced in the feedback we got but i could not see it in storybook or anywhere in the code 

<img width="412" alt="Screenshot 2023-07-03 at 17 29 27" src="https://github.com/telekom/scale/assets/97440128/65502ec5-1430-4ca3-be50-53cf885f4970">

