### PR TITLE
fix: escape name of hidden input in dropdown-select...

### DIFF
--- a/packages/components/src/components/dropdown-select/dropdown-select.tsx
+++ b/packages/components/src/components/dropdown-select/dropdown-select.tsx
@@ -324,7 +324,7 @@ export class DropdownSelect {
 
   updateInputHidden(value: string = this.value): void {
     this.hostElement.querySelector<HTMLInputElement>(
-      `input[name=${this.name}]`
+      `input[name="${this.name}"]`
     ).value = value;
   }
 


### PR DESCRIPTION
...to support square brackets.

Otherwise the input can't be found because the selector is invalid.

See:
![Bildschirmfoto 2024-02-01 um 17 35 00](https://github.com/telekom/scale/assets/118465726/a98ab2e6-f721-44fe-9436-77a4afc69aa3)

I didn't write specs as i'm not a JS developer, but maybe tests would help here.