### PR TITLE
doc: adds VS code support for Scale customElements

### DIFF
--- a/packages/components/stencil.config.ts
+++ b/packages/components/stencil.config.ts
@@ -78,7 +78,7 @@ export const config: Config = {
     },
     {
       type: 'docs-vscode',
-      file: './dist/custom-elements.json',
+      file: './dist/vscode-data.json',
     },
     {
       type: 'docs-json',

--- a/packages/components/stencil.config.ts
+++ b/packages/components/stencil.config.ts
@@ -78,7 +78,7 @@ export const config: Config = {
     },
     {
       type: 'docs-vscode',
-      file: 'custom-elements.json',
+      file: './dist/custom-elements.json',
     },
     {
       type: 'docs-json',


### PR DESCRIPTION
Fixes https://github.com/telekom/scale/issues/2302

This adds the vscode-elements.json description file to the build directory. So that VSCode can provide auto-complete and Intellisense based on it. 