### PR TITLE
fix: allow sorting by german date format

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
     "@types/lodash": "4.14.149",
     "@types/resize-observer-browser": "^0.1.6",
     "babel-loader": "^8.1.0",
-    "date-fns": "^2.6.0",
+    "date-fns": "^2.30.0",
     "express": "^4.17.1",
     "fast-glob": "^3.2.4",
     "file-loader": "^6.0.0",

--- a/packages/components/src/components/data-grid/cell-handlers/cell-interface.ts
+++ b/packages/components/src/components/data-grid/cell-handlers/cell-interface.ts
@@ -16,7 +16,7 @@ export interface Cell {
     mobileTitle?: boolean;
     resizable?: boolean;
     sortable?: boolean;
-    sortBy?: 'number' | 'text';
+    sortBy?: 'number' | 'text' | 'date';
     stretchWeight?: number;
     textAlign?: 'left' | 'center' | 'right';
     visible?: boolean;

--- a/packages/components/src/components/data-grid/cell-handlers/date-cell.tsx
+++ b/packages/components/src/components/data-grid/cell-handlers/date-cell.tsx
@@ -21,7 +21,7 @@ import { Cell } from './cell-interface';
 
 export const DateCell: Cell = {
   defaults: {
-    sortBy: 'text',
+    sortBy: 'date',
   },
   render: ({ content, isAutoWidthCheck }) => {
     let value = content;

--- a/packages/components/src/components/data-grid/data-grid.tsx
+++ b/packages/components/src/components/data-grid/data-grid.tsx
@@ -429,7 +429,7 @@ export class DataGrid {
 
         const dateObjectA = getDateObject(a[columnIndex]);
         const dateObjectB = getDateObject(b[columnIndex]);
-        //valueOf here for typescript to not complain about dateObjectA and dateObjectB not being numbers
+        // valueOf here for typescript to not complain about dateObjectA and dateObjectB not being numbers
         return sortDirection === 'ascending'
           ? dateObjectA.valueOf() - dateObjectB.valueOf()
           : dateObjectB.valueOf() - dateObjectA.valueOf();

--- a/packages/components/src/components/data-grid/data-grid.tsx
+++ b/packages/components/src/components/data-grid/data-grid.tsx
@@ -413,10 +413,32 @@ export class DataGrid {
   }
 
   sortTable(sortDirection, type, columnIndex) {
+    const format = this.fields[columnIndex].format;
     if (sortDirection === 'none') {
       this.rows.sort((a, b) => {
         return a.initialIndex - b.initialIndex;
       });
+    } else if (type === 'date' && format) {
+      const splitRegex = /[./]/
+      if (format && format === 'DD.MM.YYYY' || format && format === 'DD/MM/YYYY')  {
+        if (sortDirection === 'ascending') {
+          this.rows.sort((a, b) => {
+            var aDateParts = a[columnIndex].split(splitRegex)
+            var aDateObject = new Date(+aDateParts[2], aDateParts[1] - 1, +aDateParts[0]); 
+            var bDateParts = b[columnIndex].split(splitRegex)
+            var bDateObject = new Date(+bDateParts[2], bDateParts[1] - 1, +bDateParts[0]); 
+            return aDateObject.valueOf() > bDateObject.valueOf() ? -1 : aDateObject.valueOf() < bDateObject.valueOf() ? 1 : 0;
+          })            
+        } else if (sortDirection === 'descending') {
+          this.rows.sort((a, b) => {
+            var aDateParts = a[columnIndex].split(splitRegex)
+            var aDateObject = new Date(+aDateParts[2], aDateParts[1] - 1, +aDateParts[0]); 
+            var bDateParts = b[columnIndex].split(splitRegex)
+            var bDateObject = new Date(+bDateParts[2], bDateParts[1] - 1, +bDateParts[0]); 
+            return aDateObject.valueOf() < bDateObject.valueOf() ? -1 : aDateObject.valueOf() >  bDateObject.valueOf() ? 1 : 0;
+          })                
+        }
+      }
     } else {
       switch (
         (CELL_TYPES[type] &&
@@ -425,6 +447,7 @@ export class DataGrid {
         CELL_DEFAULTS.sortBy
       ) {
         case 'text':
+        case 'date':
           if (sortDirection === 'ascending') {
             this.rows.sort((a, b) => {
               const textA = a[columnIndex].toLowerCase();

--- a/packages/components/src/components/data-grid/data-grid.tsx
+++ b/packages/components/src/components/data-grid/data-grid.tsx
@@ -28,10 +28,7 @@ import {
 import classNames from 'classnames';
 import { emitEvent } from '../../utils/utils';
 
-import { 
-  parse
- } from 'date-fns'
-
+import { parse } from 'date-fns';
 
 // [ ] add options to show nested content without the html column
 // [ ] add options to pre-expand all html content
@@ -423,21 +420,21 @@ export class DataGrid {
       this.rows.sort((a, b) => {
         return a.initialIndex - b.initialIndex;
       });
-    }
-    else if (type === 'date' && format) {
+    } else if (type === 'date' && format) {
       this.rows.sort((a, b) => {
         const getDateObject = (dateString) => {
-          const parsed = parse(dateString, format, new Date())
-          return parsed
+          const parsed = parse(dateString, format, new Date());
+          return parsed;
         };
-  
+
         const dateObjectA = getDateObject(a[columnIndex]);
         const dateObjectB = getDateObject(b[columnIndex]);
         //valueOf here for typescript to not complain about dateObjectA and dateObjectB not being numbers
-        return sortDirection === 'ascending' ? dateObjectA.valueOf() - dateObjectB.valueOf() : dateObjectB.valueOf() - dateObjectA.valueOf();
+        return sortDirection === 'ascending'
+          ? dateObjectA.valueOf() - dateObjectB.valueOf()
+          : dateObjectB.valueOf() - dateObjectA.valueOf();
       });
-    }    
-     else {
+    } else {
       switch (
         (CELL_TYPES[type] &&
           CELL_TYPES[type].defaults &&

--- a/packages/components/src/components/data-grid/data-grid.tsx
+++ b/packages/components/src/components/data-grid/data-grid.tsx
@@ -426,14 +426,14 @@ export class DataGrid {
       ) {
         if (sortDirection === 'ascending') {
           this.rows.sort((a, b) => {
-            var aDateParts = a[columnIndex].split(splitRegex);
-            var aDateObject = new Date(
+            const aDateParts = a[columnIndex].split(splitRegex);
+            const aDateObject = new Date(
               +aDateParts[2],
               aDateParts[1] - 1,
               +aDateParts[0]
             );
-            var bDateParts = b[columnIndex].split(splitRegex);
-            var bDateObject = new Date(
+            const bDateParts = b[columnIndex].split(splitRegex);
+            const bDateObject = new Date(
               +bDateParts[2],
               bDateParts[1] - 1,
               +bDateParts[0]
@@ -446,14 +446,14 @@ export class DataGrid {
           });
         } else if (sortDirection === 'descending') {
           this.rows.sort((a, b) => {
-            var aDateParts = a[columnIndex].split(splitRegex);
-            var aDateObject = new Date(
+            const aDateParts = a[columnIndex].split(splitRegex);
+            const aDateObject = new Date(
               +aDateParts[2],
               aDateParts[1] - 1,
               +aDateParts[0]
             );
-            var bDateParts = b[columnIndex].split(splitRegex);
-            var bDateObject = new Date(
+            const bDateParts = b[columnIndex].split(splitRegex);
+            const bDateObject = new Date(
               +bDateParts[2],
               bDateParts[1] - 1,
               +bDateParts[0]

--- a/packages/components/src/components/data-grid/data-grid.tsx
+++ b/packages/components/src/components/data-grid/data-grid.tsx
@@ -28,6 +28,11 @@ import {
 import classNames from 'classnames';
 import { emitEvent } from '../../utils/utils';
 
+import { 
+  parse
+ } from 'date-fns'
+
+
 // [ ] add options to show nested content without the html column
 // [ ] add options to pre-expand all html content
 // [ ] Uber cell type where all options are available for user
@@ -418,55 +423,21 @@ export class DataGrid {
       this.rows.sort((a, b) => {
         return a.initialIndex - b.initialIndex;
       });
-    } else if (type === 'date' && format) {
-      const splitRegex = /[./]/;
-      if (
-        (format && format === 'DD.MM.YYYY') ||
-        (format && format === 'DD/MM/YYYY')
-      ) {
-        if (sortDirection === 'ascending') {
-          this.rows.sort((a, b) => {
-            const aDateParts = a[columnIndex].split(splitRegex);
-            const aDateObject = new Date(
-              +aDateParts[2],
-              aDateParts[1] - 1,
-              +aDateParts[0]
-            );
-            const bDateParts = b[columnIndex].split(splitRegex);
-            const bDateObject = new Date(
-              +bDateParts[2],
-              bDateParts[1] - 1,
-              +bDateParts[0]
-            );
-            return aDateObject.valueOf() > bDateObject.valueOf()
-              ? -1
-              : aDateObject.valueOf() < bDateObject.valueOf()
-              ? 1
-              : 0;
-          });
-        } else if (sortDirection === 'descending') {
-          this.rows.sort((a, b) => {
-            const aDateParts = a[columnIndex].split(splitRegex);
-            const aDateObject = new Date(
-              +aDateParts[2],
-              aDateParts[1] - 1,
-              +aDateParts[0]
-            );
-            const bDateParts = b[columnIndex].split(splitRegex);
-            const bDateObject = new Date(
-              +bDateParts[2],
-              bDateParts[1] - 1,
-              +bDateParts[0]
-            );
-            return aDateObject.valueOf() < bDateObject.valueOf()
-              ? -1
-              : aDateObject.valueOf() > bDateObject.valueOf()
-              ? 1
-              : 0;
-          });
-        }
-      }
-    } else {
+    }
+    else if (type === 'date' && format) {
+      this.rows.sort((a, b) => {
+        const getDateObject = (dateString) => {
+          const parsed = parse(dateString, format, new Date())
+          return parsed
+        };
+  
+        const dateObjectA = getDateObject(a[columnIndex]);
+        const dateObjectB = getDateObject(b[columnIndex]);
+        //valueOf here for typescript to not complain about dateObjectA and dateObjectB not being numbers
+        return sortDirection === 'ascending' ? dateObjectA.valueOf() - dateObjectB.valueOf() : dateObjectB.valueOf() - dateObjectA.valueOf();
+      });
+    }    
+     else {
       switch (
         (CELL_TYPES[type] &&
           CELL_TYPES[type].defaults &&

--- a/packages/components/src/components/data-grid/data-grid.tsx
+++ b/packages/components/src/components/data-grid/data-grid.tsx
@@ -419,24 +419,51 @@ export class DataGrid {
         return a.initialIndex - b.initialIndex;
       });
     } else if (type === 'date' && format) {
-      const splitRegex = /[./]/
-      if (format && format === 'DD.MM.YYYY' || format && format === 'DD/MM/YYYY')  {
+      const splitRegex = /[./]/;
+      if (
+        (format && format === 'DD.MM.YYYY') ||
+        (format && format === 'DD/MM/YYYY')
+      ) {
         if (sortDirection === 'ascending') {
           this.rows.sort((a, b) => {
-            var aDateParts = a[columnIndex].split(splitRegex)
-            var aDateObject = new Date(+aDateParts[2], aDateParts[1] - 1, +aDateParts[0]); 
-            var bDateParts = b[columnIndex].split(splitRegex)
-            var bDateObject = new Date(+bDateParts[2], bDateParts[1] - 1, +bDateParts[0]); 
-            return aDateObject.valueOf() > bDateObject.valueOf() ? -1 : aDateObject.valueOf() < bDateObject.valueOf() ? 1 : 0;
-          })            
+            var aDateParts = a[columnIndex].split(splitRegex);
+            var aDateObject = new Date(
+              +aDateParts[2],
+              aDateParts[1] - 1,
+              +aDateParts[0]
+            );
+            var bDateParts = b[columnIndex].split(splitRegex);
+            var bDateObject = new Date(
+              +bDateParts[2],
+              bDateParts[1] - 1,
+              +bDateParts[0]
+            );
+            return aDateObject.valueOf() > bDateObject.valueOf()
+              ? -1
+              : aDateObject.valueOf() < bDateObject.valueOf()
+              ? 1
+              : 0;
+          });
         } else if (sortDirection === 'descending') {
           this.rows.sort((a, b) => {
-            var aDateParts = a[columnIndex].split(splitRegex)
-            var aDateObject = new Date(+aDateParts[2], aDateParts[1] - 1, +aDateParts[0]); 
-            var bDateParts = b[columnIndex].split(splitRegex)
-            var bDateObject = new Date(+bDateParts[2], bDateParts[1] - 1, +bDateParts[0]); 
-            return aDateObject.valueOf() < bDateObject.valueOf() ? -1 : aDateObject.valueOf() >  bDateObject.valueOf() ? 1 : 0;
-          })                
+            var aDateParts = a[columnIndex].split(splitRegex);
+            var aDateObject = new Date(
+              +aDateParts[2],
+              aDateParts[1] - 1,
+              +aDateParts[0]
+            );
+            var bDateParts = b[columnIndex].split(splitRegex);
+            var bDateObject = new Date(
+              +bDateParts[2],
+              bDateParts[1] - 1,
+              +bDateParts[0]
+            );
+            return aDateObject.valueOf() < bDateObject.valueOf()
+              ? -1
+              : aDateObject.valueOf() > bDateObject.valueOf()
+              ? 1
+              : 0;
+          });
         }
       }
     } else {

--- a/packages/storybook-vue/stories/components/data-grid/DataGrid.stories.mdx
+++ b/packages/storybook-vue/stories/components/data-grid/DataGrid.stories.mdx
@@ -439,6 +439,11 @@ Email label is partially beautified by automatically removing the protocol (`mai
 
 Expected format: date/time `string`, eg `'10:23:00'`
 
+##### Unique options, and their defaults
+
+- `format?: string = 'MM.dd.yyyy'`
+the date is parsed via date-fn, see [date-fn docs](https://date-fns.org/v2.30.0/docs/parse) for more info and additional formatting options, eg: `'dd.MM.yyyy'`
+
 <Canvas withSource="close">
   <Story name="Date Cell">
     {`<content>

--- a/packages/storybook-vue/stories/components/data-grid/DataGrid.stories.mdx
+++ b/packages/storybook-vue/stories/components/data-grid/DataGrid.stories.mdx
@@ -442,7 +442,8 @@ Expected format: date/time `string`, eg `'10:23:00'`
 ##### Unique options, and their defaults
 
 - `format?: string = 'MM.dd.yyyy'`
-the date is parsed via date-fn, see [date-fn docs](https://date-fns.org/v2.30.0/docs/parse) for more info and additional formatting options, eg: `'dd.MM.yyyy'`
+
+to properly sort by date, the date string value is parsed according to this format. For more info and additional formatting options, e.g. `'dd/MM/yyyy'` check the [date-fn docs](https://date-fns.org/v2.30.0/docs/parse).
 
 <Canvas withSource="close">
   <Story name="Date Cell">

--- a/yarn.lock
+++ b/yarn.lock
@@ -2991,6 +2991,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.21.0":
+  version "7.23.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.2.tgz#062b0ac103261d68a966c4c7baf2ae3e62ec3885"
+  integrity sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/runtime@^7.7.6":
   version "7.17.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
@@ -9124,10 +9131,12 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-date-fns@^2.6.0:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.15.0.tgz"
-  integrity sha512-ZCPzAMJZn3rNUvvQIMlXhDr4A+Ar07eLeGsGREoWU19a3Pqf5oYa+ccd+B3F6XVtQY6HANMFdOQ8A+ipFnvJdQ==
+date-fns@^2.30.0:
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
+  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
+  dependencies:
+    "@babel/runtime" "^7.21.0"
 
 dateformat@3.0.2:
   version "3.0.2"
@@ -16621,6 +16630,11 @@ regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7:
   version "0.13.7"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz"
   integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
+
+regenerator-runtime@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz#5e19d68eb12d486f797e15a3c6a918f7cec5eb45"
+  integrity sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==
 
 regenerator-transform@^0.14.2:
   version "0.14.5"


### PR DESCRIPTION
this fixes a supportpal issue (56456) - sorting by german date format in data grid date cell
