### PR TITLE
fix(data-grid): fix overflowing table header text when title space reduced

### DIFF
--- a/packages/components/src/components/data-grid/data-grid.css
+++ b/packages/components/src/components/data-grid/data-grid.css
@@ -169,6 +169,12 @@
   color: var(--telekom-color-text-and-icon-additional);
 }
 
+.thead__text {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .thead__cell--numbered {
   text-align: right;
   justify-content: flex-end;
@@ -184,6 +190,8 @@
 }
 .thead__title {
   color: var(--telekom-color-text-and-icon-standard);
+  width: 100%;
+  display: flex;
 }
 
 .thead__text {
@@ -194,10 +202,7 @@
 
 .thead__arrow-top,
 .thead__arrow-bottom {
-  position: absolute;
   display: none !important;
-  top: -2px;
-  left: -16px;
 }
 
 .thead__sort-prompt {

--- a/packages/components/src/components/data-grid/data-grid.tsx
+++ b/packages/components/src/components/data-grid/data-grid.tsx
@@ -1106,21 +1106,19 @@ export class DataGrid {
                     : {})}
                 >
                   <div class={`thead__title`}>
-                    <span class={`thead__text`}>
-                      {sortable && (
-                        <scale-icon-content-sort-indicator-up
-                          size={16}
-                          class={`thead__arrow-top`}
-                        ></scale-icon-content-sort-indicator-up>
-                      )}
-                      {sortable && (
-                        <scale-icon-content-sort-indicator-down
-                          size={16}
-                          class={`thead__arrow-bottom`}
-                        ></scale-icon-content-sort-indicator-down>
-                      )}
-                      {label}
-                    </span>
+                    <span class={`thead__text`}>{label}</span>
+                    {sortable && (
+                      <scale-icon-content-sort-indicator-up
+                        size={16}
+                        class={`thead__arrow-top`}
+                      ></scale-icon-content-sort-indicator-up>
+                    )}
+                    {sortable && (
+                      <scale-icon-content-sort-indicator-down
+                        size={16}
+                        class={`thead__arrow-bottom`}
+                      ></scale-icon-content-sort-indicator-down>
+                    )}
                   </div>
 
                   {resizable && (


### PR DESCRIPTION
Fixing the issue with overflowing data-grid table header text when width of the column is reduced.

The sort indicator icons were moved out of the text element and removed their absolute positioning as well as it was never reset and thus the icons were not visible. This I discovered by accident, not sure if previous behaviour was intentional or not, but this seems to work better. 
New position of sort indicator icons is after the header text which also seems to work better as it reduces the move of the text when icon appears.