### PR TITLE
ci: sets up docker compose alias for compatibility

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -134,12 +134,15 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-
+      - name: Set up Docker Compose alias 
+        run: |
+          sudo touch /usr/bin/docker-compose
+          echo 'docker compose --compatibility "$@"' | sudo tee /usr/bin/docker-compose
+          sudo chmod +x /usr/bin/docker-compose
+          
       - name: Restore Lerna
         id: yarn-cache
         uses: actions/cache@v2


### PR DESCRIPTION
This PR attempts to fix the failing visual-test job in the workflow.  It first removes the unneccessary `ref` for the `actions/checkout@v3` as it tries to pull references that might not exist in addition based on the latest [Docker changes ](https://docs.docker.com/compose/migrate/) the `docker-compose` used by our `docker-chromium` dependency is removed from July 2023, and we need to provide a Symlink that calls the new `docker compose` v2. 