### PR TITLE
fix(tab-nav): fixes preselect logic in tabs with disabled attribute

### DIFF
--- a/packages/components/src/components/tab-header/readme.md
+++ b/packages/components/src/components/tab-header/readme.md
@@ -18,10 +18,10 @@
 
 ## Events
 
-| Event                | Description                                      | Type               |
-| -------------------- | ------------------------------------------------ | ------------------ |
-| `scale-got-disabled` | Emitted when currently selected tab got disabled | `CustomEvent<any>` |
-| `scale-select`       | Emitted on header select                         | `CustomEvent<any>` |
+| Event            | Description                                      | Type               |
+| ---------------- | ------------------------------------------------ | ------------------ |
+| `scale-disabled` | Emitted when currently selected tab got disabled | `CustomEvent<any>` |
+| `scale-select`   | Emitted on header select                         | `CustomEvent<any>` |
 
 
 ----------------------------------------------

--- a/packages/components/src/components/tab-header/readme.md
+++ b/packages/components/src/components/tab-header/readme.md
@@ -18,9 +18,10 @@
 
 ## Events
 
-| Event          | Description | Type               |
-| -------------- | ----------- | ------------------ |
-| `scale-select` |             | `CustomEvent<any>` |
+| Event                | Description                                      | Type               |
+| -------------------- | ------------------------------------------------ | ------------------ |
+| `scale-got-disabled` | Emitted when currently selected tab got disabled | `CustomEvent<any>` |
+| `scale-select`       | Emitted on header select                         | `CustomEvent<any>` |
 
 
 ----------------------------------------------

--- a/packages/components/src/components/tab-header/tab-header.tsx
+++ b/packages/components/src/components/tab-header/tab-header.tsx
@@ -47,7 +47,7 @@ export class TabHeader {
   /** (optional) size  */
   @Prop() size?: 'small' | 'large' = 'small';
   /** (optional) Whether the tab is selected */
-  @Prop() selected?: boolean;
+  @Prop({ mutable: true }) selected?: boolean;
   /** (optional) Injected CSS styles */
   @Prop() styles?: string;
 
@@ -64,7 +64,7 @@ export class TabHeader {
     if (this.disabled) {
       return;
     }
-    this.scaleSelect.emit();
+    this.selected = true;
   }
 
   @Watch('selected')
@@ -73,6 +73,9 @@ export class TabHeader {
       return;
     }
     if (!this.disabled) {
+      if (newValue === true) {
+        this.scaleSelect.emit();
+      }
       if (newValue === true && this.tabsHaveFocus()) {
         // Having focus on the host element, and not on inner elements,
         // is required because screen readers.

--- a/packages/components/src/components/tab-header/tab-header.tsx
+++ b/packages/components/src/components/tab-header/tab-header.tsx
@@ -65,6 +65,7 @@ export class TabHeader {
       return;
     }
     this.selected = true;
+    this.scaleSelect.emit();
   }
 
   @Watch('selected')

--- a/packages/components/src/components/tab-header/tab-header.tsx
+++ b/packages/components/src/components/tab-header/tab-header.tsx
@@ -56,7 +56,7 @@ export class TabHeader {
   /** Emitted on header select */
   @Event({ eventName: 'scale-select' }) scaleSelect: EventEmitter;
   /** Emitted when currently selected tab got disabled */
-  @Event({ eventName: 'scale-got-disabled' }) scaleGotDisabled: EventEmitter;
+  @Event({ eventName: 'scale-disabled' }) scaleDisabled: EventEmitter;
 
   @Listen('click')
   handleClick(event: MouseEvent) {
@@ -69,27 +69,25 @@ export class TabHeader {
 
   @Watch('selected')
   selectedChanged(newValue: boolean) {
-    if (!this.hostElement.isConnected) {
+    if (!this.hostElement.isConnected || this.disabled) {
       return;
     }
-    if (!this.disabled) {
-      if (newValue === true) {
-        this.scaleSelect.emit();
-      }
-      if (newValue === true && this.tabsHaveFocus()) {
-        // Having focus on the host element, and not on inner elements,
-        // is required because screen readers.
-        this.hostElement.focus();
-      }
-      this.updateSlottedIcon();
+    if (newValue) {
+      this.scaleSelect.emit();
     }
+    if (newValue && this.tabsHaveFocus()) {
+      // Having focus on the host element, and not on inner elements,
+      // is required because screen readers.
+      this.hostElement.focus();
+    }
+    this.updateSlottedIcon();
   }
 
   @Watch('disabled')
   disabledChanged() {
-    if (this.disabled && this.selected) {
+    if (this.disabled) {
       this.selected = false;
-      this.scaleGotDisabled.emit();
+      this.scaleDisabled.emit();
     }
   }
 

--- a/packages/components/src/components/tab-header/tab-header.tsx
+++ b/packages/components/src/components/tab-header/tab-header.tsx
@@ -76,8 +76,7 @@ export class TabHeader {
       this.scaleSelect.emit();
     }
     if (newValue && this.tabsHaveFocus()) {
-      // Having focus on the host element, and not on inner elements,
-      // is required because screen readers.
+      // Having focus on the host element and not on inner elements is required because of screen readers
       this.hostElement.focus();
     }
     this.updateSlottedIcon();

--- a/packages/components/src/components/tab-header/tab-header.tsx
+++ b/packages/components/src/components/tab-header/tab-header.tsx
@@ -53,7 +53,10 @@ export class TabHeader {
 
   @State() hasFocus: boolean = false;
 
+  /** Emitted on header select */
   @Event({ eventName: 'scale-select' }) scaleSelect: EventEmitter;
+  /** Emitted when currently selected tab got disabled */
+  @Event({ eventName: 'scale-got-disabled' }) scaleGotDisabled: EventEmitter;
 
   @Listen('click')
   handleClick(event: MouseEvent) {
@@ -81,8 +84,9 @@ export class TabHeader {
 
   @Watch('disabled')
   disabledChanged() {
-    if (this.disabled) {
+    if (this.disabled && this.selected) {
       this.selected = false;
+      this.scaleGotDisabled.emit();
     }
   }
 

--- a/packages/components/src/components/tab-nav/tab-nav.tsx
+++ b/packages/components/src/components/tab-nav/tab-nav.tsx
@@ -47,6 +47,11 @@ export class TabNav {
     }
   }
 
+  @Listen('scale-got-disabled')
+  handleDisabledTabHeader() {
+    this.selectProperTab();
+  }
+
   @Listen('keydown')
   handleKeydown(event: KeyboardEvent) {
     const target = event.target as HTMLScaleTabHeaderElement;
@@ -94,6 +99,7 @@ export class TabNav {
     ]).then(() => {
       this.linkPanels();
       this.propagateSizeToTabs();
+      this.selectProperTab();
     });
 
     if (this.small !== false) {
@@ -146,15 +152,18 @@ export class TabNav {
 
   linkPanels() {
     const tabs = this.getAllTabs();
-    const selectedTab =
-      tabs.find((x) => x.selected) || tabs.filter((x) => !x.disabled)[0];
-
     tabs.forEach((tab) => {
       const panel = tab.nextElementSibling;
       tab.setAttribute('aria-controls', panel.id);
       panel.setAttribute('aria-labelledby', tab.id);
     });
-    this.selectTab(selectedTab);
+  }
+
+  selectProperTab(): void {
+    const tabs = this.getAllTabs();
+    const tabToSelect =
+      tabs.find(tab => tab.selected) || tabs.filter(tab => !tab.disabled)[0];
+    this.selectTab(tabToSelect);
   }
 
   reset() {

--- a/packages/components/src/components/tab-nav/tab-nav.tsx
+++ b/packages/components/src/components/tab-nav/tab-nav.tsx
@@ -166,16 +166,13 @@ export class TabNav {
     this.selectTab(tabToSelect);
   }
 
-  resetTabs(nextTab?: HTMLScaleTabHeaderElement) {
+  reset(nextTab?: HTMLScaleTabHeaderElement) {
     const tabs = this.getAllEnabledTabs();
     tabs.forEach((tab) => {
       if (tab !== nextTab) {
         tab.selected = false;
       }
     });
-  }
-
-  resetPanels() {
     const panels = this.getAllPanels();
     panels.forEach((panel) => (panel.hidden = true));
   }
@@ -186,13 +183,12 @@ export class TabNav {
   }
 
   selectTab(nextTab: HTMLScaleTabHeaderElement) {
-    this.resetTabs(nextTab);
-    this.resetPanels();
+    this.reset(nextTab);
     if (!nextTab.selected) {
       nextTab.selected = true;
     }
-    const nextPanel = this.findPanelForTab(nextTab);
-    nextPanel.hidden = false;
+    const targetPanel = this.findPanelForTab(nextTab);
+    targetPanel.hidden = false;
   }
 
   /**

--- a/packages/components/src/components/tab-nav/tab-nav.tsx
+++ b/packages/components/src/components/tab-nav/tab-nav.tsx
@@ -164,13 +164,14 @@ export class TabNav {
   selectProperTab(): void {
     const tabs = this.getAllTabs();
     const tabToSelect =
-      tabs.find(tab => tab.selected) || tabs.filter(tab => !tab.disabled)[0];
+      tabs.find((tab) => tab.selected) ||
+      tabs.filter((tab) => !tab.disabled)[0];
     this.selectTab(tabToSelect);
   }
 
   resetTabs() {
     const tabs = this.getAllEnabledTabs();
-    tabs.forEach(tab => tab.selected = false);
+    tabs.forEach((tab) => (tab.selected = false));
   }
 
   resetPanels() {
@@ -197,8 +198,10 @@ export class TabNav {
 
   deselectTabs(nextTab: HTMLScaleTabHeaderElement) {
     const tabs = this.getAllEnabledTabs();
-    tabs.forEach(tab => {
-      if (tab !== nextTab) { tab.selected = false }
+    tabs.forEach((tab) => {
+      if (tab !== nextTab) {
+        tab.selected = false;
+      }
     });
   }
 

--- a/packages/components/src/components/tab-nav/tab-nav.tsx
+++ b/packages/components/src/components/tab-nav/tab-nav.tsx
@@ -95,9 +95,8 @@ export class TabNav {
       customElements.whenDefined('scale-tab-header'),
       customElements.whenDefined('scale-tab-panel'),
     ]).then(() => {
-      this.linkPanels();
+      this.linkPanelsAndSelectTab();
       this.propagateSizeToTabs();
-      this.selectNextTab();
     });
 
     if (this.small !== false) {
@@ -148,13 +147,14 @@ export class TabNav {
     return tabs[tabs.length - 1];
   }
 
-  linkPanels() {
+  linkPanelsAndSelectTab() {
     const tabs = this.getAllTabs();
     tabs.forEach((tab) => {
       const panel = tab.nextElementSibling;
       tab.setAttribute('aria-controls', panel.id);
       panel.setAttribute('aria-labelledby', tab.id);
     });
+    this.selectNextTab();
   }
 
   selectNextTab(nextTab?: HTMLScaleTabHeaderElement): void {

--- a/packages/components/src/components/tab-nav/tab-nav.tsx
+++ b/packages/components/src/components/tab-nav/tab-nav.tsx
@@ -187,8 +187,8 @@ export class TabNav {
     if (!nextTab.selected) {
       nextTab.selected = true;
     }
-    const targetPanel = this.findPanelForTab(nextTab);
-    targetPanel.hidden = false;
+    const nextPanel = this.findPanelForTab(nextTab);
+    nextPanel.hidden = false;
   }
 
   /**

--- a/packages/components/src/components/tab-nav/tab-nav.tsx
+++ b/packages/components/src/components/tab-nav/tab-nav.tsx
@@ -42,9 +42,11 @@ export class TabNav {
   handleSelect(event) {
     const nextTab = event.target as HTMLScaleTabHeaderElement;
     // Act only if it's a direct child
-    if (this.getAllEnabledTabs().includes(nextTab) && !nextTab.disabled) {
-      this.selectTab(nextTab);
+    if (!this.getAllEnabledTabs().includes(nextTab) || nextTab.disabled) {
+      return;
     }
+    this.deselectTabs(nextTab);
+    this.selectPanel(nextTab);
   }
 
   @Listen('scale-got-disabled')
@@ -166,11 +168,13 @@ export class TabNav {
     this.selectTab(tabToSelect);
   }
 
-  reset() {
+  resetTabs() {
     const tabs = this.getAllEnabledTabs();
-    const panels = this.getAllPanels();
+    tabs.forEach(tab => tab.selected = false);
+  }
 
-    tabs.forEach((tab) => (tab.selected = false));
+  resetPanels() {
+    const panels = this.getAllPanels();
     panels.forEach((panel) => (panel.hidden = true));
   }
 
@@ -180,10 +184,22 @@ export class TabNav {
   }
 
   selectTab(nextTab: HTMLScaleTabHeaderElement) {
-    const nextPanel = this.findPanelForTab(nextTab);
-    this.reset();
-    nextPanel.hidden = false;
+    this.resetTabs();
     nextTab.selected = true;
+    this.selectPanel(nextTab);
+  }
+
+  selectPanel(nextTab: HTMLScaleTabHeaderElement) {
+    this.resetPanels();
+    const nextPanel = this.findPanelForTab(nextTab);
+    nextPanel.hidden = false;
+  }
+
+  deselectTabs(nextTab: HTMLScaleTabHeaderElement) {
+    const tabs = this.getAllEnabledTabs();
+    tabs.forEach(tab => {
+      if (tab !== nextTab) { tab.selected = false }
+    });
   }
 
   /**

--- a/packages/components/src/components/tab-nav/tab-nav.tsx
+++ b/packages/components/src/components/tab-nav/tab-nav.tsx
@@ -42,16 +42,12 @@ export class TabNav {
   handleSelect(event) {
     const nextTab = event.target as HTMLScaleTabHeaderElement;
     // Act only if it's a direct child
-    if (!this.getAllEnabledTabs().includes(nextTab) || nextTab.disabled) {
-      return;
-    }
-    this.deselectTabs(nextTab);
-    this.selectPanel(nextTab);
+    this.selectNextTab(nextTab);
   }
 
-  @Listen('scale-got-disabled')
+  @Listen('scale-disabled')
   handleDisabledTabHeader() {
-    this.selectProperTab();
+    this.selectNextTab();
   }
 
   @Listen('keydown')
@@ -101,7 +97,7 @@ export class TabNav {
     ]).then(() => {
       this.linkPanels();
       this.propagateSizeToTabs();
-      this.selectProperTab();
+      this.selectNextTab();
     });
 
     if (this.small !== false) {
@@ -161,17 +157,22 @@ export class TabNav {
     });
   }
 
-  selectProperTab(): void {
+  selectNextTab(nextTab?: HTMLScaleTabHeaderElement): void {
     const tabs = this.getAllTabs();
     const tabToSelect =
+      (!nextTab?.disabled && nextTab) ||
       tabs.find((tab) => tab.selected) ||
       tabs.filter((tab) => !tab.disabled)[0];
     this.selectTab(tabToSelect);
   }
 
-  resetTabs() {
+  resetTabs(nextTab?: HTMLScaleTabHeaderElement) {
     const tabs = this.getAllEnabledTabs();
-    tabs.forEach((tab) => (tab.selected = false));
+    tabs.forEach((tab) => {
+      if (tab !== nextTab) {
+        tab.selected = false;
+      }
+    });
   }
 
   resetPanels() {
@@ -185,24 +186,13 @@ export class TabNav {
   }
 
   selectTab(nextTab: HTMLScaleTabHeaderElement) {
-    this.resetTabs();
-    nextTab.selected = true;
-    this.selectPanel(nextTab);
-  }
-
-  selectPanel(nextTab: HTMLScaleTabHeaderElement) {
+    this.resetTabs(nextTab);
     this.resetPanels();
+    if (!nextTab.selected) {
+      nextTab.selected = true;
+    }
     const nextPanel = this.findPanelForTab(nextTab);
     nextPanel.hidden = false;
-  }
-
-  deselectTabs(nextTab: HTMLScaleTabHeaderElement) {
-    const tabs = this.getAllEnabledTabs();
-    tabs.forEach((tab) => {
-      if (tab !== nextTab) {
-        tab.selected = false;
-      }
-    });
   }
 
   /**

--- a/packages/components/src/html/tab-nav.html
+++ b/packages/components/src/html/tab-nav.html
@@ -1,57 +1,58 @@
 <!DOCTYPE html>
 <html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
+    />
+    <title>Stencil Component Starter</title>
 
-<head>
-	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
-	<title>Stencil Component Starter</title>
+    <script type="module" src="/build/scale-components.esm.js"></script>
+    <link rel="stylesheet" href="/build/scale-components.css" />
+    <style type="text/css" media="screen, print">
+      html {
+        margin: 0;
+        padding: 0;
+      }
 
-	<script type="module" src="/build/scale-components.esm.js"></script>
-	<link rel="stylesheet" href="/build/scale-components.css" />
-	<style type="text/css" media="screen, print">
-		html {
-			margin: 0;
-			padding: 0;
-		}
+      body {
+        margin: 0;
+        padding: 4rem;
+      }
+    </style>
+  </head>
 
-		body {
-			margin: 0;
-			padding: 4rem;
-		}
-	</style>
-</head>
-
-<body>
-	<p>
-		<scale-tab-nav>
-			<scale-tab-header slot="tab">General</scale-tab-header>
-			<scale-tab-panel slot="panel">
-				1 Freegan kinfolk farm-to-table humblebrag cred…
-			</scale-tab-panel>
-			<scale-tab-header slot="tab">Usage</scale-tab-header>
-			<scale-tab-panel slot="panel">
-				2 Bespoke austin pork belly yuccie pop-up. Before they sold out…
-			</scale-tab-panel>
-			<scale-tab-header slot="tab">Style</scale-tab-header>
-			<scale-tab-panel slot="panel">
-				3 Biodiesel chia af hoodie tumeric bespoke letterpress…
-			</scale-tab-panel>
-			<scale-tab-header slot="tab">Code</scale-tab-header>
-			<scale-tab-panel slot="panel">
-				4 Asymmetrical tattooed chia, banh mi blog microdosing…
-			</scale-tab-panel>
-		</scale-tab-nav>
-	</p>
-</body>
-<script>
-	setTimeout(() => {
-		let tabs = document.querySelectorAll('scale-tab-header');
-		tabs[0].disabled = true;
-	}, 2000);
-	setTimeout(() => {
-		let tabs = document.querySelectorAll('scale-tab-header');
-		tabs[3].selected = true;
-	}, 4000);
-</script>
-
+  <body>
+    <p>
+      <scale-tab-nav>
+        <scale-tab-header slot="tab">General</scale-tab-header>
+        <scale-tab-panel slot="panel">
+          1 Freegan kinfolk farm-to-table humblebrag cred…
+        </scale-tab-panel>
+        <scale-tab-header slot="tab">Usage</scale-tab-header>
+        <scale-tab-panel slot="panel">
+          2 Bespoke austin pork belly yuccie pop-up. Before they sold out…
+        </scale-tab-panel>
+        <scale-tab-header slot="tab">Style</scale-tab-header>
+        <scale-tab-panel slot="panel">
+          3 Biodiesel chia af hoodie tumeric bespoke letterpress…
+        </scale-tab-panel>
+        <scale-tab-header slot="tab">Code</scale-tab-header>
+        <scale-tab-panel slot="panel">
+          4 Asymmetrical tattooed chia, banh mi blog microdosing…
+        </scale-tab-panel>
+      </scale-tab-nav>
+    </p>
+  </body>
+  <script>
+    setTimeout(() => {
+      let tabs = document.querySelectorAll('scale-tab-header');
+      tabs[0].disabled = true;
+    }, 2000);
+    setTimeout(() => {
+      let tabs = document.querySelectorAll('scale-tab-header');
+      tabs[3].selected = true;
+    }, 4000);
+  </script>
 </html>

--- a/packages/components/src/html/tab-nav.html
+++ b/packages/components/src/html/tab-nav.html
@@ -28,7 +28,7 @@
 			<scale-tab-panel slot="panel">
 				1 Freegan kinfolk farm-to-table humblebrag cred…
 			</scale-tab-panel>
-			<scale-tab-header selected slot="tab">Usage</scale-tab-header>
+			<scale-tab-header slot="tab">Usage</scale-tab-header>
 			<scale-tab-panel slot="panel">
 				2 Bespoke austin pork belly yuccie pop-up. Before they sold out…
 			</scale-tab-panel>
@@ -46,9 +46,12 @@
 <script>
 	setTimeout(() => {
 		let tabs = document.querySelectorAll('scale-tab-header');
-		tabs[1].disabled = true;
 		tabs[0].disabled = true;
-	}, 1000);
+	}, 2000);
+	setTimeout(() => {
+		let tabs = document.querySelectorAll('scale-tab-header');
+		tabs[3].selected = true;
+	}, 4000);
 </script>
 
 </html>

--- a/packages/components/src/html/tab-nav.html
+++ b/packages/components/src/html/tab-nav.html
@@ -24,24 +24,31 @@
 <body>
 	<p>
 		<scale-tab-nav>
-			<scale-tab-header disabled slot="tab">General</scale-tab-header>
+			<scale-tab-header slot="tab">General</scale-tab-header>
 			<scale-tab-panel slot="panel">
-				Freegan kinfolk farm-to-table humblebrag cred…
+				1 Freegan kinfolk farm-to-table humblebrag cred…
 			</scale-tab-panel>
-			<scale-tab-header slot="tab">Usage</scale-tab-header>
+			<scale-tab-header selected slot="tab">Usage</scale-tab-header>
 			<scale-tab-panel slot="panel">
-				Bespoke austin pork belly yuccie pop-up. Before they sold out…
+				2 Bespoke austin pork belly yuccie pop-up. Before they sold out…
 			</scale-tab-panel>
-			<scale-tab-header selected slot="tab">Style</scale-tab-header>
+			<scale-tab-header slot="tab">Style</scale-tab-header>
 			<scale-tab-panel slot="panel">
-				Biodiesel chia af hoodie tumeric bespoke letterpress…
+				3 Biodiesel chia af hoodie tumeric bespoke letterpress…
 			</scale-tab-panel>
 			<scale-tab-header slot="tab">Code</scale-tab-header>
 			<scale-tab-panel slot="panel">
-				Asymmetrical tattooed chia, banh mi blog microdosing…
+				4 Asymmetrical tattooed chia, banh mi blog microdosing…
 			</scale-tab-panel>
 		</scale-tab-nav>
 	</p>
 </body>
+<script>
+	setTimeout(() => {
+		let tabs = document.querySelectorAll('scale-tab-header');
+		tabs[1].disabled = true;
+		tabs[0].disabled = true;
+	}, 1000);
+</script>
 
 </html>

--- a/packages/components/src/html/tab-nav.html
+++ b/packages/components/src/html/tab-nav.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+
+<head>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+	<title>Stencil Component Starter</title>
+
+	<script type="module" src="/build/scale-components.esm.js"></script>
+	<link rel="stylesheet" href="/build/scale-components.css" />
+	<style type="text/css" media="screen, print">
+		html {
+			margin: 0;
+			padding: 0;
+		}
+
+		body {
+			margin: 0;
+			padding: 4rem;
+		}
+	</style>
+</head>
+
+<body>
+	<p>
+		<scale-tab-nav>
+			<scale-tab-header disabled slot="tab">General</scale-tab-header>
+			<scale-tab-panel slot="panel">
+				Freegan kinfolk farm-to-table humblebrag cred…
+			</scale-tab-panel>
+			<scale-tab-header slot="tab">Usage</scale-tab-header>
+			<scale-tab-panel slot="panel">
+				Bespoke austin pork belly yuccie pop-up. Before they sold out…
+			</scale-tab-panel>
+			<scale-tab-header selected slot="tab">Style</scale-tab-header>
+			<scale-tab-panel slot="panel">
+				Biodiesel chia af hoodie tumeric bespoke letterpress…
+			</scale-tab-panel>
+			<scale-tab-header slot="tab">Code</scale-tab-header>
+			<scale-tab-panel slot="panel">
+				Asymmetrical tattooed chia, banh mi blog microdosing…
+			</scale-tab-panel>
+		</scale-tab-nav>
+	</p>
+</body>
+
+</html>

--- a/packages/storybook-vue/stories/components/tab-navigation/ScaleTabNav.vue
+++ b/packages/storybook-vue/stories/components/tab-navigation/ScaleTabNav.vue
@@ -53,11 +53,11 @@
 <script>
 export default {
   props: {
-    styles: {type: String},
-    disabled: {type: Boolean, default: false},
-    preselected: {type: Boolean, default: false},
-    withIcon: {type: Boolean, default: true},
-    size: {type: String, default: 'small'},
+    styles: { type: String },
+    disabled: { type: Boolean, default: false },
+    preselected: { type: Boolean, default: false },
+    withIcon: { type: Boolean, default: true },
+    size: { type: String, default: 'small' },
   },
 };
 </script>

--- a/packages/storybook-vue/stories/components/tab-navigation/ScaleTabNav.vue
+++ b/packages/storybook-vue/stories/components/tab-navigation/ScaleTabNav.vue
@@ -24,7 +24,7 @@
         bitters.
       </p>
     </scale-tab-panel>
-    <scale-tab-header slot="tab">
+    <scale-tab-header :selected="preselected ? true : false" slot="tab">
       <scale-icon-content-heart v-if="withIcon" /> Style
     </scale-tab-header>
     <scale-tab-panel slot="panel">
@@ -53,10 +53,11 @@
 <script>
 export default {
   props: {
-    styles: { type: String },
-    disabled: { type: Boolean, default: false },
-    withIcon: { type: Boolean, default: true },
-    size: { type: String, default: 'small' },
+    styles: {type: String},
+    disabled: {type: Boolean, default: false},
+    preselected: {type: Boolean, default: false},
+    withIcon: {type: Boolean, default: true},
+    size: {type: String, default: 'small'},
   },
 };
 </script>

--- a/packages/storybook-vue/stories/components/tab-navigation/ScaleTabNav.vue
+++ b/packages/storybook-vue/stories/components/tab-navigation/ScaleTabNav.vue
@@ -58,6 +58,7 @@ export default {
     preselected: { type: Boolean, default: false },
     withIcon: { type: Boolean, default: true },
     size: { type: String, default: 'small' },
+    small: { type: Boolean, default: false },
   },
 };
 </script>

--- a/packages/storybook-vue/stories/components/tab-navigation/TabHeader.vue
+++ b/packages/storybook-vue/stories/components/tab-navigation/TabHeader.vue
@@ -5,7 +5,7 @@ export default {
     styles: {type: String},
     disabled: {type: Boolean, default: 'false'},
     selected: {type: Boolean, default: 'false'},
-    size: {type: ['large', 'small'], defaultValue: 'small'}
+    size: {type: ['large', 'small'], default: 'small'}
   }
 };
 </script>

--- a/packages/storybook-vue/stories/components/tab-navigation/TabHeader.vue
+++ b/packages/storybook-vue/stories/components/tab-navigation/TabHeader.vue
@@ -5,9 +5,7 @@ export default {
     styles: {type: String},
     disabled: {type: Boolean, default: 'false'},
     selected: {type: Boolean, default: 'false'},
-    size: {
-      control: {type: ['large', 'small'], defaultValue: 'small'}
-    }
+    size: {type: ['large', 'small'], defaultValue: 'small'}
   }
 };
 </script>

--- a/packages/storybook-vue/stories/components/tab-navigation/TabHeader.vue
+++ b/packages/storybook-vue/stories/components/tab-navigation/TabHeader.vue
@@ -6,8 +6,8 @@ export default {
     disabled: {type: Boolean, default: 'false'},
     selected: {type: Boolean, default: 'false'},
     size: {
-      control: {type: 'select', options: ['large', 'small'], defaultValue: 'small'},
-    },
+      control: {type: ['large', 'small'], defaultValue: 'small'}
+    }
   }
 };
 </script>

--- a/packages/storybook-vue/stories/components/tab-navigation/TabHeader.vue
+++ b/packages/storybook-vue/stories/components/tab-navigation/TabHeader.vue
@@ -1,0 +1,13 @@
+<script>
+export default {
+  name: 'Tab Header',
+  props: {
+    styles: {type: String},
+    disabled: {type: Boolean, default: 'false'},
+    selected: {type: Boolean, default: 'false'},
+    size: {
+      control: {type: 'select', options: ['large', 'small'], defaultValue: 'small'},
+    },
+  }
+};
+</script>

--- a/packages/storybook-vue/stories/components/tab-navigation/TabHeader.vue
+++ b/packages/storybook-vue/stories/components/tab-navigation/TabHeader.vue
@@ -2,10 +2,10 @@
 export default {
   name: 'Tab Header',
   props: {
-    styles: {type: String},
-    disabled: {type: Boolean, default: 'false'},
-    selected: {type: Boolean, default: 'false'},
-    size: {type: ['large', 'small'], default: 'small'}
-  }
+    styles: { type: String },
+    disabled: { type: Boolean, default: 'false' },
+    selected: { type: Boolean, default: 'false' },
+    size: { type: ['large', 'small'], default: 'small' },
+  },
 };
 </script>

--- a/packages/storybook-vue/stories/components/tab-navigation/TabNav.stories.mdx
+++ b/packages/storybook-vue/stories/components/tab-navigation/TabNav.stories.mdx
@@ -35,6 +35,13 @@ import TabPanel from './TabPanel.vue';
       description: `(optional) DEPRECATED - size should replace small`,
       control: { type: null },
     },
+    preselected: {
+      table: {
+        disable: true,
+      },
+      description: '',
+      control: { type: null },
+    },
   }}
 />
 
@@ -124,8 +131,9 @@ export const Template = (args, { argTypes }) => ({
   --color-hover: var(--telekom-color-text-and-icon-primary-hovered);
   --color-active: var(--telekom-color-text-and-icon-primary-pressed);
   --color-selected: var(--telekom-color-text-and-icon-primary-standard);
-  --focus-outline: var(--telekom-line-weight-highlight) solid
-    var(--telekom-color-functional-focus-standard);
+  --focus-outline: var(--telekom-line-weight-highlight) solid var(
+      --telekom-color-functional-focus-standard
+    );
   --spacing-right-slotted: var(--telekom-spacing-composition-space-04);
   --color-disabled: var(--telekom-color-text-and-icon-disabled);
   --radius: var(--telekom-radius-standard);

--- a/packages/storybook-vue/stories/components/tab-navigation/TabNav.stories.mdx
+++ b/packages/storybook-vue/stories/components/tab-navigation/TabNav.stories.mdx
@@ -200,6 +200,38 @@ For Shadow Parts, please inspect the element's #shadow.
 </scale-tab-nav>
 ```
 
+## Preselected Tab
+
+<Canvas withSource="none">
+  <Story
+    name="Preselected Tab"
+    args={{ withIcon: false, size: 'small' }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+```html
+<scale-tab-nav>
+  <scale-tab-header slot="tab">General</scale-tab-header>
+  <scale-tab-panel slot="panel">
+    Freegan kinfolk farm-to-table humblebrag cred…
+  </scale-tab-panel>
+  <scale-tab-header slot="tab">Usage</scale-tab-header>
+  <scale-tab-panel slot="panel">
+    Bespoke austin pork belly yuccie pop-up. Before they sold out…
+  </scale-tab-panel>
+  <scale-tab-header selected slot="tab">Style</scale-tab-header>
+  <scale-tab-panel slot="panel">
+    Biodiesel chia af hoodie tumeric bespoke letterpress…
+  </scale-tab-panel>
+  <scale-tab-header slot="tab">Code</scale-tab-header>
+  <scale-tab-panel slot="panel">
+    Asymmetrical tattooed chia, banh mi blog microdosing…
+  </scale-tab-panel>
+</scale-tab-nav>
+```
+
 ## Large, Text & Icon
 
 <Canvas withSource="none">

--- a/packages/storybook-vue/stories/components/tab-navigation/TabNav.stories.mdx
+++ b/packages/storybook-vue/stories/components/tab-navigation/TabNav.stories.mdx
@@ -6,6 +6,7 @@ import {
   Description,
 } from '@storybook/addon-docs';
 import ScaleTabNav from './ScaleTabNav.vue';
+import TabHeader from './TabHeader.vue';
 import TabPanel from './TabPanel.vue';
 
 <Meta

--- a/packages/storybook-vue/stories/components/tab-navigation/TabNav.stories.mdx
+++ b/packages/storybook-vue/stories/components/tab-navigation/TabNav.stories.mdx
@@ -41,7 +41,7 @@ export const Template = (args, { argTypes }) => ({
   components: { ScaleTabNav },
   props: ScaleTabNav.props,
   template: `
-    <scale-tab-nav :disabled="disabled ? true : false" :size="size" :with-icon="withIcon"></scale-tab-nav>
+    <scale-tab-nav :disabled="disabled ? true : false" :preselected="preselected ? true : false" :size="size" :with-icon="withIcon"></scale-tab-nav>
   `,
 });
 
@@ -181,7 +181,7 @@ For Shadow Parts, please inspect the element's #shadow.
 
 ```html
 <scale-tab-nav>
-  <scale-tab-header disabled slot="tab">General0000</scale-tab-header>
+  <scale-tab-header disabled slot="tab">General</scale-tab-header>
   <scale-tab-panel slot="panel">
     Freegan kinfolk farm-to-table humblebrag cred…
   </scale-tab-panel>
@@ -205,7 +205,7 @@ For Shadow Parts, please inspect the element's #shadow.
 <Canvas withSource="none">
   <Story
     name="Preselected Tab"
-    args={{ withIcon: false, size: 'small' }}
+    args={{ preselected: true, withIcon: false, size: 'small' }}
   >
     {Template.bind({})}
   </Story>
@@ -213,7 +213,7 @@ For Shadow Parts, please inspect the element's #shadow.
 
 ```html
 <scale-tab-nav>
-  <scale-tab-header slot="tab">General11111</scale-tab-header>
+  <scale-tab-header slot="tab">General</scale-tab-header>
   <scale-tab-panel slot="panel">
     Freegan kinfolk farm-to-table humblebrag cred…
   </scale-tab-panel>

--- a/packages/storybook-vue/stories/components/tab-navigation/TabNav.stories.mdx
+++ b/packages/storybook-vue/stories/components/tab-navigation/TabNav.stories.mdx
@@ -11,7 +11,7 @@ import TabPanel from './TabPanel.vue';
 <Meta
   title="Components/Tab Navigation"
   component={ScaleTabNav}
-  subcomponents={{ 'Scale Tab Panel': TabPanel }}
+  subcomponents={{ 'Scale Tab Header': TabHeader, 'Scale Tab Panel': TabPanel }}
   argTypes={{
     styles: {
       table: {

--- a/packages/storybook-vue/stories/components/tab-navigation/TabNav.stories.mdx
+++ b/packages/storybook-vue/stories/components/tab-navigation/TabNav.stories.mdx
@@ -181,7 +181,7 @@ For Shadow Parts, please inspect the element's #shadow.
 
 ```html
 <scale-tab-nav>
-  <scale-tab-header disabled slot="tab">General</scale-tab-header>
+  <scale-tab-header disabled slot="tab">General0000</scale-tab-header>
   <scale-tab-panel slot="panel">
     Freegan kinfolk farm-to-table humblebrag cred…
   </scale-tab-panel>
@@ -213,7 +213,7 @@ For Shadow Parts, please inspect the element's #shadow.
 
 ```html
 <scale-tab-nav>
-  <scale-tab-header slot="tab">General</scale-tab-header>
+  <scale-tab-header slot="tab">General11111</scale-tab-header>
   <scale-tab-panel slot="panel">
     Freegan kinfolk farm-to-table humblebrag cred…
   </scale-tab-panel>


### PR DESCRIPTION
Fixes https://github.com/telekom/scale/issues/2282

- now if selected tab gots disabled, selection moves to first available tab
- example of preselected tab logic added to storybook 
