### PR TITLE
fix(header): corrected text for language switcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,6 @@
     "node": "16.x",
     "npm": "please-use-yarn",
     "yarn": "1.x"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/packages/components/src/components/telekom/telekom-nav-item/telekom-nav-item.css
+++ b/packages/components/src/components/telekom/telekom-nav-item/telekom-nav-item.css
@@ -392,4 +392,28 @@ scale-telekom-mobile-flyout-canvas
 
 .scale-telekom-nav-list > scale-menu-flyout::part(trigger) {
   height: 100%;
+} 
+.scale-telekom-nav-list[variant='lang-switcher'] {
+  display: flex;
+  gap: 0px;
 }
+ 
+.scale-telekom-nav-list[variant='lang-switcher'] > .scale-telekom-nav-item {
+  margin: 0;
+}
+ 
+.scale-telekom-nav-list[variant='lang-switcher'] > .scale-telekom-nav-item > :where(a, button) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  min-inline-size: 24px;
+  min-block-size: 24px;
+}
+
+/*  geerbte Margins an den Items überschreiben */
+.scale-telekom-nav-list[variant='lang-switcher'] > .scale-telekom-nav-item{
+  margin: 0 !important;
+}
+
+


### PR DESCRIPTION
 Summary: 
Fixes the accessibility issue in `scale-language-switcher` by increasing element size from 13.77 × 27 px to the recommended 24 × 24 px.

Result:
- Easier to activate via mouse or touch
- Lower risk of accidental clicks
- Improved accessibility for users with motor impairments