### PR TITLE
fix(data-grid): fix issue with table header overlapping the table body

### DIFF
--- a/packages/components/src/components/data-grid/data-grid.css
+++ b/packages/components/src/components/data-grid/data-grid.css
@@ -120,7 +120,7 @@
 .data-grid__table {
   border-spacing: 0;
   border-collapse: collapse;
-  overflow: hidden;
+  /* overflow: hidden; */
 }
 
 .data-grid--hide-menu .data-grid__settings-menu {
@@ -146,6 +146,8 @@
 }
 
 .data-grid--freeze-header .thead {
+  position: sticky;
+  top: 0;
   z-index: 30;
   background-color: var(--telekom-color-background-canvas);
 }

--- a/packages/components/src/components/data-grid/data-grid.css
+++ b/packages/components/src/components/data-grid/data-grid.css
@@ -120,7 +120,6 @@
 .data-grid__table {
   border-spacing: 0;
   border-collapse: collapse;
-  /* overflow: hidden; */
 }
 
 .data-grid--hide-menu .data-grid__settings-menu {

--- a/packages/components/src/components/data-grid/data-grid.tsx
+++ b/packages/components/src/components/data-grid/data-grid.tsx
@@ -150,10 +150,6 @@ export class DataGrid {
   private dataNeedsCheck: boolean = true;
   /** Track main container for element resize */
   private elMmainContainer?: any;
-  /** Track table container for scroll */
-  private elScrollContainer?: HTMLElement;
-  /** Table head for frozen header */
-  private elTableHead?: HTMLElement;
   /** Checkbox for getting toggle-all state */
   private elToggleSelectAll?: HTMLScaleCheckboxElement;
   /** Flag to know if rendering can commence */
@@ -798,15 +794,6 @@ export class DataGrid {
     this.forceRender++;
   }
 
-  onTableScroll() {
-    if (!this.freezeHeader || this.hideHeader) {
-      return;
-    }
-    // Freeze header
-    const scrollY = this.elScrollContainer.scrollTop;
-    this.elTableHead.style.transform = `translateY(${scrollY}px)`;
-  }
-
   handleMenuListClick = (event) => {
     const menuItems = ['sortBy', 'toggleVisibility'];
     const currentMenuItemsIndex = menuItems.indexOf(event.target.id);
@@ -954,11 +941,9 @@ export class DataGrid {
     }
     return (
       <div
-        ref={(el) => (this.elScrollContainer = el)}
         class={`${name}__scroll-container`}
         part="scrollable"
         style={{ height: this.height || 'auto' }}
-        onScroll={() => this.onTableScroll()}
       >
         <table class={`${name}__table`}>
           {this.renderTableHead()}
@@ -1028,7 +1013,6 @@ export class DataGrid {
   renderTableHead() {
     return (
       <thead
-        ref={(el) => (this.elTableHead = el)}
         class={`thead ${this.hideHeader ? 'sr-only' : ''}`}
       >
         <tr class={`thead__row`}>

--- a/packages/components/src/components/data-grid/data-grid.tsx
+++ b/packages/components/src/components/data-grid/data-grid.tsx
@@ -1012,9 +1012,7 @@ export class DataGrid {
 
   renderTableHead() {
     return (
-      <thead
-        class={`thead ${this.hideHeader ? 'sr-only' : ''}`}
-      >
+      <thead class={`thead ${this.hideHeader ? 'sr-only' : ''}`}>
         <tr class={`thead__row`}>
           {this.numbered && this.renderTableHeadNumberedCell()}
           {this.selectable && this.renderTableHeadSelectableCell()}


### PR DESCRIPTION
The issue appears when the last on scroll event effect to update the scroll position of the header doesn't happen. It appears as it will not render until the next redraw, sometimes keeping the header stuck over table values when using freeze-headers option and scrolling back to top.

Proposed solution removes the use of on scroll event and utilizes the `position: sticky` for the table header.