### PR TITLE
fix(telekom-profile-menu): keyboard accessibility & optional logout handler

### DIFF
--- a/packages/components/src/components/telekom/app-navigation-user-menu/app-navigation-user-menu.tsx
+++ b/packages/components/src/components/telekom/app-navigation-user-menu/app-navigation-user-menu.tsx
@@ -88,10 +88,9 @@ export class AppNavigationUserMenu {
                   }}
                   onKeyDown={(e) => {
                     if ([' ', 'Enter'].includes(e.key)) {
-                      e.stopImmediatePropagation();
-                      e.preventDefault();
-
                       if (item.onClick) {
+                        e.stopImmediatePropagation();
+                        e.preventDefault();
                         item.onClick(e);
                       }
                       this.hide();
@@ -128,16 +127,17 @@ export class AppNavigationUserMenu {
                   part="button"
                   onClick={(e) => {
                     if (item.onClick) {
+                      e.stopImmediatePropagation();
+                      e.preventDefault();
                       item.onClick(e);
                     }
                     this.hide();
                   }}
                   onKeyDown={(e) => {
                     if ([' ', 'Enter'].includes(e.key)) {
-                      e.stopImmediatePropagation();
-                      e.preventDefault();
-
                       if (item.onClick) {
+                        e.stopImmediatePropagation();
+                        e.preventDefault();
                         item.onClick(e);
                       }
                       this.hide();

--- a/packages/components/src/components/telekom/telekom-profile-menu/readme.md
+++ b/packages/components/src/components/telekom/telekom-profile-menu/readme.md
@@ -21,6 +21,7 @@
 | `loginSettingsLabel`          | `login-settings-label`           |             | `string`  | `undefined` |
 | `loginSettingsUrl`            | `login-settings-url`             |             | `string`  | `undefined` |
 | `loginUrl`                    | `login-url`                      |             | `string`  | `undefined` |
+| `logoutHandler`               | `logout-handler`                 |             | `string`  | `undefined` |
 | `logoutLabel`                 | `logout-label`                   |             | `string`  | `undefined` |
 | `logoutUrl`                   | `logout-url`                     |             | `string`  | `undefined` |
 | `registerHeadline`            | `register-headline`              |             | `string`  | `undefined` |

--- a/packages/components/src/components/telekom/telekom-profile-menu/telekom-profile-menu.tsx
+++ b/packages/components/src/components/telekom/telekom-profile-menu/telekom-profile-menu.tsx
@@ -82,6 +82,7 @@ export class TelekomProfileMenu {
 
   @Prop() logoutLabel: string;
   @Prop() logoutUrl?: string;
+  @Prop() logoutHandler?: string;
 
   @State()
   menuOpen = false;
@@ -161,6 +162,16 @@ export class TelekomProfileMenu {
     );
   }
 
+  buildLogoutButton() {
+    return {
+      type: 'button',
+      name: this.logoutLabel,
+      href: this.logoutUrl || LOGOUT_DEFAULT,
+      variant: 'secondary',
+      onClick: this.logoutHandler,
+    };
+  }
+
   buildUserNavigation() {
     const divider = [{ type: 'divider' }];
 
@@ -187,13 +198,6 @@ export class TelekomProfileMenu {
       icon: 'service-settings',
     };
 
-    const logout = {
-      type: 'button',
-      name: this.logoutLabel,
-      href: this.logoutUrl || LOGOUT_DEFAULT,
-      variant: 'secondary',
-    };
-
     let menu = [];
 
     menu = menu.concat(userInfo);
@@ -211,7 +215,7 @@ export class TelekomProfileMenu {
       menu = menu.concat(divider);
     }
 
-    menu = menu.concat(logout);
+    menu = menu.concat(this.buildLogoutButton());
 
     return menu;
   }

--- a/packages/storybook-vue/stories/components/telekom-brand-header-navigation/TelekomBrandHeader.stories.mdx
+++ b/packages/storybook-vue/stories/components/telekom-brand-header-navigation/TelekomBrandHeader.stories.mdx
@@ -539,6 +539,11 @@ window.onload = () => {
     email: 'alexander.dreyer@t-online.de',
   });
   profileMenu.serviceLinks = JSON.stringify(serviceLinks);
+
+  // optional: set a custom handler for clicks on logout button
+  profileMenu.logoutHandler = () => {
+    // ...
+  }
 };
 </script>
 ```
@@ -605,6 +610,11 @@ window.onload = () => {
     email: 'alexander.dreyer@t-online.de',
   });
   profileMenu.serviceLinks = JSON.stringify(serviceLinks);
+
+  // optional: set a custom handler for clicks on logout button
+  profileMenu.logoutHandler = () => {
+    // ...
+  }
 };
 </script>
 ```

--- a/packages/storybook-vue/stories/components/telekom-brand-header-navigation/telekom-brand-header.md
+++ b/packages/storybook-vue/stories/components/telekom-brand-header-navigation/telekom-brand-header.md
@@ -126,4 +126,4 @@ This component is still in the beta phase. When testing it, keep in mind that it
 - [Sidebar Navigation](?path=/usage/components-sidebar-navigation--standard)
 - [Tab Navigation](?path=/usage/components-tab-navigation--text-icon)
 - [Accordion](?path=/usage/components-accordion--standard)
-- [Profile Menu](?path=/docs/components-telekom-profile-menu--logged-out)
+- [Profile Menu](?path=/docs/components-telekom-brand-header-navigation--profile-menu-logged-out)

--- a/packages/storybook-vue/stories/components/telekom-brand-header-navigation/telekom-brand-header_de.md
+++ b/packages/storybook-vue/stories/components/telekom-brand-header-navigation/telekom-brand-header_de.md
@@ -127,4 +127,4 @@ Diese Komponente befindet sich noch im Beta-Stadium. Wenn du sie testest, bedenk
 - [Sidebar Navigation](?path=/usage/components-sidebar-navigation--standard)
 - [Tab Navigation](?path=/usage/components-tab-navigation--text-icon)
 - [Accordion](?path=/usage/components-accordion--standard)
-- [Profile Menu](?path=/docs/components-telekom-profile-menu--logged-out)
+- [Profile Menu](?path=/docs/components-telekom-brand-header-navigation--profile-menu-logged-out)


### PR DESCRIPTION
This PR should fix 2 issues:

1. the profile menu's links & buttons could not be activated via keyboard (since default behaviour was surpressed, even if no clickHandler defined)
2. there was no way to set a custom clickHandler to the profile menu's logout button (even if the underlying component already had the feature that could be used)