### PR TITLE
feat(accordion): allow collapsible to be individually expanded

### DIFF
--- a/packages/components/src/components/accordion/accordion.tsx
+++ b/packages/components/src/components/accordion/accordion.tsx
@@ -66,7 +66,7 @@ export class Accordion {
     /**
      * Handle `expanded`
      */
-    if (!this.dependent) {
+    if (this.expanded && !this.dependent) {
       this.getCollapsibleChildren().forEach((child) => {
         child.expanded = this.expanded;
       });


### PR DESCRIPTION
A collapsible can now be individually expanded, independent of its containing accordion.

The `expanded` prop is now only propagated, if it is set to true on the parent accordion. This allows the developer to individually select which collapsibles should start expanded instead of all or none.

This change works seamlessly with the `dependent` prop and does not introduce any breaking changes.