### PR TITLE
make link cell types customizable

### DIFF
--- a/packages/components/src/components/data-grid/cell-handlers/link-cell.tsx
+++ b/packages/components/src/components/data-grid/cell-handlers/link-cell.tsx
@@ -19,12 +19,24 @@ export const LinkCell: Cell = {
     sortBy: 'text',
   },
   render: ({ content }) => {
-    // Remove protocol (http/https)
-    const urlNoProtocol = content.replace(/^https?\:\/\//i, '');
-    return (
-      <scale-link href={content} target="_blank">
-        {urlNoProtocol}
-      </scale-link>
-    );
+    if (typeof content === 'string') {
+      // Remove protocol (http/https)
+      const urlNoProtocol = content.replace(/^https?\:\/\//i, '');
+      return (
+        <scale-link href={content} target="_blank">
+          {urlNoProtocol}
+        </scale-link>
+      );
+    } else {
+      // if the type of content is not a string, the content is handled as
+      // object of text and props (spread) which are passed as attributes to
+      // the scale-link element
+      const { text, ...props } = content;
+      return (
+        <scale-link {...props}>
+          {text}
+        </scale-link>
+      );
+    }
   },
 };

--- a/packages/components/src/components/data-grid/cell-handlers/link-cell.tsx
+++ b/packages/components/src/components/data-grid/cell-handlers/link-cell.tsx
@@ -32,11 +32,7 @@ export const LinkCell: Cell = {
       // object of text and props (spread) which are passed as attributes to
       // the scale-link element
       const { text, ...props } = content;
-      return (
-        <scale-link {...props}>
-          {text}
-        </scale-link>
-      );
+      return <scale-link {...props}>{text}</scale-link>;
     }
   },
 };


### PR DESCRIPTION
This is intended to address the feature request #2255

The old behavior as well as the new behavior are tested.

E.g. the following two scale data grid columns are defined:

```javascript
    {
      type: 'link',
      label: 'Produkt',
    },
    {
      type: 'link',
      label: 'Edition',
    }
```
And now we can add the rows like this:

```javascript
data.push(
  `https://products.telekom.de/?productId=${product.id}`,
  {text: edition.name, href:`?productId=${product.id}`}
)
```

Which then looks like this:
![image](https://github.com/telekom/scale/assets/60140364/bf9b34c6-af63-4e7e-985a-a7b3ce0750fc)

          
