### PR TITLE
fix: check for querySelector value added

### DIFF
--- a/packages/components/src/components/date-picker/date-picker.tsx
+++ b/packages/components/src/components/date-picker/date-picker.tsx
@@ -226,9 +226,12 @@ export class DatePicker {
    */
   @Watch('value')
   onValueChange() {
-    this.hasValue = this.value != null && this.value !== '';
-    // @ts-ignore
-    this.duetInput.querySelector('.duet-date__input').value = this.value;
+    this.hasValue = this.value !== null && this.value !== '';
+    const input = this.duetInput.querySelector('.duet-date__input');
+    if (input) {
+      // @ts-ignore
+      input.value = this.value;
+    }
   }
 
   /**


### PR DESCRIPTION
should fix this error (must happen on comp init, while props are coming befor DOM is ready):
![image](https://github.com/user-attachments/assets/2260f66d-2a6b-4835-9778-356b5d8dda24)

in all other places in the component, where querySelector is used, this check for undefined exists, so I've added here as well