### PR TITLE
feat: add hide-label-visually prop for scale-date-picker and scale-textarea

### DIFF
--- a/packages/components/src/components/date-picker/date-picker.css
+++ b/packages/components/src/components/date-picker/date-picker.css
@@ -148,6 +148,10 @@ duet-date-picker .duet-date__toggle:active scale-icon-content-calendar {
   overflow: hidden;
 }
 
+.scale-date-picker--hide-label .date-picker__label {
+  visibility: hidden;
+}
+
 duet-date-picker .duet-date__input::placeholder {
   visibility: hidden;
   color: transparent;

--- a/packages/components/src/components/date-picker/date-picker.css
+++ b/packages/components/src/components/date-picker/date-picker.css
@@ -152,6 +152,10 @@ duet-date-picker .duet-date__toggle:active scale-icon-content-calendar {
   visibility: hidden;
 }
 
+.scale-date-picker--hide-label duet-date-picker .duet-date__input {
+  padding-top: var(--telekom-spacing-composition-space-05);
+}
+
 duet-date-picker .duet-date__input::placeholder {
   visibility: hidden;
   color: transparent;

--- a/packages/components/src/components/date-picker/date-picker.tsx
+++ b/packages/components/src/components/date-picker/date-picker.tsx
@@ -155,6 +155,9 @@ export class DatePicker {
   /** (optional) id or space separated list of ids of elements that provide or link to additional related information. */
   @Prop() ariaDetailsId?: string;
 
+  /** (optional) to avoid displaying the label */
+  @Prop() hideLabelVisually?: boolean = false;
+
   /** Whether the input element has focus */
   @State() hasFocus: boolean = false;
 
@@ -421,7 +424,8 @@ export class DatePicker {
             this.hasFocus && 'scale-date-picker--focus',
             this.disabled && 'scale-date-picker--disabled',
             this.hasValue && 'animated',
-            this.helperText && 'has-helper-text'
+            this.helperText && 'has-helper-text',
+            this.hideLabelVisually && 'scale-date-picker--hide-label'
           )}
         >
           <label class="date-picker__label" htmlFor={this.identifier}>

--- a/packages/components/src/components/textarea/textarea.css
+++ b/packages/components/src/components/textarea/textarea.css
@@ -156,6 +156,10 @@ scale-textarea {
   visibility: hidden;
 }
 
+.textarea--hide-label .textarea__wrapper .textarea__control {
+  padding-top: var(--telekom-spacing-composition-space-02);
+}
+
 .textarea--has-focus .textarea__label,
 .animated .textarea__label {
   font: var(--telekom-text-style-small-bold);

--- a/packages/components/src/components/textarea/textarea.css
+++ b/packages/components/src/components/textarea/textarea.css
@@ -151,6 +151,11 @@ scale-textarea {
   white-space: nowrap;
   overflow: hidden;
 }
+
+.textarea--hide-label .textarea__label {
+  visibility: hidden;
+}
+
 .textarea--has-focus .textarea__label,
 .animated .textarea__label {
   font: var(--telekom-text-style-small-bold);

--- a/packages/components/src/components/textarea/textarea.tsx
+++ b/packages/components/src/components/textarea/textarea.tsx
@@ -80,6 +80,8 @@ export class Textarea {
   @Prop() styles?: string;
   /** (optional) id or space separated list of ids of elements that provide or link to additional related information. */
   @Prop() ariaDetailsId?: string;
+  /** (optional) to avoid displaying the label */
+  @Prop() hideLabelVisually?: boolean = false;
 
   /** (optional) data-qa attribute for e2e testing */
   @Prop() dataQa?: string;
@@ -250,6 +252,7 @@ export class Textarea {
       this.invalid && `textarea--status-error`,
       this.variant && `textarea--variant-${this.variant}`,
       this.readonly && `textarea--readonly`,
+      this.hideLabelVisually && `textarea--hide-label`,
       this.value != null && this.value !== '' && 'animated'
     );
   }


### PR DESCRIPTION
## Description

Added support for the `hide-label-visually` prop to both `scale-date-picker` and `scale-textarea` components. This prop allows labels to be visually hidden while remaining accessible to assistive technologies, ensuring compliance with accessibility best practices.

The implementation follows the existing pattern used in other Scale components like `scale-text-field` and `scale-dropdown-select`, using `visibility: hidden` on the label element to maintain accessibility while hiding the visual representation.

Closes #2441.

## Checklist if Applicable

- [ ] The tests passed 
- [x] Linting passed 
- [ ] Documentation has been added
- [ ] CHANGELOG.md has been updated