### PR TITLE
no userInfo for profile-menu 

### DIFF
--- a/packages/components/src/components/telekom/telekom-profile-menu/telekom-profile-menu.css
+++ b/packages/components/src/components/telekom/telekom-profile-menu/telekom-profile-menu.css
@@ -68,7 +68,7 @@ scale-telekom-profile-menu scale-menu-flyout {
   height: 12px;
 }
 
-.scale-telekom-nav-item > button {
+scale-telekom-profile-menu .scale-telekom-nav-item > button {
   padding-bottom: var(--_spacing-bottom-slotted-bottom);
 }
 

--- a/packages/components/src/components/telekom/telekom-profile-menu/telekom-profile-menu.tsx
+++ b/packages/components/src/components/telekom/telekom-profile-menu/telekom-profile-menu.tsx
@@ -217,7 +217,10 @@ export class TelekomProfileMenu {
   }
 
   serviceLinksEmpty() {
-    return (this.hideLoginSettings && this.serviceLinks.length < 1) === true;
+    return (
+      this.hideLoginSettings &&
+      (!this.serviceLinks || this.serviceLinks.length < 1)
+    );
   }
 
   buildDesktopMenuStyles() {

--- a/packages/components/src/components/telekom/telekom-profile-menu/telekom-profile-menu.tsx
+++ b/packages/components/src/components/telekom/telekom-profile-menu/telekom-profile-menu.tsx
@@ -165,7 +165,7 @@ export class TelekomProfileMenu {
   buildLogoutButton() {
     return {
       type: 'button',
-      name: this.logoutLabel,
+      name: this.logoutLabel || 'Logout',
       href: this.logoutUrl || LOGOUT_DEFAULT,
       variant: 'secondary',
       onClick: this.logoutHandler,
@@ -176,17 +176,11 @@ export class TelekomProfileMenu {
     const divider = [{ type: 'divider' }];
 
     const userInfo = readData(this.userInfo);
-    if (!userInfo) {
-      // console.error("userInfo missing");
-    }
-    userInfo.type = 'userInfo';
-
-    let serviceLinks = readData(this.serviceLinks);
-    if (!serviceLinks) {
-      // console.error("serviceLinks missing");
-      serviceLinks = [];
+    if (userInfo) {
+      userInfo.type = 'userInfo';
     }
 
+    let serviceLinks = readData(this.serviceLinks) || [];
     for (const el of serviceLinks) {
       el.type = 'item';
     }
@@ -200,9 +194,11 @@ export class TelekomProfileMenu {
 
     let menu = [];
 
-    menu = menu.concat(userInfo);
+    if (userInfo) {
+      menu = menu.concat(userInfo);
+    }
 
-    if (!this.serviceLinksEmpty()) {
+    if (userInfo && !this.serviceLinksEmpty()) {
       menu = menu.concat(divider);
     }
 

--- a/packages/components/src/components/telekom/telekom-profile-menu/telekom-profile-menu.tsx
+++ b/packages/components/src/components/telekom/telekom-profile-menu/telekom-profile-menu.tsx
@@ -180,7 +180,7 @@ export class TelekomProfileMenu {
       userInfo.type = 'userInfo';
     }
 
-    let serviceLinks = readData(this.serviceLinks) || [];
+    const serviceLinks = readData(this.serviceLinks) || [];
     for (const el of serviceLinks) {
       el.type = 'item';
     }

--- a/packages/components/src/html/telekom-header-profile-menu.html
+++ b/packages/components/src/html/telekom-header-profile-menu.html
@@ -243,322 +243,321 @@
           </a>
         </scale-telekom-nav-item>
         <!-- login-url: dynamic link - OpenID connect discovery -->
-    <scale-telekom-profile-menu
-    login-url="https://www.telekom.de/todo/login"
-    login-help-url="https://www.telekom.de/hilfe/telekom-login"
-    register-url="https://meinkonto.telekom-dienste.de/telekom/account/registration/assistant/userstatus.xhtml"
-    logged-in="false"
-    app-name="Application"
-    label="Login"
-    accessibility-label="Login"
-    close-menu-accessibility-label="Close menu"
-    service-name="Customer Center"
-    service-description="Manage your contracts, bills, usage overviews, settings, and more."
-    login-label="Log in"
-    login-help-label="Help logging in"
-    register-headline="Need an account?"
-    register-label="Register now"
-  ></scale-telekom-profile-menu>
-        </scale-telekom-nav-list>
-        <scale-telekom-nav-flyout
-          class="mobile-menu-flyout"
-          style="
-            --translate-y: 100%;
-            --duration: var(--telekom-motion-duration-animation);
-            --top: 0;
-            --height: 100vh;
-            --spacing-x: 0;
-            --background: var(--telekom-color-background-canvas);
-          "
-        >
-          <scale-telekom-mobile-menu
-            app-name="Application Name"
-            app-name-link="#"
-          >
-            <scale-telekom-nav-list
-              variant="meta-nav-external"
-              slot="top-left"
-              alignment="left"
-            >
-              <scale-telekom-nav-item>
-                <a href="#">
-                  Metalink ext 1
-                  <scale-icon-navigation-external-link
-                    size="11"
-                  ></scale-icon-navigation-external-link>
-                </a>
-              </scale-telekom-nav-item>
-              <scale-telekom-nav-item>
-                <a href="#">
-                  Metalink ext 2
-                  <scale-icon-navigation-external-link
-                    size="11"
-                  ></scale-icon-navigation-external-link>
-                </a>
-              </scale-telekom-nav-item>
-            </scale-telekom-nav-list>
-            <scale-telekom-nav-list
-              variant="lang-switcher"
-              slot="top-right"
-              alignment="right"
-            >
-              <scale-telekom-nav-item active>
-                <a href="#">MK</a>
-              </scale-telekom-nav-item>
-              <scale-telekom-nav-item>
-                <a href="#">SO</a>
-              </scale-telekom-nav-item>
-              <scale-telekom-nav-item>
-                <a href="#">DE</a>
-              </scale-telekom-nav-item>
-            </scale-telekom-nav-list>
-            <scale-telekom-mobile-menu-item active>
-              <a href="#category-1">Topic One</a>
-              <scale-telekom-mobile-menu-item slot="children">
-                <a href="#">Second Level</a>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-              </scale-telekom-mobile-menu-item>
-              <scale-telekom-mobile-menu-item slot="children">
-                <a href="#">Second Level</a>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-              </scale-telekom-mobile-menu-item>
-              <scale-telekom-mobile-menu-item slot="children">
-                <a href="#">Second Level</a>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-              </scale-telekom-mobile-menu-item>
-              <scale-telekom-mobile-menu-item slot="children">
-                <a href="#">Second Level</a>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-              </scale-telekom-mobile-menu-item>
-              <scale-telekom-mobile-menu-item slot="children">
-                <a href="#">Second Level</a>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-              </scale-telekom-mobile-menu-item>
-            </scale-telekom-mobile-menu-item>
-            <scale-telekom-mobile-menu-item>
-              <a href="#category-1">Topic Two</a>
-              <scale-telekom-mobile-menu-item slot="children">
-                <a href="#">Second Level</a>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-              </scale-telekom-mobile-menu-item>
-              <scale-telekom-mobile-menu-item slot="children">
-                <a href="#">Second Level</a>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-              </scale-telekom-mobile-menu-item>
-              <scale-telekom-mobile-menu-item slot="children">
-                <a href="#">Second Level</a>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-              </scale-telekom-mobile-menu-item>
-              <scale-telekom-mobile-menu-item slot="children">
-                <a href="#">Second Level</a>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-                <scale-telekom-mobile-menu-item slot="children">
-                  <a href="#">Third Level</a>
-                </scale-telekom-mobile-menu-item>
-              </scale-telekom-mobile-menu-item>
-            </scale-telekom-mobile-menu-item>
-            <scale-telekom-mobile-menu-item>
-              <a href="#category-1">Topic Three</a>
-            </scale-telekom-mobile-menu-item>
-            <scale-telekom-mobile-menu-item>
-              <a href="#category-1">Topic Four</a>
-            </scale-telekom-mobile-menu-item>
-            <scale-telekom-mobile-menu-item>
-              <a href="#category-1">Topic Five</a>
-            </scale-telekom-mobile-menu-item>
-            <scale-telekom-nav-list
-              variant="meta-nav-external"
-              slot="bottom"
-              alignment="left"
-              style="--flex-direction: column"
-            >
-              <scale-telekom-nav-item>
-                <a href="#">Metalink ext 1</a>
-              </scale-telekom-nav-item>
-              <scale-telekom-nav-item>
-                <a href="#">Metalink ext 2</a>
-              </scale-telekom-nav-item>
-            </scale-telekom-nav-list>
-          </scale-telekom-mobile-menu>
-        </scale-telekom-nav-flyout>
+        <scale-telekom-profile-menu
+          login-url="https://www.telekom.de/todo/login"
+          login-help-url="https://www.telekom.de/hilfe/telekom-login"
+          register-url="https://meinkonto.telekom-dienste.de/telekom/account/registration/assistant/userstatus.xhtml"
+          logged-in="false"
+          app-name="Application"
+          label="Login"
+          accessibility-label="Login"
+          close-menu-accessibility-label="Close menu"
+          service-name="Customer Center"
+          service-description="Manage your contracts, bills, usage overviews, settings, and more."
+          login-label="Log in"
+          login-help-label="Help logging in"
+          register-headline="Need an account?"
+          register-label="Register now"
+        ></scale-telekom-profile-menu>
       </scale-telekom-nav-list>
+      <scale-telekom-nav-flyout
+        class="mobile-menu-flyout"
+        style="
+          --translate-y: 100%;
+          --duration: var(--telekom-motion-duration-animation);
+          --top: 0;
+          --height: 100vh;
+          --spacing-x: 0;
+          --background: var(--telekom-color-background-canvas);
+        "
+      >
+        <scale-telekom-mobile-menu
+          app-name="Application Name"
+          app-name-link="#"
+        >
+          <scale-telekom-nav-list
+            variant="meta-nav-external"
+            slot="top-left"
+            alignment="left"
+          >
+            <scale-telekom-nav-item>
+              <a href="#">
+                Metalink ext 1
+                <scale-icon-navigation-external-link
+                  size="11"
+                ></scale-icon-navigation-external-link>
+              </a>
+            </scale-telekom-nav-item>
+            <scale-telekom-nav-item>
+              <a href="#">
+                Metalink ext 2
+                <scale-icon-navigation-external-link
+                  size="11"
+                ></scale-icon-navigation-external-link>
+              </a>
+            </scale-telekom-nav-item>
+          </scale-telekom-nav-list>
+          <scale-telekom-nav-list
+            variant="lang-switcher"
+            slot="top-right"
+            alignment="right"
+          >
+            <scale-telekom-nav-item active>
+              <a href="#">MK</a>
+            </scale-telekom-nav-item>
+            <scale-telekom-nav-item>
+              <a href="#">SO</a>
+            </scale-telekom-nav-item>
+            <scale-telekom-nav-item>
+              <a href="#">DE</a>
+            </scale-telekom-nav-item>
+          </scale-telekom-nav-list>
+          <scale-telekom-mobile-menu-item active>
+            <a href="#category-1">Topic One</a>
+            <scale-telekom-mobile-menu-item slot="children">
+              <a href="#">Second Level</a>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+            </scale-telekom-mobile-menu-item>
+            <scale-telekom-mobile-menu-item slot="children">
+              <a href="#">Second Level</a>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+            </scale-telekom-mobile-menu-item>
+            <scale-telekom-mobile-menu-item slot="children">
+              <a href="#">Second Level</a>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+            </scale-telekom-mobile-menu-item>
+            <scale-telekom-mobile-menu-item slot="children">
+              <a href="#">Second Level</a>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+            </scale-telekom-mobile-menu-item>
+            <scale-telekom-mobile-menu-item slot="children">
+              <a href="#">Second Level</a>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+            </scale-telekom-mobile-menu-item>
+          </scale-telekom-mobile-menu-item>
+          <scale-telekom-mobile-menu-item>
+            <a href="#category-1">Topic Two</a>
+            <scale-telekom-mobile-menu-item slot="children">
+              <a href="#">Second Level</a>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+            </scale-telekom-mobile-menu-item>
+            <scale-telekom-mobile-menu-item slot="children">
+              <a href="#">Second Level</a>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+            </scale-telekom-mobile-menu-item>
+            <scale-telekom-mobile-menu-item slot="children">
+              <a href="#">Second Level</a>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+            </scale-telekom-mobile-menu-item>
+            <scale-telekom-mobile-menu-item slot="children">
+              <a href="#">Second Level</a>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Third Level</a>
+              </scale-telekom-mobile-menu-item>
+            </scale-telekom-mobile-menu-item>
+          </scale-telekom-mobile-menu-item>
+          <scale-telekom-mobile-menu-item>
+            <a href="#category-1">Topic Three</a>
+          </scale-telekom-mobile-menu-item>
+          <scale-telekom-mobile-menu-item>
+            <a href="#category-1">Topic Four</a>
+          </scale-telekom-mobile-menu-item>
+          <scale-telekom-mobile-menu-item>
+            <a href="#category-1">Topic Five</a>
+          </scale-telekom-mobile-menu-item>
+          <scale-telekom-nav-list
+            variant="meta-nav-external"
+            slot="bottom"
+            alignment="left"
+            style="--flex-direction: column"
+          >
+            <scale-telekom-nav-item>
+              <a href="#">Metalink ext 1</a>
+            </scale-telekom-nav-item>
+            <scale-telekom-nav-item>
+              <a href="#">Metalink ext 2</a>
+            </scale-telekom-nav-item>
+          </scale-telekom-nav-list>
+        </scale-telekom-mobile-menu>
+      </scale-telekom-nav-flyout>
     </scale-telekom-header>
     <p>&nbsp;</p>
     <p>&nbsp;</p>

--- a/packages/components/src/html/telekom-header-profile-menu.html
+++ b/packages/components/src/html/telekom-header-profile-menu.html
@@ -1,0 +1,602 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"
+    />
+    <title>Telekom Header</title>
+
+    <script type="module" src="/build/scale-components.esm.js"></script>
+    <link rel="stylesheet" href="/build/scale-components.css" />
+    <style type="text/css" media="screen, print">
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 200vh;
+        background: var(--telekom-color-background-surface-subtle);
+      }
+
+      section {
+        /* --b: #333; */
+        /* width: 22ch; */
+        /* border: 1px dotted #666; */
+      }
+
+      scale-telekom-nav-list {
+        --spacing-inner-x: var(--telekom-spacing-unit-x14);
+      }
+
+      .flyout-body {
+        padding: var(--telekom-spacing-unit-x6) 0;
+      }
+
+      .mobile-menu-flyout {
+        --topbar-height: 60px;
+        --top: var(--topbar-height);
+        --height: calc(100vh - var(--topbar-height));
+        --position: fixed;
+      }
+      .mobile-menu-flyout > div {
+        display: flex;
+        height: 100%;
+        box-sizing: border-box;
+        padding: 1rem;
+      }
+      .mobile-menu-trigger[aria-expanded='true'] {
+        color: red;
+        text-decoration: line-through;
+      }
+      @media screen and (min-width: 1040px) {
+        .mobile-menu-trigger {
+          display: none;
+        }
+      }
+    </style>
+  </head>
+
+  <body>
+    <scale-telekom-header
+      app-name="Application Name"
+      app-name-link="https://example.com"
+    >
+      <!-- MAIN NAV -->
+      <scale-telekom-nav-list variant="main-nav" slot="main-nav">
+        <scale-telekom-nav-item active>
+          <button><span>Topic One</span></button>
+          <scale-telekom-nav-flyout hover>
+            <scale-telekom-mega-menu>
+              <scale-telekom-mega-menu-column>
+                <scale-icon-home-home slot="icon"></scale-icon-home-home>
+                <a href="#" slot="heading">My heading</a>
+                <ul>
+                  <li><a href="#">Link One</a></li>
+                  <li><a href="#">Link Two</a></li>
+                  <li><a href="#">Link Three</a></li>
+                  <li><a href="#">Link Four</a></li>
+                </ul>
+              </scale-telekom-mega-menu-column>
+              <scale-telekom-mega-menu-column>
+                <scale-icon-home-home slot="icon"></scale-icon-home-home>
+                <a href="#" slot="heading">My heading</a>
+                <ul>
+                  <li><a href="#">Link One</a></li>
+                  <li><a href="#">Link Two</a></li>
+                  <li><a href="#">Link Three</a></li>
+                  <li><a href="#">Link Four</a></li>
+                </ul>
+              </scale-telekom-mega-menu-column>
+              <scale-telekom-mega-menu-column>
+                <scale-icon-home-home slot="icon"></scale-icon-home-home>
+                <a href="#" slot="heading">My heading</a>
+                <ul>
+                  <li><a href="#">Link One</a></li>
+                  <li><a href="#">Link Two</a></li>
+                  <li><a href="#">Link Three</a></li>
+                  <li><a href="#">Link Four</a></li>
+                </ul>
+              </scale-telekom-mega-menu-column>
+              <scale-telekom-mega-menu-column>
+                <scale-icon-home-home slot="icon"></scale-icon-home-home>
+                <a href="#" slot="heading">My heading</a>
+                <ul>
+                  <li><a href="#">Link One</a></li>
+                  <li><a href="#">Link Two</a></li>
+                  <li><a href="#">Link Three</a></li>
+                  <li><a href="#">Link Four</a></li>
+                </ul>
+              </scale-telekom-mega-menu-column>
+              <scale-telekom-mega-menu-column>
+                <scale-icon-home-home slot="icon"></scale-icon-home-home>
+                <a href="#" slot="heading">My heading</a>
+                <ul>
+                  <li><a href="#">Link One</a></li>
+                  <li><a href="#">Link Two</a></li>
+                  <li><a href="#">Link Three</a></li>
+                  <li><a href="#">Link Four</a></li>
+                </ul>
+              </scale-telekom-mega-menu-column>
+            </scale-telekom-mega-menu>
+          </scale-telekom-nav-flyout>
+        </scale-telekom-nav-item>
+        <scale-telekom-nav-item>
+          <button>Topic Two</button>
+          <scale-telekom-nav-flyout hover>
+            <scale-telekom-mega-menu>
+              <scale-telekom-mega-menu-column>
+                <a href="#" slot="heading">Tarife</a>
+                <ul>
+                  <li><a href="#">Internet-Tarife</a></li>
+                  <li><a href="#">Für junge Leute unter 28</a></li>
+                  <li><a href="#">Zubuchoptionen</a></li>
+                  <li><a href="#">Verfügbarkeitsprüfung</a></li>
+                </ul>
+              </scale-telekom-mega-menu-column>
+              <scale-telekom-mega-menu-column>
+                <a href="#" slot="heading">Geräte</a>
+                <ul>
+                  <li><a href="#">WLAN & Router</a></li>
+                  <li><a href="#">Festnetztelefone</a></li>
+                  <li><a href="#">Smart Home Geräte</a></li>
+                </ul>
+              </scale-telekom-mega-menu-column>
+              <scale-telekom-mega-menu-column>
+                <a href="#" slot="heading">Vernetztes Zuhause</a>
+                <ul>
+                  <li><a href="#">WLAN Pakete</a></li>
+                  <li><a href="#">WLAN Optimierung</a></li>
+                  <li><a href="#">Mesh-Technologie</a></li>
+                  <li><a href="#">Smart Home</a></li>
+                </ul>
+              </scale-telekom-mega-menu-column>
+              <scale-telekom-mega-menu-column>
+                <a href="#" slot="heading">Netz</a>
+                <ul>
+                  <li><a href="#">Verfügbarkeitsprüfung</a></li>
+                  <li><a href="#">DSL Ausbau</a></li>
+                  <li><a href="#">Glasfaserausbau</a></li>
+                  <li><a href="#">Grünes Netz</a></li>
+                </ul>
+              </scale-telekom-mega-menu-column>
+            </scale-telekom-mega-menu>
+          </scale-telekom-nav-flyout>
+        </scale-telekom-nav-item>
+        <scale-telekom-nav-item>
+          <a href="#">Topic Three</a>
+        </scale-telekom-nav-item>
+        <scale-telekom-nav-item>
+          <a href="#">Topic Four</a>
+        </scale-telekom-nav-item>
+        <scale-telekom-nav-item>
+          <a href="#">Topic Five</a>
+        </scale-telekom-nav-item>
+      </scale-telekom-nav-list>
+      <scale-telekom-nav-list
+        variant="meta-nav-external"
+        slot="meta-nav-external"
+        alignment="left"
+      >
+        <scale-telekom-nav-item>
+          <a href="#">
+            Metalink ext 1
+            <scale-icon-navigation-external-link
+              size="11"
+            ></scale-icon-navigation-external-link>
+          </a>
+        </scale-telekom-nav-item>
+        <scale-telekom-nav-item>
+          <a href="#">
+            Metalink ext 2
+            <scale-icon-navigation-external-link
+              size="11"
+            ></scale-icon-navigation-external-link>
+          </a>
+        </scale-telekom-nav-item>
+      </scale-telekom-nav-list>
+      <scale-telekom-nav-list
+        variant="meta-nav"
+        slot="meta-nav"
+        alignment="left"
+      >
+        <scale-telekom-nav-item>
+          <a href="#">Metalink 1</a>
+        </scale-telekom-nav-item>
+        <scale-telekom-nav-item>
+          <a href="#">Metalink 2</a>
+        </scale-telekom-nav-item>
+      </scale-telekom-nav-list>
+      <scale-telekom-nav-list
+        variant="lang-switcher"
+        slot="lang-switcher"
+        alignment="right"
+      >
+        <scale-telekom-nav-item active>
+          <a href="#">MK</a>
+        </scale-telekom-nav-item>
+        <scale-telekom-nav-item>
+          <a href="#">SO</a>
+        </scale-telekom-nav-item>
+        <scale-telekom-nav-item>
+          <a href="#">DE</a>
+        </scale-telekom-nav-item>
+      </scale-telekom-nav-list>
+      <scale-telekom-nav-list
+        variant="functions"
+        slot="functions"
+        alignment="right"
+      >
+        <scale-telekom-nav-item>
+          <a href="#">
+            <scale-icon-action-search> </scale-icon-action-search>
+          </a>
+        </scale-telekom-nav-item>
+        <scale-telekom-nav-item>
+          <a href="#">
+            <scale-icon-content-credit-card> </scale-icon-content-credit-card>
+          </a>
+        </scale-telekom-nav-item>
+        <scale-telekom-nav-item>
+          <a href="#">
+            <scale-icon-action-shopping-cart> </scale-icon-action-shopping-cart>
+          </a>
+        </scale-telekom-nav-item>
+        <!-- login-url: dynamic link - OpenID connect discovery -->
+    <scale-telekom-profile-menu
+    login-url="https://www.telekom.de/todo/login"
+    login-help-url="https://www.telekom.de/hilfe/telekom-login"
+    register-url="https://meinkonto.telekom-dienste.de/telekom/account/registration/assistant/userstatus.xhtml"
+    logged-in="false"
+    app-name="Application"
+    label="Login"
+    accessibility-label="Login"
+    close-menu-accessibility-label="Close menu"
+    service-name="Customer Center"
+    service-description="Manage your contracts, bills, usage overviews, settings, and more."
+    login-label="Log in"
+    login-help-label="Help logging in"
+    register-headline="Need an account?"
+    register-label="Register now"
+  ></scale-telekom-profile-menu>
+        </scale-telekom-nav-list>
+        <scale-telekom-nav-flyout
+          class="mobile-menu-flyout"
+          style="
+            --translate-y: 100%;
+            --duration: var(--telekom-motion-duration-animation);
+            --top: 0;
+            --height: 100vh;
+            --spacing-x: 0;
+            --background: var(--telekom-color-background-canvas);
+          "
+        >
+          <scale-telekom-mobile-menu
+            app-name="Application Name"
+            app-name-link="#"
+          >
+            <scale-telekom-nav-list
+              variant="meta-nav-external"
+              slot="top-left"
+              alignment="left"
+            >
+              <scale-telekom-nav-item>
+                <a href="#">
+                  Metalink ext 1
+                  <scale-icon-navigation-external-link
+                    size="11"
+                  ></scale-icon-navigation-external-link>
+                </a>
+              </scale-telekom-nav-item>
+              <scale-telekom-nav-item>
+                <a href="#">
+                  Metalink ext 2
+                  <scale-icon-navigation-external-link
+                    size="11"
+                  ></scale-icon-navigation-external-link>
+                </a>
+              </scale-telekom-nav-item>
+            </scale-telekom-nav-list>
+            <scale-telekom-nav-list
+              variant="lang-switcher"
+              slot="top-right"
+              alignment="right"
+            >
+              <scale-telekom-nav-item active>
+                <a href="#">MK</a>
+              </scale-telekom-nav-item>
+              <scale-telekom-nav-item>
+                <a href="#">SO</a>
+              </scale-telekom-nav-item>
+              <scale-telekom-nav-item>
+                <a href="#">DE</a>
+              </scale-telekom-nav-item>
+            </scale-telekom-nav-list>
+            <scale-telekom-mobile-menu-item active>
+              <a href="#category-1">Topic One</a>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Second Level</a>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Second Level</a>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Second Level</a>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Second Level</a>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Second Level</a>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+              </scale-telekom-mobile-menu-item>
+            </scale-telekom-mobile-menu-item>
+            <scale-telekom-mobile-menu-item>
+              <a href="#category-1">Topic Two</a>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Second Level</a>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Second Level</a>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Second Level</a>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+              </scale-telekom-mobile-menu-item>
+              <scale-telekom-mobile-menu-item slot="children">
+                <a href="#">Second Level</a>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+                <scale-telekom-mobile-menu-item slot="children">
+                  <a href="#">Third Level</a>
+                </scale-telekom-mobile-menu-item>
+              </scale-telekom-mobile-menu-item>
+            </scale-telekom-mobile-menu-item>
+            <scale-telekom-mobile-menu-item>
+              <a href="#category-1">Topic Three</a>
+            </scale-telekom-mobile-menu-item>
+            <scale-telekom-mobile-menu-item>
+              <a href="#category-1">Topic Four</a>
+            </scale-telekom-mobile-menu-item>
+            <scale-telekom-mobile-menu-item>
+              <a href="#category-1">Topic Five</a>
+            </scale-telekom-mobile-menu-item>
+            <scale-telekom-nav-list
+              variant="meta-nav-external"
+              slot="bottom"
+              alignment="left"
+              style="--flex-direction: column"
+            >
+              <scale-telekom-nav-item>
+                <a href="#">Metalink ext 1</a>
+              </scale-telekom-nav-item>
+              <scale-telekom-nav-item>
+                <a href="#">Metalink ext 2</a>
+              </scale-telekom-nav-item>
+            </scale-telekom-nav-list>
+          </scale-telekom-mobile-menu>
+        </scale-telekom-nav-flyout>
+      </scale-telekom-nav-list>
+    </scale-telekom-header>
+    <p>&nbsp;</p>
+    <p>&nbsp;</p>
+    <p>&nbsp;</p>
+    <p>&nbsp;</p>
+    <p>&nbsp;</p>
+    <p>&nbsp;</p>
+    <p>&nbsp;</p>
+    <p>&nbsp;</p>
+    <p>&nbsp;</p>
+    <p>&nbsp;</p>
+    <p>&nbsp;</p>
+    <p>&nbsp;</p>
+    <p>&nbsp;</p>
+    <p>&nbsp;</p>
+    <p>&nbsp;</p>
+    <p>&nbsp;</p>
+    <p>&nbsp;</p>
+    <p>&nbsp;</p>
+
+    <style>
+      scale-grid {
+        border: 1px solid cyan;
+      }
+      scale-grid-item {
+        background: lime;
+        --size-md: 4;
+      }
+      [foo] {
+        --size-md: 1;
+      }
+    </style>
+    <scale-grid>
+      <scale-grid-item foo>1</scale-grid-item>
+      <scale-grid-item foo>2</scale-grid-item>
+      <scale-grid-item>3</scale-grid-item>
+      <scale-grid-item>4</scale-grid-item>
+      <scale-grid-item>5</scale-grid-item>
+    </scale-grid>
+  </body>
+</html>

--- a/packages/components/src/html/telekom-header-profile-menu.html
+++ b/packages/components/src/html/telekom-header-profile-menu.html
@@ -242,12 +242,11 @@
             <scale-icon-action-shopping-cart> </scale-icon-action-shopping-cart>
           </a>
         </scale-telekom-nav-item>
-        <!-- login-url: dynamic link - OpenID connect discovery -->
         <scale-telekom-profile-menu
           login-url="https://www.telekom.de/todo/login"
           login-help-url="https://www.telekom.de/hilfe/telekom-login"
           register-url="https://meinkonto.telekom-dienste.de/telekom/account/registration/assistant/userstatus.xhtml"
-          logged-in="false"
+          logged-in="true"
           app-name="Application"
           label="Login"
           accessibility-label="Login"
@@ -258,6 +257,7 @@
           login-help-label="Help logging in"
           register-headline="Need an account?"
           register-label="Register now"
+          hide-login-settings="true"
         ></scale-telekom-profile-menu>
       </scale-telekom-nav-list>
       <scale-telekom-nav-flyout


### PR DESCRIPTION
Fixes https://github.com/telekom/scale/issues/2331
Fixes https://github.com/telekom/scale/issues/2293
telekom-profile-menu component was failing in case userInfo is not provided. The check for empty prop is added.
UPD: no serviceLinks + hideLoginSettings case fixed.

UPD: lil css nesting fix for nav item inside profile menu added

@amir-ba we could discuss how css should be refactored for components having shadow: false. now looks like muddle which i'm afraid to touch
