### PR TITLE
fix-language-switcher: #2413

### DIFF
--- a/packages/components/src/components/telekom/telekom-nav-item/telekom-nav-item.css
+++ b/packages/components/src/components/telekom/telekom-nav-item/telekom-nav-item.css
@@ -393,3 +393,21 @@ scale-telekom-mobile-flyout-canvas
 .scale-telekom-nav-list > scale-menu-flyout::part(trigger) {
   height: 100%;
 }
+.scale-telekom-nav-list[variant='lang-switcher']
+  > .scale-telekom-nav-item
+  > :where(a, button) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  min-inline-size: 24px;
+  min-block-size: 24px;
+}
+
+.scale-telekom-nav-list[variant='lang-switcher'].scale-telekom-nav-list > .scale-telekom-nav-item {
+  margin: 0;
+}
+
+
+
+


### PR DESCRIPTION
The interactive elements in the scale-language-switcher previously had a size of 13.77 × 27 px, which made them difficult to activate, especially for users with motor impairments.

Fix:

Increased the minimum size of each interactive element to 24 × 24 px.

Ensures compliance with accessibility best practices by reducing the risk of accidental activations.