### PR TITLE
fix(nav-item): add null check for child element on load

### DIFF
--- a/packages/components/src/components/telekom/telekom-nav-item/telekom-nav-item.tsx
+++ b/packages/components/src/components/telekom/telekom-nav-item/telekom-nav-item.tsx
@@ -71,7 +71,7 @@ export class TelekomNavItem {
       el.matches('a, button')
     );
     const parentRole = this.hostElement.parentElement?.getAttribute('role');
-    if (parentRole === 'menu') {
+    if (child && parentRole === 'menu') {
       child.setAttribute('role', 'menuitem');
     }
   }


### PR DESCRIPTION
This PR addresses an issue in the telekom-nav-item component, where an attempt to set the attribute on a child element could result in an error if the child element is null. The fix adds a null check for the child element before setting the role attribute