### PR TITLE
fix: update styles of input components to prevent overflow

### DIFF
--- a/packages/components/src/components/date-picker/date-picker.css
+++ b/packages/components/src/components/date-picker/date-picker.css
@@ -47,8 +47,8 @@ duet-date-picker .duet-date__input {
   border: var(--telekom-line-weight-standard) solid
     var(--telekom-color-ui-border-standard);
   background-color: var(--telekom-color-ui-state-fill-standard);
-  padding: 1.125rem 3.5rem
-    0.25rem calc(var(--spacing-x) - var(--telekom-spacing-composition-space-01));
+  padding: 1.125rem 3.5rem 0.25rem
+    calc(var(--spacing-x) - var(--telekom-spacing-composition-space-01));
   height: var(--telekom-spacing-composition-space-13);
   font: var(--telekom-text-style-body);
 }

--- a/packages/components/src/components/text-field/text-field.css
+++ b/packages/components/src/components/text-field/text-field.css
@@ -183,7 +183,7 @@ scale-text-field {
   font: var(--telekom-text-style-ui);
   transform: translate(var(--spacing-x), 0.875rem);
 
-  width: calc( 100% - var(--spacing-x) * 2); 
+  width: calc(100% - var(--spacing-x) * 2);
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;

--- a/packages/components/src/components/textarea/textarea.css
+++ b/packages/components/src/components/textarea/textarea.css
@@ -146,7 +146,7 @@ scale-textarea {
   font: var(--telekom-text-style-ui);
   transform: translate(var(--spacing-x-control), 0.875rem);
 
-  width: calc( 100% - var(--spacing-x-control) * 2); 
+  width: calc(100% - var(--spacing-x-control) * 2);
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;


### PR DESCRIPTION
Issue: date picker and text field components label overflows the component /wraps to multiple lines in case of very long text provided for the label.

<img width="346" height="60" alt="image" src="https://github.com/user-attachments/assets/e5aff2dd-6682-4a32-930d-43956b735239" />

<img width="347" height="55" alt="image" src="https://github.com/user-attachments/assets/350e14e1-70a4-482a-8bb5-2e6707cb2c39" />
