### PR TITLE
fix: remove disabled attribute when false 

### DIFF
--- a/packages/components/src/components/button/button.tsx
+++ b/packages/components/src/components/button/button.tsx
@@ -17,6 +17,7 @@ import {
   Listen,
   Element,
   Method,
+  Watch,
 } from '@stencil/core';
 import classNames from 'classnames';
 import { hasShadowDom, ScaleIcon, isScaleIcon } from '../../utils/utils';
@@ -40,7 +41,7 @@ export class Button {
   /** (optional) Button variant */
   @Prop() variant?: string = 'primary';
   /** (optional) If `true`, the button is disabled */
-  @Prop({ reflect: true }) disabled?: boolean = false;
+  @Prop() disabled?: boolean = false;
   /** (optional) Button type */
   @Prop() type?: 'reset' | 'submit' | 'button';
   /** (optional) The name of the button, submitted as a pair with the button's `value` as part of the form data */
@@ -66,6 +67,11 @@ export class Button {
 
   private focusableElement: HTMLElement;
   private fallbackSubmitInputElement: HTMLInputElement;
+
+  @Watch('disabled')
+  onDisabledChange() {
+    this.syncDisabledAttr();
+  }
 
   /**
    * Prevent clicks from being emitted from the host
@@ -119,6 +125,7 @@ export class Button {
   connectedCallback() {
     this.setIconPositionProp();
     this.appendEnterKeySubmitFallback();
+    this.syncDisabledAttr();
   }
 
   disconnectedCallback() {
@@ -226,7 +233,9 @@ export class Button {
             ref={(el) => (this.focusableElement = el)}
             class={this.getCssClassMap()}
             onClick={this.handleClick}
-            disabled={this.disabled}
+            disabled={
+              this.disabled ? true : undefined
+            } /* Use undefined to properly remove the disabled attribute when false */
             type={this.type}
             part={basePart}
             tabIndex={this.innerTabindex}
@@ -252,5 +261,13 @@ export class Button {
         `button--icon-${this.iconPosition}`,
       this.disabled && `button--disabled`
     );
+  }
+
+  private syncDisabledAttr() {
+    if (this.disabled) {
+      this.hostElement.setAttribute('disabled', '');
+    } else {
+      this.hostElement.removeAttribute('disabled');
+    }
   }
 }


### PR DESCRIPTION
- Removes the `disabled` attribute when the value is `false`
- Fixes incorrect screen reader announcement (button reported as unavailable)
- Improves accessibility behavior

Closes #2390