### PR TITLE
Fix(2353): ScaleButton disabled propagating

### DIFF
--- a/packages/components/src/components/button/button.tsx
+++ b/packages/components/src/components/button/button.tsx
@@ -201,6 +201,12 @@ export class Button {
       this.disabled && 'disabled'
     );
 
+    if (!this.disabled) {
+      this.hostElement.removeAttribute('disabled');
+    } else {
+      this.hostElement.setAttribute('disabled', 'true');
+    }
+
     return (
       <Host>
         {this.styles && <style>{this.styles}</style>}


### PR DESCRIPTION
The accessibility issue was fixed by removing disabled attribute from scale-button when disabled status changes to false.