### PR TITLE
feat: add engines to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     }
   },
   "engines": {
-    "node": ">=16.0.0 <17.0.0",
+    "node": "16.x",
     "npm": "please-use-yarn",
-    "yarn": ">=1.22.0 <2.0.0"
+    "yarn": "1.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,5 +32,10 @@
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
+  },
+  "engines": {
+    "node": ">=16.0.0 <17.0.0",
+    "npm": "please-use-yarn",
+    "yarn": ">=1.22.0 <2.0.0"
   }
 }


### PR DESCRIPTION
Hopefully saving contributors some time. Using node greater than 16 or not using yarn v1 yields a bunch of install/build errors.