### PR TITLE
fix: unnecessary if statement in telekom-nav-item on active watcher

### DIFF
--- a/packages/components/src/components/telekom/telekom-nav-item/telekom-nav-item.tsx
+++ b/packages/components/src/components/telekom/telekom-nav-item/telekom-nav-item.tsx
@@ -48,12 +48,7 @@ export class TelekomNavItem {
     if (this.linkElement == null) {
       return;
     }
-    if (this.variant === 'lang-switcher' && this.active) {
-      toggleAriaCurrent(this.linkElement, newValue, 'true');
-    }
-    if (this.variant === 'main-nav' && this.active) {
-      toggleAriaCurrent(this.linkElement, newValue, 'true');
-    }
+    toggleAriaCurrent(this.linkElement, newValue, 'true');
   }
 
   connectedCallback() {


### PR DESCRIPTION
Hi,

recently started working with this library in Vue 3. I created the `scale-telekom-header` and added the `lang-switcher`.

But when I tried to change the `active` prop I ran into the issue that both languages would be "active" (bold font weight).

Here is the template:
```html
<scale-telekom-nav-list variant="lang-switcher" slot="lang-switcher" alignment="right">
   <scale-telekom-nav-item variant="lang-switcher" v-for="lang in $i18n.availableLocales" :key="'mobile'+lang" :active="$i18n.locale === lang">
     <a href="#" @click="changeLocale(lang)">{{ lang.toLocaleUpperCase() }}</a>
   </scale-telekom-nav-item>
</scale-telekom-nav-list>
```

When I entered the code, I found an unnecessary if statement, so I fixed it with this PR.