### PR TITLE
ci: bumps cache action to 3

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Restore Lerna
         id: yarn-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             node_modules
@@ -77,7 +77,7 @@ jobs:
 
       - name: Restore Lerna
         id: yarn-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             node_modules
@@ -106,7 +106,7 @@ jobs:
 
       - name: Restore Lerna
         id: yarn-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             node_modules
@@ -145,7 +145,7 @@ jobs:
           
       - name: Restore Lerna
         id: yarn-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             node_modules
@@ -213,7 +213,7 @@ jobs:
 
       - name: Restore Lerna
         id: yarn-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             node_modules

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Restore Lerna
         id: yarn-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             node_modules


### PR DESCRIPTION
the actions/cache v2 is deprecated, therefore the version is updated to 3 fix build pipelines