### PR TITLE
feat(combobox): add required prop and update documentation

### DIFF
--- a/packages/components/src/components/combobox/combobox.e2e.ts
+++ b/packages/components/src/components/combobox/combobox.e2e.ts
@@ -218,4 +218,13 @@ describe('scale-combobox', () => {
     expect(options.length).toBeLessThanOrEqual(1);
     expect(options[0]).toEqualText('stte');
   });
+
+  it('adds required attribute to input when required prop is set', async () => {
+    const page = await newE2EPage();
+    await page.setContent(
+      '<scale-combobox required label="Required field"></scale-combobox>'
+    );
+    const input = await page.find('scale-combobox >>> .combobox-input');
+    expect(input).toHaveAttribute('required');
+  });
 });

--- a/packages/components/src/components/combobox/combobox.tsx
+++ b/packages/components/src/components/combobox/combobox.tsx
@@ -64,6 +64,9 @@ export class Combobox {
   /** Invalid state */
   @Prop() invalid?: boolean = false;
 
+  /** Required state */
+  @Prop() required?: boolean = false;
+
   /** Custom filtering function */
   @Prop() filterFunction?: (option: string, query: string) => boolean;
 
@@ -180,6 +183,7 @@ export class Combobox {
               value={this.inputValue}
               placeholder={this.placeholder}
               disabled={this.disabled}
+              required={this.required}
               onInput={this.handleInputChange}
               onFocus={this.handleInputFocus}
               onBlur={this.handleInputBlur}

--- a/packages/components/src/components/combobox/readme.md
+++ b/packages/components/src/components/combobox/readme.md
@@ -18,10 +18,10 @@
 | `inputAriaLabelledBy` | `input-aria-labelled-by` | ID reference(s) for an external label element                           | `string`                                     | `undefined`                                  |
 | `inputId`             | `input-id`               | (optional) Input element id                                             | `string`                                     | `` `combobox-input-${generateUniqueId()}` `` |
 | `invalid`             | `invalid`                | Invalid state                                                           | `boolean`                                    | `false`                                      |
-| `required`            | `required`               | Whether the combobox is required                                        | `boolean`                                    | `false`                                      |
 | `label`               | `label`                  | Combobox label                                                          | `string`                                     | `''`                                         |
 | `options`             | `options`                | Available options for the combobox                                      | `string[]`                                   | `[]`                                         |
 | `placeholder`         | `placeholder`            | Combobox placeholder                                                    | `string`                                     | `''`                                         |
+| `required`            | `required`               | Required state                                                          | `boolean`                                    | `false`                                      |
 | `styles`              | `styles`                 | (optional) Injected CSS styles                                          | `string`                                     | `undefined`                                  |
 | `value`               | `value`                  | Current selected value                                                  | `string`                                     | `''`                                         |
 

--- a/packages/components/src/components/combobox/readme.md
+++ b/packages/components/src/components/combobox/readme.md
@@ -18,6 +18,7 @@
 | `inputAriaLabelledBy` | `input-aria-labelled-by` | ID reference(s) for an external label element                           | `string`                                     | `undefined`                                  |
 | `inputId`             | `input-id`               | (optional) Input element id                                             | `string`                                     | `` `combobox-input-${generateUniqueId()}` `` |
 | `invalid`             | `invalid`                | Invalid state                                                           | `boolean`                                    | `false`                                      |
+| `required`            | `required`               | Whether the combobox is required                                        | `boolean`                                    | `false`                                      |
 | `label`               | `label`                  | Combobox label                                                          | `string`                                     | `''`                                         |
 | `options`             | `options`                | Available options for the combobox                                      | `string[]`                                   | `[]`                                         |
 | `placeholder`         | `placeholder`            | Combobox placeholder                                                    | `string`                                     | `''`                                         |

--- a/packages/storybook-vue/stories/components/combobox/Combobox.stories.mdx
+++ b/packages/storybook-vue/stories/components/combobox/Combobox.stories.mdx
@@ -39,6 +39,7 @@ export const Template = (args) => {
         value: args.value,
         disabled: args.disabled,
         invalid: args.invalid,
+        required: args.required,
         allowCustom: args.allowCustom,
         options: Array.isArray(args.options) ? args.options : [],
         filterFunction: args.filterFunction || null,
@@ -53,6 +54,7 @@ export const Template = (args) => {
           :value="value"
           :disabled="disabled"
           :invalid="invalid"
+          :required="required"
           :allow-custom="allowCustom"
           :options.prop="options"
           :filter-function.prop="filterFunction"

--- a/packages/storybook-vue/stories/components/combobox/ScaleCombobox.vue
+++ b/packages/storybook-vue/stories/components/combobox/ScaleCombobox.vue
@@ -4,6 +4,7 @@
     :placeholder="placeholder"
     :disabled="disabled"
     :invalid="invalid"
+    :required="required"
     :allow-custom="allowCustom"
     :helper-text="helperText"
     :value="value"
@@ -30,6 +31,10 @@ export default {
       default: false,
     },
     invalid: {
+      type: Boolean,
+      default: false,
+    },
+    required: {
       type: Boolean,
       default: false,
     },

--- a/packages/storybook-vue/stories/components/combobox/combobox.md
+++ b/packages/storybook-vue/stories/components/combobox/combobox.md
@@ -40,6 +40,10 @@ Add helper text below the input to provide additional guidance or context about 
 
 Display an error state when validation fails, with appropriate styling and helper text to guide the user.
 
+### Required State
+
+Add a required attribute to the input to indicate that the field must be filled out before form submission.
+
 ### Disabled Option
 
 A disabled combobox is non-interactive. Use this when an option is not available due to permissions or dependencies.

--- a/packages/storybook-vue/stories/components/combobox/combobox_de.md
+++ b/packages/storybook-vue/stories/components/combobox/combobox_de.md
@@ -40,6 +40,10 @@ Fügen Sie Hilfetext unterhalb der Eingabe hinzu, um zusätzliche Anleitungen od
 
 Zeigen Sie einen Fehlerstatus an, wenn die Validierung fehlschlägt, mit angemessenem Styling und Hilfetext, um den Benutzer zu leiten.
 
+### Erforderlicher Status
+
+Fügen Sie ein erforderliches Attribut zum Eingabefeld hinzu, um anzugeben, dass das Feld vor der Formularübermittlung ausgefüllt werden muss.
+
 ### Deaktivierte Option
 
 Eine deaktivierte Combobox ist nicht interaktiv. Verwenden Sie dies, wenn eine Option aufgrund von Berechtigungen oder Abhängigkeiten nicht verfügbar ist.


### PR DESCRIPTION
Add `required` prop to the combobox component to support the HTML required attribute on the input field. Includes e2e tests, and updated documentation.