### PR TITLE
Fix/data grid tags colors

### DIFF
--- a/packages/components/src/components/data-grid/cell-handlers/tags-cell.tsx
+++ b/packages/components/src/components/data-grid/cell-handlers/tags-cell.tsx
@@ -20,7 +20,6 @@ export const TagsCell: Cell = {
   },
   render: ({ content }) => {
     let tags = [];
-    console.log('content', content, typeof content);
     // for backwards compatibility
     if (typeof content === 'string') {
       tags = content.split(',').map((el) => ({

--- a/packages/components/src/components/data-grid/cell-handlers/tags-cell.tsx
+++ b/packages/components/src/components/data-grid/cell-handlers/tags-cell.tsx
@@ -25,11 +25,10 @@ export const TagsCell: Cell = {
     if (typeof content === 'string') {
       tags = content.split(',').map((el) => ({
         content: el,
-        color: 'standard'
+        color: 'standard',
       }));
-    }
-    else {
-      tags = content
+    } else {
+      tags = content;
     }
     return (
       <ul class={`tbody__tag-list`}>

--- a/packages/components/src/components/data-grid/cell-handlers/tags-cell.tsx
+++ b/packages/components/src/components/data-grid/cell-handlers/tags-cell.tsx
@@ -19,13 +19,24 @@ export const TagsCell: Cell = {
     sortBy: 'text',
   },
   render: ({ content }) => {
-    const tags = content.split(',').map((s) => s.trim());
+    let tags = [];
+    console.log('content', content, typeof content);
+    // for backwards compatibility
+    if (typeof content === 'string') {
+      tags = content.split(',').map((el) => ({
+        content: el,
+        color: 'standard'
+      }));
+    }
+    else {
+      tags = content
+    }
     return (
       <ul class={`tbody__tag-list`}>
         {tags.map((tag) => (
           <li>
-            <scale-tag size="small" type="strong">
-              {tag}
+            <scale-tag size="small" type="strong" color={tag.color}>
+              {tag.content}
             </scale-tag>
           </li>
         ))}

--- a/packages/storybook-vue/stories/components/data-grid/DataGrid.stories.mdx
+++ b/packages/storybook-vue/stories/components/data-grid/DataGrid.stories.mdx
@@ -669,7 +669,7 @@ Expected format: string
 
 ## Tags Cell
 
-Expected format: comma delimited `string`, eg `'one, two, three'`
+Expected format: comma delimited `string`, eg `'one, two, three'` or array of objects with content and color keys, e.g. `{content: 'Apple', color: 'red'}`
 
 <Canvas withSource="close">
   <Story name="Tags Cell">
@@ -689,7 +689,7 @@ Expected format: comma delimited `string`, eg `'one, two, three'`
             },
         ];
         dataGrid.rows = [
-            [[{content: 'Apple', color: 'red'}, {content: 'Banana', color: 'yellow'}], 'Tomato, Cucumber'],
+            ['Apple, Banana', 'Tomato, Cucumber'],
             ['Strawberry', 'Aubergine, Carrot, Celery'],
             ['Orange, Lemon, Watermelon', 'Pizza'],
         ];

--- a/packages/storybook-vue/stories/components/data-grid/DataGrid.stories.mdx
+++ b/packages/storybook-vue/stories/components/data-grid/DataGrid.stories.mdx
@@ -689,7 +689,7 @@ Expected format: comma delimited `string`, eg `'one, two, three'`
             },
         ];
         dataGrid.rows = [
-            ['Apple, Banana', 'Tomato, Cucumber'],
+            [[{content: 'Apple', color: 'red'}, {content: 'Banana', color: 'yellow'}], 'Tomato, Cucumber'],
             ['Strawberry', 'Aubergine, Carrot, Celery'],
             ['Orange, Lemon, Watermelon', 'Pizza'],
         ];


### PR DESCRIPTION
from a supportpal request as well as https://github.com/telekom/scale/issues/1406 -> https://github.com/telekom/scale/issues/1076 and https://github.com/telekom/scale/issues/955

this doesn't allow to completely customize the styles of the tags, but at least to use the standard colors we provide https://telekom.github.io/scale/?path=/docs/components-tag--colors#colors