### PR TITLE
fix(data-grid): prevents null or undefined break max content length calculation

### DIFF
--- a/packages/components/src/components/data-grid/data-grid.tsx
+++ b/packages/components/src/components/data-grid/data-grid.tsx
@@ -380,7 +380,7 @@ export class DataGrid {
     let maxLength = 0;
     let longestContent;
     rows.forEach((row) => {
-      const length = row[columnIndex].toString().length;
+      const length = row[columnIndex]?.toString()?.length || 0;
       if (length > maxLength) {
         longestContent = row[columnIndex];
         maxLength = length;


### PR DESCRIPTION
# What does this PR do?
- Fixes issue https://github.com/telekom/scale/issues/2376
- Prevents `null` or `undefined` values from breaking data-grid component.

## Quick summary
Data Grid component calculates the _longest_ row. For this it relies on `.toString()` [method to obtain its length.](https://github.com/telekom/scale/blob/8ce3a450c2bf023dac4c3d5273279f5a7781815a/packages/components/src/components/data-grid/data-grid.tsx#L383C1-L383C64)
Both `null` and `undefined` lack the former one, and will break the component after invoking the method.

## What has been done
- Add to 0 as default-
- optional chaining to prevent these values from breaking the component.

## Some Observations
- This is my first PR here 👋🏻 so if I'm missing something let me know. 
- I'm still figuring lerna and this monorepo out, so any observations are welcome.
- Tested locally in a mock project.
