### PR TITLE
Feature/fix segments

### DIFF
--- a/packages/components/src/components/collapsible/collapsible.tsx
+++ b/packages/components/src/components/collapsible/collapsible.tsx
@@ -76,8 +76,9 @@ export class Collapsible {
    * @see https://github.com/telekom/scale/pull/319
    */
   setHeadingFromLightDOM() {
-    const lightHeading: HTMLElement =
-      this.hostElement.querySelector(':first-child');
+    const lightHeading: HTMLElement = this.hostElement.querySelector(
+      ':first-child'
+    );
     if (lightHeading == null) {
       return;
     }

--- a/packages/components/src/components/data-grid/data-grid.tsx
+++ b/packages/components/src/components/data-grid/data-grid.tsx
@@ -299,9 +299,8 @@ export class DataGrid {
       if (this.rows[i].length !== this.fields.length) {
         // tslint:disable-next-line: no-console
         console.warn(
-          `Unable to render ${
-            this.heading && `"${this.heading}" `
-          }table: row data length not equal to supplied fields.`
+          `Unable to render ${this.heading &&
+            `"${this.heading}" `}table: row data length not equal to supplied fields.`
         );
         return false;
       }
@@ -893,8 +892,8 @@ export class DataGrid {
           {this.selectable && (
             <scale-menu-flyout-item
               onScale-select={() => {
-                this.elToggleSelectAll.checked =
-                  !this.elToggleSelectAll.checked;
+                this.elToggleSelectAll.checked = !this.elToggleSelectAll
+                  .checked;
                 this.toggleSelectAll();
               }}
             >

--- a/packages/components/src/components/date-picker/date-picker.tsx
+++ b/packages/components/src/components/date-picker/date-picker.tsx
@@ -364,9 +364,8 @@ export class DatePicker {
       '.duet-date__day.is-today span.duet-date__vhidden'
     );
     if (today) {
-      today.innerHTML = `${today.innerHTML}, ${
-        this.localization?.today || 'today'
-      }`;
+      today.innerHTML = `${today.innerHTML}, ${this.localization?.today ||
+        'today'}`;
     }
 
     this.adjustButtonsLabelsForA11y();

--- a/packages/components/src/components/dropdown-select/dropdown-select.e2e.ts
+++ b/packages/components/src/components/dropdown-select/dropdown-select.e2e.ts
@@ -1,7 +1,7 @@
 import { E2EElement, E2EPage, newE2EPage } from '@stencil/core/testing';
 import { DropdownSelect } from './dropdown-select';
 
-describe('DropdownSelect', function () {
+describe('DropdownSelect', function() {
   it('should be able to change it`s value via keyboard nav', async () => {
     const page = await newE2EPage({
       components: [DropdownSelect],

--- a/packages/components/src/components/dropdown-select/dropdown-select.spec.ts
+++ b/packages/components/src/components/dropdown-select/dropdown-select.spec.ts
@@ -1,7 +1,7 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { DropdownSelect } from './dropdown-select';
 
-describe('DropdownSelect', function () {
+describe('DropdownSelect', function() {
   it('should take options via slots', async () => {
     const page = await newSpecPage({
       components: [DropdownSelect],
@@ -65,8 +65,8 @@ describe('DropdownSelect', function () {
     const selectEl = page.doc.querySelector('scale-dropdown-select');
     selectEl.addEventListener('scale-change', changeSpy);
     const comboboxEl = selectEl.shadowRoot.querySelector('[part="combobox"]');
-    comboboxEl.scrollIntoView = function () {};
-    comboboxEl.focus = function () {};
+    comboboxEl.scrollIntoView = function() {};
+    comboboxEl.focus = function() {};
     const optionsEls = selectEl.shadowRoot.querySelectorAll('[role="option"]');
 
     comboboxEl.click();
@@ -100,12 +100,14 @@ describe('DropdownSelect', function () {
 
       const selectEl = page.doc.querySelector('scale-dropdown-select');
       selectEl.addEventListener('scale-change', changeSpy);
-      const comboboxEl: HTMLElement =
-        selectEl.shadowRoot.querySelector('[part="combobox"]');
-      comboboxEl.scrollIntoView = function () {};
-      comboboxEl.focus = function () {};
-      const optionsEls: NodeListOf<HTMLElement> =
-        selectEl.shadowRoot.querySelectorAll('[role="option"]');
+      const comboboxEl: HTMLElement = selectEl.shadowRoot.querySelector(
+        '[part="combobox"]'
+      );
+      comboboxEl.scrollIntoView = function() {};
+      comboboxEl.focus = function() {};
+      const optionsEls: NodeListOf<HTMLElement> = selectEl.shadowRoot.querySelectorAll(
+        '[role="option"]'
+      );
       optionsEls[1].addEventListener('click', clickSpy);
 
       comboboxEl.click();

--- a/packages/components/src/components/dropdown-select/dropdown-select.tsx
+++ b/packages/components/src/components/dropdown-select/dropdown-select.tsx
@@ -345,8 +345,9 @@ export class DropdownSelect {
   }
 
   bringIntoView(index) {
-    const options: NodeListOf<HTMLElement> =
-      this.listboxEl.querySelectorAll('[role=option]');
+    const options: NodeListOf<HTMLElement> = this.listboxEl.querySelectorAll(
+      '[role=option]'
+    );
 
     if (hasOverflow(this.listboxEl)) {
       keepInView(options[index], this.listboxEl);

--- a/packages/components/src/components/input/input.tsx
+++ b/packages/components/src/components/input/input.tsx
@@ -156,14 +156,12 @@ export class Input {
       tag: 'deprecated',
       source: this.el,
       type: 'warn',
-      extraMessage: `Please use <${
-        {
-          select: 'scale-dropdown',
-          checkbox: 'scale-checkbox',
-          radio: 'scale-radio-button',
-          textarea: 'scale-textarea',
-        }[this.type] || 'scale-text-field'
-      }> instead.`,
+      extraMessage: `Please use <${{
+        select: 'scale-dropdown',
+        checkbox: 'scale-checkbox',
+        radio: 'scale-radio-button',
+        textarea: 'scale-textarea',
+      }[this.type] || 'scale-text-field'}> instead.`,
     });
     // Keep this.value up-to-date for type="select".
     // This is important also for React, where `value` is used to control the element state.

--- a/packages/components/src/components/menu-flyout-list/menu-flyout-list.tsx
+++ b/packages/components/src/components/menu-flyout-list/menu-flyout-list.tsx
@@ -457,9 +457,10 @@ export class MenuFlyoutList {
   }
 
   getListItems() {
-    return Array.from(this.hostElement.children).filter(
-      (el: HTMLScaleMenuFlyoutItemElement) =>
-        ITEM_ROLES.includes(el.getAttribute('role'))
+    return Array.from(
+      this.hostElement.children
+    ).filter((el: HTMLScaleMenuFlyoutItemElement) =>
+      ITEM_ROLES.includes(el.getAttribute('role'))
     );
   }
 

--- a/packages/components/src/components/notification-toast/notification-toast.tsx
+++ b/packages/components/src/components/notification-toast/notification-toast.tsx
@@ -264,8 +264,8 @@ export class NotificationToast {
   };
 
   getToastHeightWithOffset() {
-    const toastHeight =
-      this.element.shadowRoot.querySelector('.toast').scrollHeight;
+    const toastHeight = this.element.shadowRoot.querySelector('.toast')
+      .scrollHeight;
     this.toastHeightWithOffset = toastHeight + this.positionVertical;
   }
 

--- a/packages/components/src/components/segment/segment.tsx
+++ b/packages/components/src/components/segment/segment.tsx
@@ -38,7 +38,7 @@ export class Segment {
   /** (optional) If `true`, the segment is disabled */
   @Prop() disabled?: boolean = false;
   /** (optional) segment's id */
-  @Prop({ reflect: true, mutable: true }) segmentId?: string;
+  @Prop({ reflect: true }) segmentId?: string = 'segment-' + i++;
   /** (optional) aria-label attribute needed for icon-only segments */
   @Prop() ariaLabelSegment: string;
   /** (optional) Segment width set to ensure that all segments have the same width */
@@ -85,12 +85,7 @@ export class Segment {
     this.focusableElement.focus();
   }
 
-  componentWillLoad() {
-    if (this.segmentId == null) {
-      this.segmentId = 'segment-' + i++;
-    }
-  }
-  componentDidUpdate() {
+  componentWillUpdate() {
     this.handleIcon();
   }
 

--- a/packages/components/src/components/segmented-button/segmented-button.tsx
+++ b/packages/components/src/components/segmented-button/segmented-button.tsx
@@ -138,12 +138,10 @@ export class SegmentedButton {
   }
   componentDidLoad() {
     const longestButtonWidth = this.getLongestButtonWidth();
-    if (!this.fullWidth) {
-      this.container.style.gridTemplateColumns = longestButtonWidth
-        ? `repeat(${this.hostElement.children.length}, ${Math.ceil(
-            longestButtonWidth
-          )}px)`
-        : `repeat(${this.hostElement.children.length}, auto)`;
+    if (!this.fullWidth && this.longestButtonWidth) {
+      this.container.style.gridTemplateColumns = `repeat(${
+        this.hostElement.children.length
+      }, ${Math.ceil(longestButtonWidth)}px)`;
     } else {
       this.container.style.display = 'flex';
     }
@@ -193,8 +191,9 @@ export class SegmentedButton {
   getLongestButtonWidth() {
     let tempWidth = 0;
     Array.from(this.hostElement.children)
-      .filter((child) => child.getBoundingClientRect().width)
-      .forEach((child) => {
+      .filter((child: HTMLScaleSegmentElement) => this.getWidth(child))
+      .forEach((child: HTMLScaleSegmentElement) => {
+        const width = this.getWidth(child);
         const selected = child.hasAttribute('selected');
         const iconOnly = child.hasAttribute('icon-only');
         const checkmark =
@@ -204,20 +203,25 @@ export class SegmentedButton {
             ? CHECKMARK_WIDTH_MEDIUM
             : CHECKMARK_WIDTH_LARGE;
         if (selected || iconOnly) {
-          tempWidth =
-            child.getBoundingClientRect().width > tempWidth
-              ? child.getBoundingClientRect().width
-              : tempWidth;
+          tempWidth = width > tempWidth ? width : tempWidth;
         } else {
           tempWidth =
-            child.getBoundingClientRect().width + checkmark > tempWidth
-              ? child.getBoundingClientRect().width + checkmark
-              : tempWidth;
+            width + checkmark > tempWidth ? width + checkmark : tempWidth;
         }
       });
     return tempWidth;
   }
-
+  getWidth = (element: HTMLScaleSegmentElement) => {
+    const rect = element.getBoundingClientRect();
+    let width = rect.width;
+    if (!width) {
+      const widthString = element.width || element.getAttribute('width');
+      if (widthString && widthString.includes('px')) {
+        width = parseFloat(widthString.replace('px', ''));
+      }
+    }
+    return width;
+  };
   setState(tempState: SegmentStatus[]) {
     const segments = Array.from(
       this.hostElement.querySelectorAll('scale-segment')

--- a/packages/components/src/components/segmented-button/segmented-button.tsx
+++ b/packages/components/src/components/segmented-button/segmented-button.tsx
@@ -52,7 +52,7 @@ export class SegmentedButton {
   /** (optional) Allow more than one button to be selected */
   @Prop() multiSelect: boolean = false;
   /** (optional) the index of the selected segment */
-  @Prop() selectedIndex?: number;
+  @Prop({ mutable: true }) selectedIndex?: number;
   /** (optional) If `true`, the button is disabled */
   @Prop({ reflect: true }) disabled?: boolean = false;
   /** (optional) If `true`, expand to container width */
@@ -119,38 +119,35 @@ export class SegmentedButton {
     });
   }
 
-  componentDidLoad() {
+  componentWillLoad() {
     const tempState: SegmentStatus[] = [];
     const segments = this.getAllSegments();
     this.slottedSegments = segments.length;
-    const longestButtonWidth = this.getLongestButtonWidth();
-    segments.forEach((segment) => {
-      this.position++;
+    segments.forEach((segment, i) => {
       tempState.push({
         id: segment.getAttribute('segment-id') || segment.segmentId,
         selected: segment.hasAttribute('selected') || segment.selected,
       });
-      segment.setAttribute('position', this.position.toString());
+      segment.setAttribute('position', `${i + 1}`);
       segment.setAttribute(
         'aria-description-translation',
         '$position $selected'
       );
     });
+    this.setState(tempState);
+  }
+  componentDidLoad() {
+    const longestButtonWidth = this.getLongestButtonWidth();
     if (!this.fullWidth) {
-      this.container.style.gridTemplateColumns = `repeat(${
-        this.hostElement.children.length
-      }, ${Math.ceil(longestButtonWidth)}px)`;
+      this.container.style.gridTemplateColumns = longestButtonWidth
+        ? `repeat(${this.hostElement.children.length}, ${Math.ceil(
+            longestButtonWidth
+          )}px)`
+        : `repeat(${this.hostElement.children.length}, auto)`;
     } else {
       this.container.style.display = 'flex';
     }
-
-    this.selectedIndex = this.getSelectedIndex();
-    this.propagatePropsToChildren();
-    this.position = 0;
-    this.status = tempState;
-    this.setState(tempState);
   }
-
   componentWillUpdate() {
     this.selectedIndex = this.getSelectedIndex();
     this.showHelperText = false;
@@ -195,27 +192,29 @@ export class SegmentedButton {
   // all segmented buttons should have the same width, based on the largest one
   getLongestButtonWidth() {
     let tempWidth = 0;
-    Array.from(this.hostElement.children).forEach((child) => {
-      const selected = child.hasAttribute('selected');
-      const iconOnly = child.hasAttribute('icon-only');
-      const checkmark =
-        this.size === 'small'
-          ? CHECKMARK_WIDTH_SMALL
-          : this.size === 'medium'
-          ? CHECKMARK_WIDTH_MEDIUM
-          : CHECKMARK_WIDTH_LARGE;
-      if (selected || iconOnly) {
-        tempWidth =
-          child.getBoundingClientRect().width > tempWidth
-            ? child.getBoundingClientRect().width
-            : tempWidth;
-      } else {
-        tempWidth =
-          child.getBoundingClientRect().width + checkmark > tempWidth
-            ? child.getBoundingClientRect().width + checkmark
-            : tempWidth;
-      }
-    });
+    Array.from(this.hostElement.children)
+      .filter((child) => child.getBoundingClientRect().width)
+      .forEach((child) => {
+        const selected = child.hasAttribute('selected');
+        const iconOnly = child.hasAttribute('icon-only');
+        const checkmark =
+          this.size === 'small'
+            ? CHECKMARK_WIDTH_SMALL
+            : this.size === 'medium'
+            ? CHECKMARK_WIDTH_MEDIUM
+            : CHECKMARK_WIDTH_LARGE;
+        if (selected || iconOnly) {
+          tempWidth =
+            child.getBoundingClientRect().width > tempWidth
+              ? child.getBoundingClientRect().width
+              : tempWidth;
+        } else {
+          tempWidth =
+            child.getBoundingClientRect().width + checkmark > tempWidth
+              ? child.getBoundingClientRect().width + checkmark
+              : tempWidth;
+        }
+      });
     return tempWidth;
   }
 

--- a/packages/components/src/components/telekom/app-header/app-header.tsx
+++ b/packages/components/src/components/telekom/app-header/app-header.tsx
@@ -128,11 +128,13 @@ export class Header {
   }
 
   componentWillLoad() {
-    this.hasSlotMenuMain =
-      !!this.hostElement.querySelector('[slot="menu-main"]');
+    this.hasSlotMenuMain = !!this.hostElement.querySelector(
+      '[slot="menu-main"]'
+    );
 
-    this.hasSlotMenuIcon =
-      !!this.hostElement.querySelector('[slot="menu-icon"]');
+    this.hasSlotMenuIcon = !!this.hostElement.querySelector(
+      '[slot="menu-icon"]'
+    );
     this.hasSlotMenuSector = !!this.hostElement.querySelector(
       '[slot="menu-sector"]'
     );
@@ -149,11 +151,13 @@ export class Header {
   }
 
   componentDidUpdate() {
-    this.hasSlotMenuMain =
-      !!this.hostElement.querySelector('[slot="menu-main"]');
+    this.hasSlotMenuMain = !!this.hostElement.querySelector(
+      '[slot="menu-main"]'
+    );
 
-    this.hasSlotMenuIcon =
-      !!this.hostElement.querySelector('[slot="menu-icon"]');
+    this.hasSlotMenuIcon = !!this.hostElement.querySelector(
+      '[slot="menu-icon"]'
+    );
     this.hasSlotMenuSector = !!this.hostElement.querySelector(
       '[slot="menu-sector"]'
     );
@@ -281,13 +285,9 @@ export class Header {
     const { defaultName, openedName } = readData(this.iconNavigation).find(
       ({ id }) => id === 'menu'
     ) || { defaultName: 'Menu', openedName: 'Close' };
-    const {
-      shortName = 'Login',
-      badge,
-      badgeLabel,
-    } = readData(this.userNavigation).find(
-      ({ type }) => type === 'userInfo'
-    ) || {
+    const { shortName = 'Login', badge, badgeLabel } = readData(
+      this.userNavigation
+    ).find(({ type }) => type === 'userInfo') || {
       shortName: 'Login',
     };
 

--- a/packages/components/src/components/telekom/app-navigation-main-mobile/app-navigation-main-mobile.tsx
+++ b/packages/components/src/components/telekom/app-navigation-main-mobile/app-navigation-main-mobile.tsx
@@ -155,8 +155,9 @@ export class MainNavigationMobile {
                     this.handleSelect(event, child);
                     setTimeout(() => {
                       // focus first child menu item link to ease tab navigation
-                      const firstChildren =
-                        this.childrenWrapper.querySelector('a');
+                      const firstChildren = this.childrenWrapper.querySelector(
+                        'a'
+                      );
                       if (firstChildren) {
                         this.childrenWrapper.querySelector('a').focus();
                       }
@@ -220,8 +221,9 @@ export class MainNavigationMobile {
                     this.handleSelect(event, item);
                     setTimeout(() => {
                       // focus first child menu item link to ease tab navigation
-                      const firstChildren =
-                        this.childrenWrapper.querySelector('a');
+                      const firstChildren = this.childrenWrapper.querySelector(
+                        'a'
+                      );
                       if (firstChildren) {
                         this.childrenWrapper.querySelector('a').focus();
                       }

--- a/packages/components/src/components/telekom/telekom-header-data-back-compat/telekom-header-data-back-compat.tsx
+++ b/packages/components/src/components/telekom/telekom-header-data-back-compat/telekom-header-data-back-compat.tsx
@@ -50,13 +50,9 @@ export class TelekomHeaderDataBackCompat {
   userMenuDesktopLink?: HTMLAnchorElement;
 
   render() {
-    const {
-      shortName = 'Login',
-      badge,
-      badgeLabel,
-    } = (readData(this.userNavigation) || []).find(
-      ({ type }) => type === 'userInfo'
-    ) || {
+    const { shortName = 'Login', badge, badgeLabel } = (
+      readData(this.userNavigation) || []
+    ).find(({ type }) => type === 'userInfo') || {
       shortName: 'Login',
     };
 

--- a/packages/components/src/components/toast/toast.tsx
+++ b/packages/components/src/components/toast/toast.tsx
@@ -183,8 +183,8 @@ export class Toast {
   };
 
   getToastHeightWithOffset() {
-    const toastHeight =
-      this.element.shadowRoot.querySelector('.toast').scrollHeight;
+    const toastHeight = this.element.shadowRoot.querySelector('.toast')
+      .scrollHeight;
     this.toastHeightWithOffset = toastHeight + this.positionTop;
   }
 

--- a/packages/components/src/html/date-picker.html
+++ b/packages/components/src/html/date-picker.html
@@ -56,9 +56,8 @@
           }
         },
         format(date) {
-          return `${date.getDate()}.${
-            date.getMonth() + 1
-          }.${date.getFullYear()}`;
+          return `${date.getDate()}.${date.getMonth() +
+            1}.${date.getFullYear()}`;
         },
       };
 
@@ -125,14 +124,14 @@
       });
 
       // Listen for when date is selected
-      picker.addEventListener('scaleChange', function (e) {
+      picker.addEventListener('scaleChange', function(e) {
         console.log('scaleChange selected date', e.detail.valueAsDate);
       });
-      picker.addEventListener('scaleFocus', function (e) {
+      picker.addEventListener('scaleFocus', function(e) {
         console.log('scaleFocus', e);
       });
 
-      picker.addEventListener('scaleBlur', function (e) {
+      picker.addEventListener('scaleBlur', function(e) {
         console.log('scaleBlur', e);
       });
     </script>

--- a/packages/components/src/html/dropdown-select.html
+++ b/packages/components/src/html/dropdown-select.html
@@ -132,11 +132,11 @@
     const Select = document.getElementById('person-select');
     const ChooseDarioBtn = document.getElementById('choose-dario');
 
-    Select.addEventListener('scale-change', function (event) {
+    Select.addEventListener('scale-change', function(event) {
       console.log(event.target.name, event.detail.value);
     });
 
-    ChooseDarioBtn.addEventListener('click', function () {
+    ChooseDarioBtn.addEventListener('click', function() {
       Select.value = 'dario';
       const newOption = document.createElement('option');
 

--- a/packages/components/src/html/telekom/header-custom.html
+++ b/packages/components/src/html/telekom/header-custom.html
@@ -532,15 +532,15 @@ width: 100%; */
         },
       ];
       footer.claimLang = 'de';
-      navMainWithMegaMenu.addEventListener('mouseenter', function () {
+      navMainWithMegaMenu.addEventListener('mouseenter', function() {
         navMainWithMegaMenu.isMegaMenuVisible = true;
         header.isMegaMenuVisible = true;
       });
-      navMainWithMegaMenu.addEventListener('mouseleave', function () {
+      navMainWithMegaMenu.addEventListener('mouseleave', function() {
         navMainWithMegaMenu.isMegaMenuVisible = false;
         header.isMegaMenuVisible = false;
       });
-      document.body.addEventListener('keydown', function (event) {
+      document.body.addEventListener('keydown', function(event) {
         if (['Escape', 'Esc'].includes(event.key)) {
           event.preventDefault();
           header.dispatchEvent(new Event('closeMenu'));

--- a/packages/components/src/utils/status-note.ts
+++ b/packages/components/src/utils/status-note.ts
@@ -17,8 +17,10 @@ const tagTypes = {
 };
 
 const defaultMessages = {
-  beta: 'This component is currently in beta status. Some things may be refactored. Watch the change log for now.',
-  WIP: "This component is currently under development and is prone to change. Please wait for its release.\nIt will be available in Storybook once it's finished and documented.",
+  beta:
+    'This component is currently in beta status. Some things may be refactored. Watch the change log for now.',
+  WIP:
+    "This component is currently under development and is prone to change. Please wait for its release.\nIt will be available in Storybook once it's finished and documented.",
   deprecated: 'This component is deprecated.',
 };
 


### PR DESCRIPTION
This PR attempts to address the issue raised here [2314](https://github.com/telekom/scale/issues/2314): 
As part of this PR the `segment-button` component is refactored to : 
- Use better lifecycle hooks to reduce the component render 
- Use default values for the segment IDs 
- Fallback to `full-width` option in the `segment` when calculating the child button width, when no `getBoundingClientRect` or `width` attribute exist for the segment child element.  This issue will occur when the `segment-button` is rendered inside some other components `<slot>` element as it will be rendered but with `display: none`  attribute, which will cause the component to break. 
-