### PR TITLE
fix(scale-telekom-header): fix no service links breaks component

### DIFF
--- a/packages/components/src/components/telekom/telekom-profile-menu/telekom-profile-menu.tsx
+++ b/packages/components/src/components/telekom/telekom-profile-menu/telekom-profile-menu.tsx
@@ -221,7 +221,7 @@ export class TelekomProfileMenu {
   }
 
   serviceLinksEmpty() {
-    return (this.hideLoginSettings && this.serviceLinks.length < 1) === true;
+    return (this.hideLoginSettings && (!this.serviceLinks || this.serviceLinks.length < 1)) === true;
   }
 
   buildDesktopMenuStyles() {


### PR DESCRIPTION
When using the `scale-telekom-header` with a profile menu with no service links **and** `hideLoginSettings` set to true, the component will crash as the serviceLinks property is undefined.

![image](https://github.com/telekom/scale/assets/7442307/c5620266-c2c4-44a3-89ff-1c4a2e517f91)

Example:
```html
<scale-telekom-header type="slim" app-name="Reseller RBU">
    <scale-telekom-nav-list variant="functions" slot="functions" scrolled>
        <scale-telekom-profile-menu
            hide-login-settings="true"
            login-url="/login"
            logged-in="true"
            label="Niklas"
            logout-label="Logout"
            logout-url="/logout"
        ></scale-telekom-profile-menu>
    </scale-telekom-nav-list>
</scale-telekom-header>
```

This PR changes the `serviceLinksEmpty` method by introducing a preceding property check to see if the property is defined and then continues with the length check.
