### PR TITLE
fix(segmented button): Scale Segmented Button doesn't respect controlled selected state (#2166)

### DIFF
--- a/packages/components/src/components/segment/segment.tsx
+++ b/packages/components/src/components/segment/segment.tsx
@@ -18,6 +18,7 @@ import {
   Event,
   EventEmitter,
   Method,
+  Watch,
 } from '@stencil/core';
 import classNames from 'classnames';
 import { emitEvent } from '../../utils/utils';
@@ -72,6 +73,8 @@ export class Segment {
     id: string;
     selected: boolean;
   }>;
+  /** Emitted when selection has been changed. */
+  @Event({ eventName: 'scaleSelectionChanged' }) scaleSelectionChanged!: EventEmitter;
   /** @deprecated in v3 in favor of kebab-case event names */
   @Event({ eventName: 'scaleClick' }) scaleClickLegacy!: EventEmitter<{
     id: string;
@@ -79,6 +82,11 @@ export class Segment {
   }>;
 
   private focusableElement: HTMLElement;
+
+  @Watch('selected')
+  selectionChanged() {
+    emitEvent(this, 'scaleSelectionChanged');
+  }
 
   @Method()
   async setFocus() {

--- a/packages/components/src/components/segmented-button/segmented-button.tsx
+++ b/packages/components/src/components/segmented-button/segmented-button.tsx
@@ -99,6 +99,15 @@ export class SegmentedButton {
     this.setState(tempState);
   }
 
+  @Listen('scaleSelectionChanged')
+  selectionChangedHandler() {
+    this.selectedIndex = this.getSelectedIndex();
+    if (typeof(this.selectedIndex) !== 'number') { return }
+    this.getAllSegments().forEach((segment) => {
+      segment.setAttribute('selected-index', this.selectedIndex.toString());
+    })
+  }
+
   @Watch('disabled')
   @Watch('size')
   @Watch('selectedIndex')


### PR DESCRIPTION
Reason for this issue was that segmented button has never known when selected segment has been changed. Therefore I had to send an event when segment was selected outside the scale component and react on this event in segment button.