### PR TITLE
Fix: submit button does not add name or value to submit form event

### DIFF
--- a/packages/components/src/components/button/button.tsx
+++ b/packages/components/src/components/button/button.tsx
@@ -102,6 +102,12 @@ export class Button {
         if (this.type) {
           fakeButton.type = this.type;
         }
+        if (this.value) {
+          fakeButton.value = this.value;
+        }
+        if (this.name) {
+          fakeButton.name = this.name;
+        }
         fakeButton.style.display = 'none';
         parentForm.appendChild(fakeButton);
         fakeButton.click();


### PR DESCRIPTION
The name and value used on the button element are not submitted as part of the form event as these are not cloned onto the temporary button used for submitting the form.