### PR TITLE
feat(dropdown-select): add disabled state for individual options

### DIFF
--- a/packages/components/src/components/dropdown-select-item/dropdown-select-item.tsx
+++ b/packages/components/src/components/dropdown-select-item/dropdown-select-item.tsx
@@ -10,6 +10,7 @@ export class DropdownSelectItem {
   @Prop() selected?: boolean;
   @Prop() focused?: boolean;
   @Prop({ reflect: true }) value?: any;
+  @Prop({ reflect: true }) disabled?: boolean;
 
   render() {
     return (

--- a/packages/components/src/components/dropdown-select/dropdown-select.css
+++ b/packages/components/src/components/dropdown-select/dropdown-select.css
@@ -255,6 +255,11 @@
 /*option*/
 [part~='option'] {
   color: var(--color);
+
+  &[part~='disabled'] {
+    color: var(--color-disabled);
+    cursor: not-allowed;
+  }
 }
 
 [part~='option']:hover {

--- a/packages/components/src/components/dropdown-select/dropdown-select.e2e.ts
+++ b/packages/components/src/components/dropdown-select/dropdown-select.e2e.ts
@@ -1,4 +1,4 @@
-import { newE2EPage } from '@stencil/core/testing';
+import { E2EElement, E2EPage, newE2EPage } from '@stencil/core/testing';
 import { DropdownSelect } from './dropdown-select';
 
 describe('DropdownSelect', function () {
@@ -58,5 +58,113 @@ describe('DropdownSelect', function () {
 
     expect(comboboxEl).toEqualText('Cedric');
     expect(selectEl).toEqualAttribute('value', 'cedric');
+  });
+
+  describe('when contains some disabled options', () => {
+    let page: E2EPage;
+    let selectEl: E2EElement;
+    let comboboxEl: E2EElement;
+
+    beforeEach(async () => {
+      page = await newE2EPage({
+        components: [DropdownSelect],
+        html: `
+        <scale-dropdown-select>
+          <scale-dropdown-select-item value="adam">Adam</scale-dropdown-select-item>
+          <scale-dropdown-select-item value="cedrik" disabled>Cedrik</scale-dropdown-select-item>
+          <scale-dropdown-select-item value="cedric" disabled>Cedric</scale-dropdown-select-item>
+          <scale-dropdown-select-item value="cem">Cem</scale-dropdown-select-item>
+          <scale-dropdown-select-item value="chris">Chris</scale-dropdown-select-item>
+          <scale-dropdown-select-item value="christian">Christian</scale-dropdown-select-item>
+          <scale-dropdown-select-item value="christiano">Christiano</scale-dropdown-select-item>
+        </scale-dropdown-select>`,
+      });
+
+      selectEl = await page.find('scale-dropdown-select');
+      comboboxEl = await page.find(
+        'scale-dropdown-select >>> [part="combobox"]'
+      );
+    });
+
+    it('should skip disabled options when navigating with keyboard', async () => {
+      await page.keyboard.down('Tab');
+      await page.keyboard.down('Enter');
+      await page.keyboard.down('ArrowDown');
+      await page.keyboard.down('ArrowDown');
+      await page.keyboard.down('Enter');
+      await page.waitForChanges();
+
+      // should skip Cedrik and Cedric
+      expect(comboboxEl).toEqualText('Cem');
+      expect(selectEl).toEqualAttribute('value', 'cem');
+    });
+
+    it('should skip disabled options when typing', async () => {
+      await page.keyboard.down('Tab');
+      await page.keyboard.down('Enter');
+      await page.keyboard.down('c');
+      await page.keyboard.down('e');
+      await page.keyboard.down('Enter');
+      await page.waitForChanges();
+
+      expect(comboboxEl).toEqualText('Cem');
+      expect(selectEl).toEqualAttribute('value', 'cem');
+    });
+  });
+
+  describe('when ALL options are disabled', () => {
+    let page: E2EPage;
+    let selectEl: E2EElement;
+    let comboboxEl: E2EElement;
+
+    beforeEach(async () => {
+      page = await newE2EPage({
+        components: [DropdownSelect],
+        html: `
+        <scale-dropdown-select value="default">
+          <scale-dropdown-select-item disabled value="adam">Adam</scale-dropdown-select-item>
+          <scale-dropdown-select-item disabled value="cedrik">Cedrik</scale-dropdown-select-item>
+          <scale-dropdown-select-item disabled value="cedric">Cedric</scale-dropdown-select-item>
+          <scale-dropdown-select-item disabled value="cem">Cem</scale-dropdown-select-item>
+          <scale-dropdown-select-item disabled value="chris">Chris</scale-dropdown-select-item>
+          <scale-dropdown-select-item disabled value="christian">Christian</scale-dropdown-select-item>
+          <scale-dropdown-select-item disabled value="christiano">Christiano</scale-dropdown-select-item>
+        </scale-dropdown-select>`,
+      });
+
+      selectEl = await page.find('scale-dropdown-select');
+      comboboxEl = await page.find(
+        'scale-dropdown-select >>> [part="combobox"]'
+      );
+    });
+
+    it('should not be able to select any option', async () => {
+      await page.keyboard.down('Tab');
+      await page.keyboard.down('Enter');
+      await page.keyboard.down('ArrowDown');
+      await page.keyboard.down('ArrowDown');
+      await page.keyboard.down('ArrowDown');
+      await page.keyboard.down('ArrowUp');
+      await page.keyboard.down('ArrowUp');
+      await page.keyboard.down('ArrowDown');
+      await page.keyboard.down('Enter');
+      await page.waitForChanges();
+
+      expect(comboboxEl).toEqualText('');
+      expect(selectEl).toEqualAttribute('value', 'default');
+    });
+
+    it('should not be able to select any option by typing', async () => {
+      await page.keyboard.down('Tab');
+      await page.keyboard.down('Enter');
+      await page.keyboard.down('c');
+      await page.keyboard.down('e');
+      await page.keyboard.down('d');
+      await page.keyboard.down('Enter');
+      await page.waitForChanges();
+
+      expect(comboboxEl).toEqualText('');
+      expect(selectEl).toEqualAttribute('value', 'default');
+    });
   });
 });

--- a/packages/components/src/components/dropdown-select/dropdown-select.spec.ts
+++ b/packages/components/src/components/dropdown-select/dropdown-select.spec.ts
@@ -82,4 +82,41 @@ describe('DropdownSelect', function () {
       })
     );
   });
+
+  describe('when clicking on disabled option', () => {
+    it('should neither change it`s value, nor emit an event', async () => {
+      const page = await newSpecPage({
+        components: [DropdownSelect],
+        html: `
+        <scale-dropdown-select value="">
+            <scale-dropdown-select-item value="caspar">Caspar</scale-dropdown-select-item>
+            <scale-dropdown-select-item value="cedric" disabled>Cedric</scale-dropdown-select-item>
+            <scale-dropdown-select-item value="cem" disabled>Cem</scale-dropdown-select-item>
+        </scale-dropdown-select>`,
+      });
+
+      const clickSpy = jest.fn();
+      const changeSpy = jest.fn();
+
+      const selectEl = page.doc.querySelector('scale-dropdown-select');
+      selectEl.addEventListener('scale-change', changeSpy);
+      const comboboxEl: HTMLElement =
+        selectEl.shadowRoot.querySelector('[part="combobox"]');
+      comboboxEl.scrollIntoView = function () {};
+      comboboxEl.focus = function () {};
+      const optionsEls: NodeListOf<HTMLElement> =
+        selectEl.shadowRoot.querySelectorAll('[role="option"]');
+      optionsEls[1].addEventListener('click', clickSpy);
+
+      comboboxEl.click();
+      optionsEls[1].click();
+
+      await page.waitForChanges();
+
+      expect(comboboxEl.textContent).not.toBe('Cem');
+      expect(selectEl.value).not.toBe('cem');
+      expect(clickSpy).toBeCalledTimes(1);
+      expect(changeSpy).not.toBeCalled();
+    });
+  });
 });

--- a/packages/components/src/components/dropdown-select/dropdown-select.tsx
+++ b/packages/components/src/components/dropdown-select/dropdown-select.tsx
@@ -31,17 +31,34 @@ enum Actions {
 
 const DEFAULT_ICON_SIZE = 20;
 
+interface SelectOption {
+  label: string;
+  value: any;
+  disabled: boolean;
+  ItemElement: VNode;
+}
+
 const isElementValue = (x: unknown): x is Element & { value: string } =>
   typeof (x as { value: unknown }).value === 'string';
 const readValue = (element: Element) =>
   isElementValue(element) ? element.value : null;
 
-const readOptions = (
-  hostElement: HTMLElement
-): Array<{ label: string; value: any; ItemElement: VNode }> => {
+const isElementDisabled = (x: unknown): x is Element & { disable: boolean } => {
+  return typeof (x as { disable: unknown }).disable === 'boolean';
+};
+const readDisabled = (element: Element) => {
+  const attr = element.getAttribute('disabled');
+  return (
+    (attr !== null && `${attr}` !== 'false') ||
+    (isElementDisabled(element) ? element.disable : false)
+  );
+};
+
+const readOptions = (hostElement: HTMLElement): SelectOption[] => {
   return Array.from(hostElement.children).map((x) => ({
     label: x.textContent.trim(),
     value: x.getAttribute('value') ?? readValue(x),
+    disabled: readDisabled(x),
     ItemElement: <span innerHTML={x.outerHTML}></span>,
   }));
 };
@@ -95,39 +112,64 @@ function getActionFromKey(event: KeyboardEvent, open: boolean) {
   }
 }
 
-function jumpToIndex(currentIndex: number, maxIndex: number, action: Actions) {
+function jumpToIndex(from: number, action: Actions, options: SelectOption[]) {
   const JUMP_SIZE = 10;
+  const findNearestEnabled = (current: number, step: number) => {
+    let nextIndex: number = current;
+    let nextOption: SelectOption;
 
+    do {
+      nextIndex += step;
+      nextOption = options[nextIndex];
+      if (nextOption === undefined) {
+        break;
+      }
+    } while (nextOption?.disabled);
+
+    return nextOption ? nextIndex : current;
+  };
+
+  let nearest: number;
   switch (action) {
     case Actions['First']:
-      return 0;
+      return options[0]?.disabled ? findNearestEnabled(-1, 1) : 0;
     case Actions['Last']:
-      return maxIndex;
+      nearest = findNearestEnabled(options.length, -1);
+      return nearest === options.length ? -1 : nearest; // rare case when all options are disabled
     case Actions['Previous']:
-      return Math.max(0, currentIndex - 1);
+      return findNearestEnabled(from, -1);
     case Actions['Next']:
-      return Math.min(maxIndex, currentIndex + 1);
+      return findNearestEnabled(from, 1);
     case Actions['PageUp']:
-      return Math.max(0, currentIndex - JUMP_SIZE);
+      const lowerBound = Math.max(from - JUMP_SIZE, -1);
+      return findNearestEnabled(lowerBound, 1);
     case Actions['PageDown']:
-      return Math.min(maxIndex, currentIndex + JUMP_SIZE);
+      const upperBound = Math.min(from + JUMP_SIZE, options.length);
+      nearest = findNearestEnabled(upperBound, -1);
+      return nearest === options.length ? -1 : nearest; // rare case when all options are disabled
     default:
-      return currentIndex;
+      return from;
   }
 }
 
-function matchOptions(options: string[] = [], filter: string) {
+function matchEnabledOptions(options: SelectOption[] = [], filter: string) {
   return options.filter(
-    (option) => option.toLowerCase().indexOf(filter.toLowerCase()) === 0
+    (option) =>
+      !option.disabled &&
+      option.label.toLowerCase().indexOf(filter.toLowerCase()) === 0
   );
 }
 
-function getIndexByChar(values: string[], filter: string, startIndex = 0) {
-  const sortedValues = [
+function getIndexByChar(
+  values: SelectOption[],
+  filter: string,
+  startIndex = 0
+) {
+  const sortedOptions = [
     ...values.slice(startIndex),
     ...values.slice(0, startIndex),
   ];
-  const firstHit = matchOptions(sortedValues, filter)[0];
+  const firstHit = matchEnabledOptions(sortedOptions, filter)[0];
   const allMatchingChars = (array) => array.every((char) => char === array[0]);
 
   if (firstHit) {
@@ -135,7 +177,7 @@ function getIndexByChar(values: string[], filter: string, startIndex = 0) {
   }
 
   if (allMatchingChars(filter.split(''))) {
-    const hits = matchOptions(sortedValues, filter[0]);
+    const hits = matchEnabledOptions(sortedOptions, filter[0]);
     return values.indexOf(hits[0]);
   }
 
@@ -271,7 +313,10 @@ export class DropdownSelect {
 
   handleOptionChange(index) {
     this.currentIndex = index;
-    this.bringIntoView(index);
+
+    if (index > -1) {
+      this.bringIntoView(index);
+    }
   }
 
   bringIntoView(index) {
@@ -306,6 +351,10 @@ export class DropdownSelect {
 
   handleOptionClick(event, index) {
     event.stopPropagation();
+    if (readOptions(this.hostElement)[index].disabled) {
+      return;
+    }
+
     this.handleOptionChange(index);
     this.selectOption(index);
     this.setOpen(false);
@@ -329,7 +378,7 @@ export class DropdownSelect {
 
     const queryString = this.getSearchString(char);
     const queryIndex = getIndexByChar(
-      readOptions(this.hostElement).map(({ label }) => label),
+      readOptions(this.hostElement),
       queryString,
       this.currentIndex + 1
     );
@@ -344,7 +393,7 @@ export class DropdownSelect {
 
   handleKeyDown = (event) => {
     const { key } = event;
-    const max = readOptions(this.hostElement).length - 1;
+    const options = readOptions(this.hostElement);
     const action = getActionFromKey(event, this.open);
     emitEvent(this, 'scaleKeydown', event);
 
@@ -358,11 +407,16 @@ export class DropdownSelect {
       case Actions['PageDown']:
         event.preventDefault();
         return this.handleOptionChange(
-          jumpToIndex(this.currentIndex, max, action)
+          jumpToIndex(this.currentIndex, action, options)
         );
       case Actions['CloseSelect']:
         event.preventDefault();
-        this.selectOption(this.currentIndex);
+        if (options[this.currentIndex]?.disabled) {
+          return;
+        }
+        if (this.currentIndex !== -1) {
+          this.selectOption(this.currentIndex);
+        }
       case Actions['Close']:
         event.preventDefault();
         return this.setOpen(false);
@@ -458,12 +512,10 @@ export class DropdownSelect {
                   tabindex="-1"
                 >
                   {readOptions(this.hostElement).map(
-                    ({ value, ItemElement }, index) => (
+                    ({ value, disabled, ItemElement }, index) => (
                       <div
                         role="option"
-                        part={`option${
-                          index === this.currentIndex ? ' current' : ''
-                        }`}
+                        part={this.getOptionPartMap(index, disabled)}
                         id={value}
                         onClick={(event) => {
                           this.handleOptionClick(event, index);
@@ -474,6 +526,7 @@ export class DropdownSelect {
                         {...(value === this.value
                           ? { 'aria-selected': 'true' }
                           : {})}
+                        {...(disabled ? { 'aria-disabled': 'true' } : {})}
                       >
                         {ItemElement}
                         {value === this.value ? (
@@ -539,6 +592,14 @@ export class DropdownSelect {
       this.helperText && 'has-helper-text',
       this.floatingStrategy && `strategy-${this.floatingStrategy}`,
       this.hideLabelVisually && 'hide-label'
+    );
+  }
+
+  getOptionPartMap(index: number, disabled: boolean) {
+    return classNames(
+      'option',
+      index === this.currentIndex && `current`,
+      disabled && `disabled`
     );
   }
 }

--- a/packages/components/src/components/dropdown-select/dropdown-select.tsx
+++ b/packages/components/src/components/dropdown-select/dropdown-select.tsx
@@ -402,18 +402,12 @@ export class DropdownSelect {
   };
 
   render() {
-    const ValueElement = (
-      readOptions(this.hostElement).find(({ value }) => value === this.value) ||
-      ({} as any)
-    ).ItemElement;
-    const hasEmptyValueElement =
-      (
-        readOptions(this.hostElement).find(
-          ({ value }) => value === this.value
-        ) || ({} as any)
-      ).value === ''
-        ? true
-        : false;
+    const element =
+      readOptions(this.hostElement).find(({ value }) => value === this.value) ??
+      ({} as any);
+
+    const ValueElement = element.ItemElement;
+    const hasEmptyValueElement = element.value === '';
     const helperTextId = `helper-message-${generateUniqueId()}`;
     const ariaDescribedByAttr = { 'aria-describedBy': helperTextId };
 

--- a/packages/components/src/html/dropdown-select.html
+++ b/packages/components/src/html/dropdown-select.html
@@ -37,10 +37,10 @@
         <scale-icon-action-add slot="suffix"></scale-icon-action-add>
         Caspar</scale-dropdown-select-item
       >
-      <scale-dropdown-select-item value="cedric">
+      <scale-dropdown-select-item value="cedric" disabled>
         Cedric</scale-dropdown-select-item
       >
-      <scale-dropdown-select-item value="cedrik"
+      <scale-dropdown-select-item value="cedrik" disabled
         >Cedrik</scale-dropdown-select-item
       >
       <scale-dropdown-select-item value="cem">Cem</scale-dropdown-select-item>


### PR DESCRIPTION
This PR adds new feature for `dropdown-select` component, as described in (#2114).

Also added tests (both unit and e2e) for this feature.

Regarding _disabled reasons_, I came to decision **not** to implement it, since component already provides 3 slots, where consumer can define reason of some sort.

Disabled state is supported for any elements with `disabled` attribute, not only for `scale-dropdown-select-item` component.
Keyboard navigation handlers was adjusted to skip any disabled attributes (similar to native `select` element).

Question for maintainers: Should I also add some entries to Docs? If so, can you give me a hint, where to add it exactly? 

fixes #2114 