### PR TITLE
refactor: simplify custom elements initialization docs by removing polyfills

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,9 @@ To use the components, you need to load a CSS file and some JavaScript. The CSS 
 
 ```javascript
 import '@telekom/scale-components-neutral/dist/scale-components/scale-components.css';
-import {
-  applyPolyfills,
-  defineCustomElements,
-} from '@telekom/scale-components-neutral/loader';
+import { defineCustomElements } from '@telekom/scale-components-neutral/loader';
 
-applyPolyfills().then(() => {
-  defineCustomElements(window);
-});
+defineCustomElements(window);
 ```
 
 ### NPM packages
@@ -120,11 +115,9 @@ npm install @telekom/scale-components@next
 
 ```javascript
 import "@telekom/scale-components/dist/scale-components/scale-components.css";
-import { applyPolyfills, defineCustomElements } from "@telekom/scale-components/loader";
+import { defineCustomElements } from "@telekom/scale-components/loader";
 
-applyPolyfills().then(() => {
-  defineCustomElements(window);
-});
+defineCustomElements(window);
 ```
 
 ### NPM packages

--- a/packages/components-angular/README.md
+++ b/packages/components-angular/README.md
@@ -17,7 +17,7 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
 
-import { applyPolyfills, defineCustomElements } from '@telekom/scale-components/loader';
+import { defineCustomElements } from '@telekom/scale-components/loader';
 
 if (environment.production) {
   enableProdMode();
@@ -26,9 +26,7 @@ if (environment.production) {
 platformBrowserDynamic().bootstrapModule(AppModule)
   .catch(err => console.error(err));
 
-applyPolyfills().then(() => {
-  defineCustomElements(window);
-});
+defineCustomElements(window);
 ```
 
 ## src/app.module.ts

--- a/packages/components-react/README.md
+++ b/packages/components-react/README.md
@@ -12,14 +12,12 @@ Once you have installed both packages and defined the custom elements, `Scale` c
 ```javascript
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { applyPolyfills, defineCustomElements } from '@telekom/scale-components/loader';
+import { defineCustomElements } from '@telekom/scale-components/loader';
 import App from './App';
 import '@telekom/scale-components/dist/scale-components/scale-components.css';
 import './index.css';
 
-applyPolyfills().then(() => {
-  defineCustomElements(window);
-});
+defineCustomElements(window);
 
 ReactDOM.render(<App />, document.getElementById('root'));
 ```

--- a/packages/components-vue/README.md
+++ b/packages/components-vue/README.md
@@ -13,15 +13,13 @@ Once you have installed both packages and defined the custom elements, `Scale` c
 ```javascript
 import Vue from "vue";
 import App from "./App.vue";
-import { applyPolyfills, defineCustomElements } from "@telekom/scale-components/loader";
+import { defineCustomElements } from "@telekom/scale-components/loader";
 import "@telekom/scale-components/dist/scale-components/scale-components.css";
 
 Vue.config.productionTip = false;
 Vue.config.ignoredElements = [/scale-\w*/];
 
-applyPolyfills().then(() => {
-  defineCustomElements(window);
-});
+defineCustomElements(window);
 
 new Vue({
   render: h => h(App)

--- a/packages/design-tokens/README.md
+++ b/packages/design-tokens/README.md
@@ -49,14 +49,9 @@ To use the components, you need to load a CSS file and some JavaScript. The CSS 
 
 ```javascript
 import '@telekom/scale-components-neutral/dist/scale-components/scale-components.css';
-import {
-  applyPolyfills,
-  defineCustomElements,
-} from '@telekom/scale-components-neutral/loader';
+import { defineCustomElements } from '@telekom/scale-components-neutral/loader';
 
-applyPolyfills().then(() => {
-  defineCustomElements(window);
-});
+defineCustomElements(window);
 ```
 
 ### NPM packages
@@ -112,11 +107,9 @@ npm install @telekom/scale-components
 
 ```javascript
 import "@telekom/scale-components/dist/scale-components/scale-components.css";
-import { applyPolyfills, defineCustomElements } from "@telekom/scale-components/loader";
+import { defineCustomElements } from "@telekom/scale-components/loader";
 
-applyPolyfills().then(() => {
-  defineCustomElements(window);
-});
+defineCustomElements(window);
 ```
 
 ### NPM packages

--- a/packages/storybook-vue/stories/setup_and_info/GettingStartedForDevelopers_de.md
+++ b/packages/storybook-vue/stories/setup_and_info/GettingStartedForDevelopers_de.md
@@ -31,14 +31,9 @@ Um die Komponenten zu verwenden, lade die CSS-Datei sowie JavaScript. Die CSS-Da
 
 ```js
 import '@telekom/scale-components/dist/scale-components/scale-components.css';
-import {
-  applyPolyfills,
-  defineCustomElements,
-} from '@telekom/scale-components/loader';
+import { defineCustomElements } from '@telekom/scale-components/loader';
 
-applyPolyfills().then(() => {
-  defineCustomElements(window);
-});
+defineCustomElements(window);
 ```
 
 Falls Sie nur eine spezifische Komponente laden möchten, z.B. die Komponente Button, können Sie diese Komponente auch auf folgende Art laden:

--- a/packages/storybook-vue/stories/setup_and_info/GettingStartedForDevelopers_en.md
+++ b/packages/storybook-vue/stories/setup_and_info/GettingStartedForDevelopers_en.md
@@ -33,14 +33,9 @@ To use the components, you need to load a CSS file and some JavaScript. The CSS 
 
 ```js
 import '@telekom/scale-components/dist/scale-components/scale-components.css';
-import {
-  applyPolyfills,
-  defineCustomElements,
-} from '@telekom/scale-components/loader';
+import { defineCustomElements } from '@telekom/scale-components/loader';
 
-applyPolyfills().then(() => {
-  defineCustomElements(window);
-});
+defineCustomElements(window);
 ```
 
 Alternatively, if you wish to only load the component you need, for example, the button component, you can load the component in the following way:


### PR DESCRIPTION
Removed applyPolyfills from all documentation snippets and updated imports/calls to use defineCustomElements directly in root README and package docs
it addresses #2462 