### PR TITLE
feat(dropdown-select): add clear button to improve user experience

### DIFF
--- a/packages/components/src/components/data-grid/readme.md
+++ b/packages/components/src/components/data-grid/readme.md
@@ -114,6 +114,7 @@ graph TD;
   scale-progress-bar --> scale-icon-alert-error
   scale-progress-bar --> scale-icon-action-success
   scale-dropdown-select --> scale-icon-action-checkmark
+  scale-dropdown-select --> scale-icon-action-close
   scale-dropdown-select --> scale-icon-navigation-collapse-up
   scale-dropdown-select --> scale-icon-navigation-collapse-down
   scale-dropdown-select --> scale-helper-text

--- a/packages/components/src/components/dropdown-select/dropdown-select.css
+++ b/packages/components/src/components/dropdown-select/dropdown-select.css
@@ -178,6 +178,16 @@
   transition: var(--transition-icon);
 }
 
+[part='clear'] {
+  top: 50%;
+  right: var(--spacing-x);
+  position: absolute;
+  transform: translateY(-50%);
+  height: var(--height-icon);
+  color: var(--color-icon);
+  transition: var(--transition-icon);
+}
+
 [part~='disabled'] [part='icon'] {
   color: var(--color-disabled);
 }

--- a/packages/components/src/components/dropdown-select/dropdown-select.tsx
+++ b/packages/components/src/components/dropdown-select/dropdown-select.tsx
@@ -260,6 +260,9 @@ export class DropdownSelect {
   /** (optional) id or space separated list of ids of elements that provide or link to additional related information. */
   @Prop() ariaDetailsId?: string;
 
+  @Prop() allowClear?: boolean = true;
+  /** (optional) clear button inside the dropdown, that clears all iputs and resets the dropdown */
+
   @Event({ eventName: 'scale-change' }) scaleChange!: EventEmitter<void>;
   @Event({ eventName: 'scale-focus' }) scaleFocus!: EventEmitter<void>;
   @Event({ eventName: 'scale-blur' }) scaleBlur!: EventEmitter<void>;
@@ -581,22 +584,28 @@ export class DropdownSelect {
                 </div>
               </div>
             </div>
-
-            <div part="icon">
-              {this.open ? (
-                <scale-icon-navigation-collapse-up
-                  decorative
-                  size={DEFAULT_ICON_SIZE}
-                />
-              ) : (
-                <scale-icon-navigation-collapse-down
-                  decorative
-                  size={DEFAULT_ICON_SIZE}
-                />
-              )}
-            </div>
+            {this.allowClear && this.value ? (
+              <scale-icon-action-close
+                accessibility-title="close"
+                part="clear"
+                onClick={this.handleClearClick}
+              ></scale-icon-action-close>
+            ) : (
+              <div part="icon">
+                {this.open ? (
+                  <scale-icon-navigation-collapse-up
+                    decorative
+                    size={DEFAULT_ICON_SIZE}
+                  />
+                ) : (
+                  <scale-icon-navigation-collapse-down
+                    decorative
+                    size={DEFAULT_ICON_SIZE}
+                  />
+                )}
+              </div>
+            )}
           </div>
-
           {this.helperText && (
             <scale-helper-text
               helperText={this.helperText}
@@ -638,4 +647,21 @@ export class DropdownSelect {
       disabled && `disabled`
     );
   }
+
+  private handleClearClick = (event: MouseEvent) => {
+    event.stopPropagation();
+    // Verhindert, dass das Dropdown durch den Klick geöffnet/geschlossen wird
+
+    if (this.disabled || this.readonly) {
+      return;
+    }
+
+    this.value = '';
+    // Setzt den Wert zurück. Überlegen Sie, ob null passender wäre.
+
+    this.currentIndex = -1; // Setzt den Index des ausgewählten Elements zurück
+
+    emitEvent(this, 'scaleChange', { value: this.value });
+    // Informiert über die Wertänderung
+  };
 }

--- a/packages/components/src/components/dropdown-select/dropdown-select.tsx
+++ b/packages/components/src/components/dropdown-select/dropdown-select.tsx
@@ -259,8 +259,7 @@ export class DropdownSelect {
   @Prop() hcmLabelDisabled?: string = 'this field is disabled';
   /** (optional) id or space separated list of ids of elements that provide or link to additional related information. */
   @Prop() ariaDetailsId?: string;
-
-  @Prop() allowClear?: boolean = true;
+  @Prop() allowClear?: boolean = false;
   /** (optional) clear button inside the dropdown, that clears all iputs and resets the dropdown */
 
   @Event({ eventName: 'scale-change' }) scaleChange!: EventEmitter<void>;
@@ -650,18 +649,12 @@ export class DropdownSelect {
 
   private handleClearClick = (event: MouseEvent) => {
     event.stopPropagation();
-    // Verhindert, dass das Dropdown durch den Klick geöffnet/geschlossen wird
-
     if (this.disabled || this.readonly) {
       return;
     }
 
     this.value = '';
-    // Setzt den Wert zurück. Überlegen Sie, ob null passender wäre.
-
-    this.currentIndex = -1; // Setzt den Index des ausgewählten Elements zurück
-
+    this.currentIndex = -1;
     emitEvent(this, 'scaleChange', { value: this.value });
-    // Informiert über die Wertänderung
   };
 }

--- a/packages/components/src/components/dropdown-select/readme.md
+++ b/packages/components/src/components/dropdown-select/readme.md
@@ -9,6 +9,7 @@
 
 | Property            | Attribute             | Description                                                                                                      | Type                                                    | Default                    |
 | ------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- | -------------------------- |
+| `allowClear`        | `allow-clear`         |                                                                                                                  | `boolean`                                               | `false`                    |
 | `ariaDetailsId`     | `aria-details-id`     | (optional) id or space separated list of ids of elements that provide or link to additional related information. | `string`                                                | `undefined`                |
 | `ariaLabelSelected` | `aria-label-selected` | (optional) Screen reader text appended to the selected element                                                   | `string`                                                | `'selected'`               |
 | `comboboxId`        | `combobox-id`         |                                                                                                                  | `string`                                                | `'combobox'`               |
@@ -28,18 +29,19 @@
 
 ## Events
 
-| Event           | Description | Type                |
-| --------------- | ----------- | ------------------- |
-| `scale-blur`    |             | `CustomEvent<void>` |
-| `scale-change`  |             | `CustomEvent<void>` |
-| `scale-focus`   |             | `CustomEvent<void>` |
-| `scale-keydown` |             | `CustomEvent<void>` |
+| Event           | Description                                                                                | Type                |
+| --------------- | ------------------------------------------------------------------------------------------ | ------------------- |
+| `scale-blur`    |                                                                                            | `CustomEvent<void>` |
+| `scale-change`  | (optional) clear button inside the dropdown, that clears all iputs and resets the dropdown | `CustomEvent<void>` |
+| `scale-focus`   |                                                                                            | `CustomEvent<void>` |
+| `scale-keydown` |                                                                                            | `CustomEvent<void>` |
 
 
 ## Shadow Parts
 
 | Part                         | Description |
 | ---------------------------- | ----------- |
+| `"clear"`                    |             |
 | `"combobox-container"`       |             |
 | `"combobox-value"`           |             |
 | `"icon"`                     |             |
@@ -58,6 +60,7 @@
 ### Depends on
 
 - [scale-icon-action-checkmark](../icons/action-checkmark)
+- [scale-icon-action-close](../icons/action-close)
 - [scale-icon-navigation-collapse-up](../icons/navigation-collapse-up)
 - [scale-icon-navigation-collapse-down](../icons/navigation-collapse-down)
 - [scale-helper-text](../helper-text)
@@ -66,6 +69,7 @@
 ```mermaid
 graph TD;
   scale-dropdown-select --> scale-icon-action-checkmark
+  scale-dropdown-select --> scale-icon-action-close
   scale-dropdown-select --> scale-icon-navigation-collapse-up
   scale-dropdown-select --> scale-icon-navigation-collapse-down
   scale-dropdown-select --> scale-helper-text

--- a/packages/components/src/html/dropdown-select.html
+++ b/packages/components/src/html/dropdown-select.html
@@ -32,7 +32,7 @@
       invalid
       value="caspar"
       name="foo"
-      allow-clear="true"
+      allow-clear="false"
     >
       <scale-dropdown-select-item value="caspar">
         <scale-icon-action-add slot="suffix"></scale-icon-action-add>

--- a/packages/components/src/html/dropdown-select.html
+++ b/packages/components/src/html/dropdown-select.html
@@ -32,6 +32,7 @@
       invalid
       value="caspar"
       name="foo"
+      allow-clear="true"
     >
       <scale-dropdown-select-item value="caspar">
         <scale-icon-action-add slot="suffix"></scale-icon-action-add>

--- a/packages/storybook-vue/stories/components/dropdown-select/DropdownSelect.stories.mdx
+++ b/packages/storybook-vue/stories/components/dropdown-select/DropdownSelect.stories.mdx
@@ -23,6 +23,9 @@ import { action } from '@storybook/addon-actions';
     floatingStrategy: {
       description: "see https://floating-ui.com/docs/computePosition#strategy "
     },
+    allowClear: {
+      description: "(optional) when set allows user to clear selected value using the added clearButton" 
+    }
   }}
 />
 

--- a/packages/storybook-vue/stories/components/dropdown-select/ScaleDropdownSelect.vue
+++ b/packages/storybook-vue/stories/components/dropdown-select/ScaleDropdownSelect.vue
@@ -14,6 +14,7 @@
     :transparent="transparent"
     :aria-label-selected="ariaLabelSelected"
     :hcm-label-disabled="hcmLabelDisabled"
+    :allow-clear="allowClear"
     @scaleChange="['scale-change']"
     @scaleFocus="['scale-focus']"
     @scaleBlur="['scale-blur']"
@@ -45,6 +46,7 @@ export default {
     ariaLabelSelected: { type: String },
     hcmLabelDisabled: { type: String },
     value: { type: String},
+    allowClear: {type: Boolean}
   },
   methods: {
     'scale-change'($event) {


### PR DESCRIPTION
I added an optional feature to the dropdown-select component, which allows clearing the selected dropwdown element by klicking an 'x' icon.