### PR TITLE
fix: empty date in datagrid kills rendering

### DIFF
--- a/packages/components/src/components/data-grid/cell-handlers/date-cell.tsx
+++ b/packages/components/src/components/data-grid/cell-handlers/date-cell.tsx
@@ -24,7 +24,7 @@ export const DateCell: Cell = {
     sortBy: 'date',
   },
   render: ({ content, isAutoWidthCheck }) => {
-    let value = content;
+    let value = content ?? '';
 
     // Render all digits with 8s as they're the widest
     if (isAutoWidthCheck) {


### PR DESCRIPTION
This is a simple change which will avoid a fatal call to replace on undefined or null