### PR TITLE
fix: dev build causes ts errors

### DIFF
--- a/packages/components/src/components/dropdown-select/dropdown-select.e2e.ts
+++ b/packages/components/src/components/dropdown-select/dropdown-select.e2e.ts
@@ -1,10 +1,8 @@
 import { E2EElement, E2EPage, newE2EPage } from '@stencil/core/testing';
-import { DropdownSelect } from './dropdown-select';
 
 describe('DropdownSelect', function () {
   it('should be able to change it`s value via keyboard nav', async () => {
     const page = await newE2EPage({
-      components: [DropdownSelect],
       html: `
       <scale-dropdown-select>
         <scale-dropdown-select-item value="caspar">Caspar</scale-dropdown-select-item>
@@ -31,7 +29,6 @@ describe('DropdownSelect', function () {
   });
   it('should be able to change it`s value via typing', async () => {
     const page = await newE2EPage({
-      components: [DropdownSelect],
       html: `
       <scale-dropdown-select>
         <scale-dropdown-select-item value="caspar">Caspar</scale-dropdown-select-item>
@@ -67,7 +64,6 @@ describe('DropdownSelect', function () {
 
     beforeEach(async () => {
       page = await newE2EPage({
-        components: [DropdownSelect],
         html: `
         <scale-dropdown-select>
           <scale-dropdown-select-item value="adam">Adam</scale-dropdown-select-item>
@@ -119,7 +115,6 @@ describe('DropdownSelect', function () {
 
     beforeEach(async () => {
       page = await newE2EPage({
-        components: [DropdownSelect],
         html: `
         <scale-dropdown-select value="default">
           <scale-dropdown-select-item disabled value="adam">Adam</scale-dropdown-select-item>

--- a/packages/components/src/components/dropdown-select/dropdown-select.spec.ts
+++ b/packages/components/src/components/dropdown-select/dropdown-select.spec.ts
@@ -64,10 +64,14 @@ describe('DropdownSelect', function () {
 
     const selectEl = page.doc.querySelector('scale-dropdown-select');
     selectEl.addEventListener('scale-change', changeSpy);
-    const comboboxEl = selectEl.shadowRoot.querySelector('[part="combobox"]') as HTMLElement;
+    const comboboxEl = selectEl.shadowRoot.querySelector(
+      '[part="combobox"]'
+    ) as HTMLElement;
     comboboxEl.scrollIntoView = function () {};
     comboboxEl.focus = function () {};
-    const optionsEls = selectEl.shadowRoot.querySelectorAll('[role="option"]') as NodeListOf<HTMLElement>;
+    const optionsEls = selectEl.shadowRoot.querySelectorAll(
+      '[role="option"]'
+    ) as NodeListOf<HTMLElement>;
 
     comboboxEl.click();
     optionsEls[2].click();

--- a/packages/components/src/components/dropdown-select/dropdown-select.spec.ts
+++ b/packages/components/src/components/dropdown-select/dropdown-select.spec.ts
@@ -64,10 +64,10 @@ describe('DropdownSelect', function () {
 
     const selectEl = page.doc.querySelector('scale-dropdown-select');
     selectEl.addEventListener('scale-change', changeSpy);
-    const comboboxEl = selectEl.shadowRoot.querySelector('[part="combobox"]');
+    const comboboxEl = selectEl.shadowRoot.querySelector('[part="combobox"]') as HTMLElement;
     comboboxEl.scrollIntoView = function () {};
     comboboxEl.focus = function () {};
-    const optionsEls = selectEl.shadowRoot.querySelectorAll('[role="option"]');
+    const optionsEls = selectEl.shadowRoot.querySelectorAll('[role="option"]') as NodeListOf<HTMLElement>;
 
     comboboxEl.click();
     optionsEls[2].click();

--- a/packages/components/src/components/helper-text/helper-text.spec.ts
+++ b/packages/components/src/components/helper-text/helper-text.spec.ts
@@ -13,11 +13,6 @@ import { newSpecPage } from '@stencil/core/testing';
 import { HelperText } from './helper-text';
 
 describe('Helper Text', () => {
-  let element;
-  beforeEach(async () => {
-    element = new HelperText();
-  });
-
   it('should render informational helper text with info icon if no variant is specified', async () => {
     const page = await newSpecPage({
       components: [HelperText],

--- a/packages/components/src/components/link/link.spec.ts
+++ b/packages/components/src/components/link/link.spec.ts
@@ -13,11 +13,6 @@ import { newSpecPage } from '@stencil/core/testing';
 import { Link } from './link';
 
 describe('Link', () => {
-  let element;
-  beforeEach(async () => {
-    element = new Link();
-  });
-
   it('should match snapshot', async () => {
     const page = await newSpecPage({
       components: [Link],

--- a/packages/components/src/components/notification/notification.spec.ts
+++ b/packages/components/src/components/notification/notification.spec.ts
@@ -13,12 +13,6 @@ import { newSpecPage } from '@stencil/core/testing';
 import { Notification } from './notification';
 
 describe('Notification ', () => {
-  let element;
-
-  beforeEach(async () => {
-    element = new Notification();
-  });
-
   it('should match snapshot', async () => {
     const page = await newSpecPage({
       components: [Notification],


### PR DESCRIPTION
The dev-build leads to errors and warnings of some few test files:

- dropdown-select.e2e.ts: components option not supported and needed any more
- dropdown-select.spec.ts: casting to HTMLElement is missing
- helper-text.spec.ts, link.spec.ts, notification.spec.ts: removal of unused code