### PR TITLE
fix: set scrolled attribute only when offset is larger than the header

### DIFF
--- a/packages/components/src/components/telekom/telekom-header/telekom-header.tsx
+++ b/packages/components/src/components/telekom/telekom-header/telekom-header.tsx
@@ -47,7 +47,7 @@ export class TelekomHeader {
 
   @Listen('scroll', { target: 'document' })
   onScroll() {
-    this.scrolled = window.pageYOffset > 2;
+    this.scrolled = window.pageYOffset > 48;
     this.scrolledBack =
       this.pageYOffset !== window.pageYOffset && window.pageYOffset <= 0;
     this.pageYOffset = pageYOffset;

--- a/packages/components/src/components/telekom/telekom-header/telekom-header.tsx
+++ b/packages/components/src/components/telekom/telekom-header/telekom-header.tsx
@@ -47,6 +47,8 @@ export class TelekomHeader {
 
   @Listen('scroll', { target: 'document' })
   onScroll() {
+    // 48px is the height of the header, set scrolled when the user scrolls past it
+    // todo: calculate this value dynamically (for slim header, smaller viewports, etc)
     this.scrolled = window.pageYOffset > 48;
     this.scrolledBack =
       this.pageYOffset !== window.pageYOffset && window.pageYOffset <= 0;


### PR DESCRIPTION
fix for https://github.com/telekom/scale/issues/2130