### PR TITLE
fix(switch): add text color for switch toggle

### DIFF
--- a/packages/components/src/components/switch/switch.css
+++ b/packages/components/src/components/switch/switch.css
@@ -26,6 +26,7 @@ scale-switch {
 
 .switch {
   --_background: var(--telekom-color-ui-faint);
+  --_on-background: var(--telekom-color-text-and-icon-standard);
   --_color-thumb: var(--telekom-color-ui-white, #fff);
   --_overlay-background: transparent;
 
@@ -55,6 +56,7 @@ scale-switch {
   width: var(--width);
   height: var(--height);
   background: var(--_background);
+  color: var(--_on-background);
   border-radius: var(--radius);
   transition-property: background;
   transition-duration: var(--transition-duration);


### PR DESCRIPTION
Introduces a `--_on-background` variable that's used to define the IO text color relative to the `--_background` color of the toggle, and applies it to the base state.

## The Problem

Black background with white text; both the label and IO text have poor to no contrast.
![grafik](https://github.com/telekom/scale/assets/388308/e96f8e2f-3296-4c2d-aa23-8dc440ab72c2)

This can be mitigated by setting `--color-label` to `currentColor` to honor the chosen text color. Maybe this should even be the default, considering the label is always going to be on top of the surrounding background? The contrast problem remains for the IO text, and is not adjustable by the user.
![grafik](https://github.com/telekom/scale/assets/388308/20e5f26e-361a-43a2-baad-19ee65fcea31)

## The Solution

Since the switch toggle itself already has a background color, contrast becomes independent of the surrounding background. It's therefore inconsistent to honor `--color-label` in this context. The new variable ensures that the base states color actually related to the background it's drawn on.
![grafik](https://github.com/telekom/scale/assets/388308/e58186ab-381f-4fbf-8752-bc41005f6dc4)

It currently defaults to `var(--telekom-color-text-and-icon-standard)`, which also behaves correctly when the control is used in dark mode.
![grafik](https://github.com/telekom/scale/assets/388308/5ea4827d-72ee-4423-b154-ce45cee09ff0)
