### PR TITLE
feat(data-grid): add scale-selection event and enhance editable text field

### DIFF
--- a/packages/components/src/components/data-grid/cell-handlers/text-cell.tsx
+++ b/packages/components/src/components/data-grid/cell-handlers/text-cell.tsx
@@ -38,7 +38,7 @@ export const TextCell: Cell = {
       iconPrefix,
       iconSuffix,
       label,
-      textFieldProps = {}
+      textFieldProps = {},
     } = field;
 
     // Input component doesn't expand with content, so need to return a fake element that simulates width

--- a/packages/components/src/components/data-grid/cell-handlers/text-cell.tsx
+++ b/packages/components/src/components/data-grid/cell-handlers/text-cell.tsx
@@ -38,6 +38,7 @@ export const TextCell: Cell = {
       iconPrefix,
       iconSuffix,
       label,
+      textFieldProps = {}
     } = field;
 
     // Input component doesn't expand with content, so need to return a fake element that simulates width
@@ -52,6 +53,7 @@ export const TextCell: Cell = {
     if (editable) {
       const props = {
         type: 'text',
+        ...textFieldProps,
         value: content,
         label,
       } as any;

--- a/packages/components/src/components/data-grid/data-grid.tsx
+++ b/packages/components/src/components/data-grid/data-grid.tsx
@@ -102,7 +102,7 @@ export class DataGrid {
   /** (optional) Set to true to add selection column */
   @Prop() selectable?: boolean = false;
   /** Read-only selection array - populated with raw data from selected rows */
-  @Prop({mutable: true}) selection: any[] = [];
+  @Prop({ mutable: true }) selection: any[] = [];
   /** (optional) Shade every second row darker */
   @Prop() shadeAlternate?: boolean = true;
   /** (optional) Injected css styles */

--- a/packages/components/src/components/data-grid/data-grid.tsx
+++ b/packages/components/src/components/data-grid/data-grid.tsx
@@ -102,7 +102,7 @@ export class DataGrid {
   /** (optional) Set to true to add selection column */
   @Prop() selectable?: boolean = false;
   /** Read-only selection array - populated with raw data from selected rows */
-  @State() selection: any[] = [];
+  @Prop({mutable: true}) selection: any[] = [];
   /** (optional) Shade every second row darker */
   @Prop() shadeAlternate?: boolean = true;
   /** (optional) Injected css styles */
@@ -255,7 +255,8 @@ export class DataGrid {
       this.sortTable(
         this.fields[this.activeSortingIndex].sortDirection,
         this.fields[this.activeSortingIndex].type,
-        this.activeSortingIndex, true
+        this.activeSortingIndex,
+        true
       );
     }
   }

--- a/packages/components/src/components/data-grid/data-grid.tsx
+++ b/packages/components/src/components/data-grid/data-grid.tsx
@@ -136,7 +136,7 @@ export class DataGrid {
   /** @deprecated in v3 in favor of kebab-case event names */
   @Event({ eventName: 'scaleSort' })
   scaleSortLegacy: EventEmitter<DataGridSortedEventDetail>;
-  /**Event triggered every time the selection list updates  */
+  /** Event triggered every time the selection list updates  */
   @Event({ eventName: 'scale-selection' })
   scaleSelection: EventEmitter<any[]>;
   /* 5. Private Properties (alphabetical) */
@@ -343,7 +343,7 @@ export class DataGrid {
     if (!this.fields) {
       return;
     }
-    this.fields?.forEach(({ sortable }) => {
+    this.fields.forEach(({ sortable }) => {
       if (sortable) {
         this.isSortable = true;
       }
@@ -684,7 +684,7 @@ export class DataGrid {
         }
       }
       // Add each visible column's target width
-      this.fields?.forEach(({ visible = true, width }) => {
+      this.fields.forEach(({ visible = true, width }) => {
         if (visible) {
           // 32 for padding+margin
           total += width + 32;
@@ -706,7 +706,7 @@ export class DataGrid {
       // If stretchWeight unset, share remainder of 1 (if any) between all unset cols
       let totalSetWeight = 0;
       let unsetColsCount = 0;
-      this.fields?.forEach(({ visible = true, stretchWeight }) => {
+      this.fields.forEach(({ visible = true, stretchWeight }) => {
         // Disregard invisible columns
         if (!visible) {
           return;
@@ -720,7 +720,7 @@ export class DataGrid {
       const remainderWeight = Math.max(0, 1 - totalSetWeight);
       // Set total to be divided against to be above 1 to keep total set/unset weights equal to 1
       totalSetWeight = Math.max(1, totalSetWeight);
-      this.fields?.forEach((field) => {
+      this.fields.forEach((field) => {
         const { visible = true, stretchWeight } = field;
         if (!visible) {
           return;

--- a/packages/components/src/components/data-grid/data-grid.tsx
+++ b/packages/components/src/components/data-grid/data-grid.tsx
@@ -956,6 +956,7 @@ export class DataGrid {
       <div
         ref={(el) => (this.elScrollContainer = el)}
         class={`${name}__scroll-container`}
+        part="scrollable"
         style={{ height: this.height || 'auto' }}
         onScroll={() => this.onTableScroll()}
       >
@@ -1393,7 +1394,7 @@ export class DataGrid {
       >
         {this.styles && <style>{this.styles}</style>}
         <div class={this.getCssClassMap()}>
-          <div class={`${name}__title-block`}>
+          <div class={`${name}__title-block`} part="title">
             {/* h4 tag + h5 styles feels weird, ideally one should be able to set the tag with an attribute */}
             {this.heading && (
               <h4 class={`${name}__heading scl-h5`}>{this.heading}</h4>

--- a/packages/components/src/components/data-grid/readme.md
+++ b/packages/components/src/components/data-grid/readme.md
@@ -20,7 +20,7 @@
 | `pageSize`            | `page-size`             | (optional) Set number of rows to display per pagination page                                                                  | `number`                                                                                                        | `Infinity`                  |
 | `rows`                | `rows`                  | Input data array                                                                                                              | `any`                                                                                                           | `undefined`                 |
 | `selectable`          | `selectable`            | (optional) Set to true to add selection column                                                                                | `boolean`                                                                                                       | `false`                     |
-| `selection`           | --                      | Read-only selection array - populated with raw data from selected rows                                                        | `string[]`                                                                                                      | `[]`                        |
+| `selection`           | --                      | Read-only selection array - populated with raw data from selected rows                                                        | `any[]`                                                                                                         | `[]`                        |
 | `shadeAlternate`      | `shade-alternate`       | (optional) Shade every second row darker                                                                                      | `boolean`                                                                                                       | `true`                      |
 | `sortableColumnTitle` | `sortable-column-title` | (optional) Title for sortable columns                                                                                         | `string`                                                                                                        | `'Activate to sort column'` |
 | `styles`              | `styles`                | (optional) Injected css styles                                                                                                | `any`                                                                                                           | `undefined`                 |
@@ -29,12 +29,13 @@
 
 ## Events
 
-| Event        | Description                                                                                        | Type                                     |
-| ------------ | -------------------------------------------------------------------------------------------------- | ---------------------------------------- |
-| `scale-edit` | Event triggered every time the editable cells are changed, updating the original rows data         | `CustomEvent<DataGridEditEventDetail>`   |
-| `scale-sort` | Event triggered every time the data is sorted, changing original rows data                         | `CustomEvent<DataGridSortedEventDetail>` |
-| `scaleEdit`  | <span style="color:red">**[DEPRECATED]**</span> in v3 in favor of kebab-case event names<br/><br/> | `CustomEvent<DataGridEditEventDetail>`   |
-| `scaleSort`  | <span style="color:red">**[DEPRECATED]**</span> in v3 in favor of kebab-case event names<br/><br/> | `CustomEvent<DataGridSortedEventDetail>` |
+| Event             | Description                                                                                        | Type                                     |
+| ----------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| `scale-edit`      | Event triggered every time the editable cells are changed, updating the original rows data         | `CustomEvent<DataGridEditEventDetail>`   |
+| `scale-selection` | Event triggered every time the selection list updates                                              | `CustomEvent<any[]>`                     |
+| `scale-sort`      | Event triggered every time the data is sorted, changing original rows data                         | `CustomEvent<DataGridSortedEventDetail>` |
+| `scaleEdit`       | <span style="color:red">**[DEPRECATED]**</span> in v3 in favor of kebab-case event names<br/><br/> | `CustomEvent<DataGridEditEventDetail>`   |
+| `scaleSort`       | <span style="color:red">**[DEPRECATED]**</span> in v3 in favor of kebab-case event names<br/><br/> | `CustomEvent<DataGridSortedEventDetail>` |
 
 
 ## Dependencies

--- a/packages/components/src/components/data-grid/readme.md
+++ b/packages/components/src/components/data-grid/readme.md
@@ -38,6 +38,14 @@
 | `scaleSort`       | <span style="color:red">**[DEPRECATED]**</span> in v3 in favor of kebab-case event names<br/><br/> | `CustomEvent<DataGridSortedEventDetail>` |
 
 
+## Shadow Parts
+
+| Part           | Description |
+| -------------- | ----------- |
+| `"scrollable"` |             |
+| `"title"`      |             |
+
+
 ## Dependencies
 
 ### Depends on

--- a/packages/components/src/html/data-grid.html
+++ b/packages/components/src/html/data-grid.html
@@ -189,15 +189,15 @@
           style: 'switch',
           editable: true,
         },
-        {  
+        {
           type: 'text',
           label: 'Nr-edit',
           editable: true,
           width: 60,
           textFieldProps: {
             type: 'number',
-            'max':2
-          }
+            max: 2,
+          },
         },
         {
           type: 'graph',
@@ -849,12 +849,16 @@
 
       // Pass in data
       const table = document.querySelector('#table1');
-      document.querySelector('scale-data-grid').addEventListener('scale-sort', ({ detail }) => {
-        console.log('sort', detail);
-      });
-      document.querySelector('scale-data-grid').addEventListener('scale-selection', ({ detail }) => {
-        console.log('select', detail);
-      });
+      document
+        .querySelector('scale-data-grid')
+        .addEventListener('scale-sort', ({ detail }) => {
+          console.log('sort', detail);
+        });
+      document
+        .querySelector('scale-data-grid')
+        .addEventListener('scale-selection', ({ detail }) => {
+          console.log('select', detail);
+        });
       table.fields = fields;
       table.rows = rows;
       table.localization = localization;

--- a/packages/components/src/html/data-grid.html
+++ b/packages/components/src/html/data-grid.html
@@ -189,6 +189,16 @@
           style: 'switch',
           editable: true,
         },
+        {  
+          type: 'text',
+          label: 'Nr-edit',
+          editable: true,
+          width: 60,
+          textFieldProps: {
+            type: 'number',
+            'max':2
+          }
+        },
         {
           type: 'graph',
           label: 'Progress',
@@ -222,6 +232,7 @@
           '00:00:20',
           101045.0,
           false,
+          1,
           15,
           (() => {
             const demoNestedContent = document.createElement('div');
@@ -255,6 +266,7 @@
           '00:01:15',
           43.2,
           true,
+          2,
           73.2,
           (() => {
             const demoNestedContent = document.createElement('div');
@@ -288,6 +300,7 @@
           '00:00:20',
           102045.0,
           false,
+          3,
           15,
           (() => {
             const demoNestedContent = document.createElement('div');
@@ -326,6 +339,7 @@
           '00:01:15',
           45.2,
           true,
+          4,
           73.2,
           (() => {
             const demoNestedContent = document.createElement('div');
@@ -359,6 +373,7 @@
           '00:00:20',
           103045.0,
           false,
+          5,
           15,
           (() => {
             const demoNestedContent = document.createElement('div');
@@ -392,6 +407,7 @@
           '00:01:15',
           47.2,
           true,
+          6,
           73.2,
           (() => {
             const demoNestedContent = document.createElement('div');
@@ -425,6 +441,7 @@
           '00:00:20',
           105045.0,
           false,
+          7,
           15,
           (() => {
             const demoNestedContent = document.createElement('div');
@@ -458,6 +475,7 @@
           '00:01:15',
           48.2,
           true,
+          8,
           73.2,
           (() => {
             const demoNestedContent = document.createElement('div');
@@ -491,6 +509,7 @@
           '00:00:20',
           109045.0,
           false,
+          9,
           15,
           (() => {
             const demoNestedContent = document.createElement('div');
@@ -524,6 +543,7 @@
           '00:01:15',
           40.2,
           true,
+          10,
           73.2,
           (() => {
             const demoNestedContent = document.createElement('div');
@@ -557,6 +577,7 @@
           '00:00:20',
           108045.0,
           false,
+          11,
           15,
           (() => {
             const demoNestedContent = document.createElement('div');
@@ -590,6 +611,7 @@
           '00:01:15',
           43.2,
           true,
+          12,
           73.2,
           (() => {
             const demoNestedContent = document.createElement('div');
@@ -622,6 +644,7 @@
           '00:00:20',
           102045.0,
           false,
+          13,
           15,
           (() => {
             const demoNestedContent = document.createElement('div');
@@ -655,6 +678,7 @@
           '00:01:15',
           43.2,
           true,
+          14,
           73.2,
           (() => {
             const demoNestedContent = document.createElement('div');
@@ -689,6 +713,7 @@
           102045.0,
           false,
           15,
+          15,
           (() => {
             const demoNestedContent = document.createElement('div');
             demoNestedContent.innerHTML = `<scale-button href="https://example.com" target="_blank" title="External link, opens in new tab">
@@ -721,6 +746,7 @@
           '00:01:15',
           43.2,
           true,
+          16,
           73.2,
           (() => {
             const demoNestedContent = document.createElement('div');
@@ -754,6 +780,7 @@
           '00:00:20',
           102045.0,
           false,
+          17,
           15,
           (() => {
             const demoNestedContent = document.createElement('div');
@@ -787,6 +814,7 @@
           '00:01:15',
           43.2,
           true,
+          18,
           73.2,
           (() => {
             const demoNestedContent = document.createElement('div');
@@ -817,12 +845,16 @@
         select: 'SelectLoc',
         tableOptions: 'OptionsLoc',
         expand: 'Klicken Sie zu expanden',
-        collapse: 'Klicken Sie zu collapsen',
       };
 
       // Pass in data
       const table = document.querySelector('#table1');
-
+      document.querySelector('scale-data-grid').addEventListener('scale-sort', ({ detail }) => {
+        console.log('sort', detail);
+      });
+      document.querySelector('scale-data-grid').addEventListener('scale-selection', ({ detail }) => {
+        console.log('select', detail);
+      });
       table.fields = fields;
       table.rows = rows;
       table.localization = localization;

--- a/packages/storybook-vue/stories/components/data-grid/DataGrid.stories.mdx
+++ b/packages/storybook-vue/stories/components/data-grid/DataGrid.stories.mdx
@@ -748,6 +748,8 @@ Expected format: unformatted `string`, eg `'this is a string'`
 - `iconPrefix?: scale-icon-string (eg 'action-download')`
 - `iconSuffix?: scale-icon-string (eg 'action-download')`
 - `editable?: boolean = false`
+
+
  If `editable` is set to `true`, a `scale-text-field` is used for the element. The properties of the `scale-text-field` can be passed to the editable component using the `textFieldProps` attribute.
  <Canvas withSource="close">
   <Story name="Text Cell">

--- a/packages/storybook-vue/stories/components/data-grid/DataGrid.stories.mdx
+++ b/packages/storybook-vue/stories/components/data-grid/DataGrid.stories.mdx
@@ -752,7 +752,7 @@ Expected format: unformatted `string`, eg `'this is a string'`
 
 
  If `editable` is set to `true`, a `scale-text-field` is used for the element. The properties of the `scale-text-field` can be passed directly to the editable component using the `textFieldProps` attribute.
- and if the `editable` is set to `false`, the `scale-text-field` has no effect, as the cell will be read-only.
+ and if the `editable` is set to `false`, the `textFieldProps` has no effect, as the cell will be read-only.
  <Canvas withSource="close">
   <Story name="Text Cell">
     {`<content>

--- a/packages/storybook-vue/stories/components/data-grid/DataGrid.stories.mdx
+++ b/packages/storybook-vue/stories/components/data-grid/DataGrid.stories.mdx
@@ -748,9 +748,11 @@ Expected format: unformatted `string`, eg `'this is a string'`
 - `iconPrefix?: scale-icon-string (eg 'action-download')`
 - `iconSuffix?: scale-icon-string (eg 'action-download')`
 - `editable?: boolean = false`
+- `textFieldProps?: Object (eg { type: 'number', helperText: 'Enter a number' })`
 
 
- If `editable` is set to `true`, a `scale-text-field` is used for the element. The properties of the `scale-text-field` can be passed to the editable component using the `textFieldProps` attribute.
+ If `editable` is set to `true`, a `scale-text-field` is used for the element. The properties of the `scale-text-field` can be passed directly to the editable component using the `textFieldProps` attribute.
+ and if the `editable` is set to `false`, the `scale-text-field` has no effect, as the cell will be read-only.
  <Canvas withSource="close">
   <Story name="Text Cell">
     {`<content>

--- a/packages/storybook-vue/stories/components/data-grid/DataGrid.stories.mdx
+++ b/packages/storybook-vue/stories/components/data-grid/DataGrid.stories.mdx
@@ -169,6 +169,14 @@ import ScaleDataGrid from './ScaleDataGrid.vue';
       description: `Event triggered every time the data is sorted, changing original rows data`,
       control: { type: null },
     },
+    eventScaleSelection: {
+      name: '[event] scale-selection',
+      table: {
+        type: { summary: 'event' },
+      },
+      description: `Event triggered every time the selection list updates`,
+      control: { type: null },
+    },
     slotMenu: {
       name: '[slot] menu',
       table: {
@@ -740,8 +748,8 @@ Expected format: unformatted `string`, eg `'this is a string'`
 - `iconPrefix?: scale-icon-string (eg 'action-download')`
 - `iconSuffix?: scale-icon-string (eg 'action-download')`
 - `editable?: boolean = false`
-
-<Canvas withSource="close">
+ If `editable` is set to `true`, a `scale-text-field` is used for the element. The properties of the `scale-text-field` can be passed to the editable component using the `textFieldProps` attribute.
+ <Canvas withSource="close">
   <Story name="Text Cell">
     {`<content>
     <scale-data-grid id="text-example" hide-menu></scale-data-grid>


### PR DESCRIPTION
This PR introduces the following changes:
**Feature 1**: Added the `scale-selection` event to the data grid component. This event is triggered every time the selection list updates, providing better integration and control over row selection.
**Feature 2**: Enhanced the editable text cell properties in the data grid. Now, the text cell supports additional properties supported by the underlying `scale-text-field`, allowing for more customization and improved user experience.
**Documentation**: Updates to documentation storybook for the new event and the text cell config.