### PR TITLE
fix(data-grid): heading height with hidden menu

### DIFF
--- a/packages/components/src/components/data-grid/data-grid.css
+++ b/packages/components/src/components/data-grid/data-grid.css
@@ -127,7 +127,8 @@
   display: none;
 }
 
-.data-grid:not(.data-grid--hide-menu.data-grid--no-heading) .data-grid__title-block {
+.data-grid:not(.data-grid--hide-menu.data-grid--no-heading)
+  .data-grid__title-block {
   min-height: var(--telekom-spacing-composition-space-18, 72px);
 }
 .data-grid--hide-menu .data-grid__title-block {

--- a/packages/components/src/components/data-grid/data-grid.css
+++ b/packages/components/src/components/data-grid/data-grid.css
@@ -127,8 +127,8 @@
   display: none;
 }
 
-.data-grid:not(.data-grid--hide-menu) .data-grid__title-block {
-  min-height: 72px;
+.data-grid .data-grid__title-block {
+  min-height: var(--telekom-spacing-composition-space-18, 72px);
 }
 .data-grid--hide-menu .data-grid__title-block {
   padding-right: var(--telekom-spacing-composition-space-06);

--- a/packages/components/src/components/data-grid/data-grid.css
+++ b/packages/components/src/components/data-grid/data-grid.css
@@ -127,7 +127,7 @@
   display: none;
 }
 
-.data-grid .data-grid__title-block {
+.data-grid:not(.data-grid--hide-menu.data-grid--no-heading) .data-grid__title-block {
   min-height: var(--telekom-spacing-composition-space-18, 72px);
 }
 .data-grid--hide-menu .data-grid__title-block {

--- a/packages/components/src/components/data-grid/data-grid.tsx
+++ b/packages/components/src/components/data-grid/data-grid.tsx
@@ -335,7 +335,7 @@ export class DataGrid {
       this.freezeHeader && `${name}--freeze-header`,
       this.hideBorder && `${name}--hide-border`,
       this.hideMenu && `${name}--hide-menu`,
-      !this.heading && `${name}--no-heading`,
+      !this.heading && `${name}--no-heading`
     );
   }
 

--- a/packages/components/src/components/data-grid/data-grid.tsx
+++ b/packages/components/src/components/data-grid/data-grid.tsx
@@ -334,7 +334,8 @@ export class DataGrid {
       this.shadeAlternate && `${name}--shade-alternate`,
       this.freezeHeader && `${name}--freeze-header`,
       this.hideBorder && `${name}--hide-border`,
-      this.hideMenu && `${name}--hide-menu`
+      this.hideMenu && `${name}--hide-menu`,
+      !this.heading && `${name}--no-heading`,
     );
   }
 


### PR DESCRIPTION
The spacing in the heading block would break with a heading and the `hide-menu` prop enabled.