### PR TITLE
fix: allow setting href on footer logo

### DIFF
--- a/packages/components/src/components/telekom/logo/logo.tsx
+++ b/packages/components/src/components/telekom/logo/logo.tsx
@@ -93,7 +93,7 @@ export class Logo {
               window.scrollTo({ top: 0 });
             }
           }}
-          title={this.logoHideTitle ? '' : this.logoTitle}
+          title={this.logoHideTitle ? undefined : this.logoTitle}
           aria-describedby={this.logoAriaDescribedBy}
           aria-hidden={this.logoAriaHidden}
           tabindex={this.logoAriaHidden ? -1 : 0}

--- a/packages/components/src/components/telekom/telekom-footer/readme.md
+++ b/packages/components/src/components/telekom/telekom-footer/readme.md
@@ -5,6 +5,15 @@
 <!-- Auto Generated Below -->
 
 
+## Properties
+
+| Property        | Attribute         | Description                        | Type      | Default                 |
+| --------------- | ----------------- | ---------------------------------- | --------- | ----------------------- |
+| `logoHideTitle` | `logo-hide-title` | (optional) set logo specific title | `boolean` | `false`                 |
+| `logoHref`      | `logo-href`       | (optional) Logo link               | `string`  | `'javascript:void(0);'` |
+| `logoTitle`     | `logo-title`      | (optional) set logo specific title | `string`  | `'Telekom Logo'`        |
+
+
 ## Shadow Parts
 
 | Part           | Description |

--- a/packages/components/src/components/telekom/telekom-footer/telekom-footer-content.tsx
+++ b/packages/components/src/components/telekom/telekom-footer/telekom-footer-content.tsx
@@ -40,7 +40,8 @@ export class TelekomFooterContent {
                 }}
                 transparent
                 href={this.logoHref}
-                title={this.logoHideTitle ? '' : this.logoTitle}
+                logoHideTitle={this.logoHideTitle}
+                logoTitle={this.logoHideTitle ? undefined : this.logoTitle}
               ></scale-logo>
             </div>
             <div part="body">

--- a/packages/components/src/components/telekom/telekom-footer/telekom-footer-content.tsx
+++ b/packages/components/src/components/telekom/telekom-footer/telekom-footer-content.tsx
@@ -9,7 +9,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { Component, h, Host } from '@stencil/core';
+import { Component, h, Host, Prop } from '@stencil/core';
 
 @Component({
   tag: 'scale-telekom-footer-content',
@@ -17,6 +17,13 @@ import { Component, h, Host } from '@stencil/core';
   shadow: true,
 })
 export class TelekomFooterContent {
+  /** (optional) Logo link */
+  @Prop() logoHref?: string = 'javascript:void(0);';
+  /** (optional) set logo specific title */
+  @Prop() logoTitle?: string = 'Telekom Logo';
+  /** (optional) set logo specific title */
+  @Prop() logoHideTitle?: boolean = false;
+
   render() {
     return (
       <Host>
@@ -32,6 +39,8 @@ export class TelekomFooterContent {
                     'var(--telekom-line-weight-highlight) solid var(--telekom-color-functional-focus-on-dark-background)',
                 }}
                 transparent
+                href={this.logoHref}
+                title={this.logoHideTitle ? '' : this.logoTitle}
               ></scale-logo>
             </div>
             <div part="body">

--- a/packages/storybook-vue/stories/components/telekom-footer/FooterContent.vue
+++ b/packages/storybook-vue/stories/components/telekom-footer/FooterContent.vue
@@ -1,0 +1,10 @@
+<script>
+  export default {
+    name: 'FooterContent',
+    props: {
+        logoHref: { type: String, default: 'javascript:void(0);' },
+        logoTitle: { type: String, default: 'Telekom Logo' },
+        logoHideTitle: { type: Boolean, default: false }
+    }
+  };
+</script>

--- a/packages/storybook-vue/stories/components/telekom-footer/TelekomFooter.stories.mdx
+++ b/packages/storybook-vue/stories/components/telekom-footer/TelekomFooter.stories.mdx
@@ -2,10 +2,12 @@ import { Meta, ArgsTable, Story, Canvas } from '@storybook/addon-docs';
 import TelekomFooter from './Footer.vue';
 import TelekomFooterDataBackCompat from './TelekomFooterDataBackCompat.vue';
 import { footerNavigation } from './fixtures';
+import FooterContent from './FooterContent.vue';
 
 <Meta
   title="Components/Telekom Footer"
   component={TelekomFooter}
+  subcomponents={{'Telekom Footer Content': FooterContent}}
   argTypes={{
     type: {
       control: { type: 'select' },


### PR DESCRIPTION
fixes https://github.com/telekom/scale/issues/2119

allow setting footer logo link and title. 

@acstll I'm not really sure how to document these props in storybook though, as they are technically for the child component `telekom-footer-content`, which doesn't have its own storybook page.  Do you have any ideas on that?