### PR TITLE
fix(utils): update event handling for checkbox and radio button

### DIFF
--- a/packages/components-vue/src/vue-component-lib/utils.ts
+++ b/packages/components-vue/src/vue-component-lib/utils.ts
@@ -8,7 +8,9 @@ export const createCommonRender = (tagName: string, eventNames: string[] = []) =
         ...listeners,
         [eventName]: (event: CustomEvent<any>) => {
           let emittedValue = event.detail;
-          if (event.detail?.value != null) {
+          if (event.detail?.checked != null) {
+            emittedValue = event.detail.checked;
+          } else if (event.detail?.value != null) {
             emittedValue = event.detail.value;
           }
           vueElement.$emit(eventName, emittedValue);

--- a/packages/components/framework-targets.ts
+++ b/packages/components/framework-targets.ts
@@ -20,16 +20,16 @@ const vueComponentModels: ComponentModelConfig[] = [
     event: 'scaleChange',
     targetAttr: 'value',
   },
-  // These do not work with the way the plugin "utils"'s wires events,
-  // and probably Vue doing something different for native input[type=checkbox|radio]
-  // {
-  //   elements: [
-  //     'scale-checkbox',
-  //     'scale-radio-button'
-  //   ],
-  //   event: 'scaleChange',
-  //   targetAttr: 'value',
-  // },
+  {
+    elements: ['scale-checkbox'],
+    event: 'scaleChange',
+    targetAttr: 'checked',
+  },
+  {
+    elements: ['scale-radio-button'],
+    event: 'scaleChange',
+    targetAttr: 'checked',
+  },
   {
     elements: ['scale-slider'],
     event: 'scaleInput',


### PR DESCRIPTION
Fixed event handling for checkbox and radio button components to use 'checked' attribute instead of 'value', enabling proper v-model functionality in Vue.js applications. The components were previously not compatible with Vues v-model directive because they were emitting events with the wrong attribute. 