### PR TITLE
fix(css): correct font format fallback

### DIFF
--- a/packages/components/src/global/fonts.css
+++ b/packages/components/src/global/fonts.css
@@ -14,8 +14,8 @@
   font-weight: 900;
   font-style: normal;
   src: url('./fonts/TeleNeoWeb/TeleNeoWeb-Ultra.eot');
-  src: url('./fonts/TeleNeoWeb/TeleNeoWeb-Ultra.woff') format('woff'),
-    url('./fonts/TeleNeoWeb/TeleNeoWeb-Ultra.woff2') format('woff2');
+  src: url('./fonts/TeleNeoWeb/TeleNeoWeb-Ultra.woff2') format('woff2'),
+    url('./fonts/TeleNeoWeb/TeleNeoWeb-Ultra.woff') format('woff');
   font-display: swap;
 }
 @font-face {
@@ -23,8 +23,8 @@
   font-weight: 900;
   font-style: italic;
   src: url('./fonts/TeleNeoWeb/TeleNeoWeb-UltraItalic.eot');
-  src: url('./fonts/TeleNeoWeb/TeleNeoWeb-UltraItalic.woff') format('woff'),
-    url('./fonts/TeleNeoWeb/TeleNeoWeb-UltraItalic.woff2') format('woff2');
+  src: url('./fonts/TeleNeoWeb/TeleNeoWeb-UltraItalic.woff2') format('woff2'),
+    url('./fonts/TeleNeoWeb/TeleNeoWeb-UltraItalic.woff') format('woff');
   font-display: swap;
 }
 @font-face {
@@ -32,8 +32,8 @@
   font-weight: 800;
   font-style: normal;
   src: url('./fonts/TeleNeoWeb/TeleNeoWeb-ExtraBold.eot');
-  src: url('./fonts/TeleNeoWeb/TeleNeoWeb-ExtraBold.woff') format('woff'),
-    url('./fonts/TeleNeoWeb/TeleNeoWeb-ExtraBold.woff2') format('woff2');
+  src: url('./fonts/TeleNeoWeb/TeleNeoWeb-ExtraBold.woff2') format('woff2'),
+    url('./fonts/TeleNeoWeb/TeleNeoWeb-ExtraBold.woff') format('woff');
   font-display: swap;
 }
 @font-face {
@@ -41,8 +41,8 @@
   font-weight: 800;
   font-style: italic;
   src: url('./fonts/TeleNeoWeb/TeleNeoWeb-ExtraBoldItalic.eot');
-  src: url('./fonts/TeleNeoWeb/TeleNeoWeb-ExtraBoldItalic.woff') format('woff'),
-    url('./fonts/TeleNeoWeb/TeleNeoWeb-ExtraBoldItalic.woff2') format('woff2');
+  src: url('./fonts/TeleNeoWeb/TeleNeoWeb-ExtraBoldItalic.woff2') format('woff2'),
+    url('./fonts/TeleNeoWeb/TeleNeoWeb-ExtraBoldItalic.woff') format('woff');
   font-display: swap;
 }
 @font-face {
@@ -50,8 +50,8 @@
   font-weight: 700;
   font-style: normal;
   src: url('./fonts/TeleNeoWeb/TeleNeoWeb-Bold.eot');
-  src: url('./fonts/TeleNeoWeb/TeleNeoWeb-Bold.woff') format('woff'),
-    url('./fonts/TeleNeoWeb/TeleNeoWeb-Bold.woff2') format('woff2');
+  src: url('./fonts/TeleNeoWeb/TeleNeoWeb-Bold.woff2') format('woff2'),
+    url('./fonts/TeleNeoWeb/TeleNeoWeb-Bold.woff') format('woff');
   font-display: swap;
 }
 @font-face {
@@ -59,8 +59,8 @@
   font-weight: 700;
   font-style: italic;
   src: url('./fonts/TeleNeoWeb/TeleNeoWeb-BoldItalic.eot');
-  src: url('./fonts/TeleNeoWeb/TeleNeoWeb-BoldItalic.woff') format('woff'),
-    url('./fonts/TeleNeoWeb/TeleNeoWeb-BoldItalic.woff2') format('woff2');
+  src: url('./fonts/TeleNeoWeb/TeleNeoWeb-BoldItalic.woff2') format('woff2'),
+    url('./fonts/TeleNeoWeb/TeleNeoWeb-BoldItalic.woff') format('woff');
   font-display: swap;
 }
 @font-face {
@@ -68,8 +68,8 @@
   font-weight: 500;
   font-style: normal;
   src: url('./fonts/TeleNeoWeb/TeleNeoWeb-Medium.eot');
-  src: url('./fonts/TeleNeoWeb/TeleNeoWeb-Medium.woff') format('woff'),
-    url('./fonts/TeleNeoWeb/TeleNeoWeb-Medium.woff2') format('woff2');
+  src: url('./fonts/TeleNeoWeb/TeleNeoWeb-Medium.woff2') format('woff2'),
+    url('./fonts/TeleNeoWeb/TeleNeoWeb-Medium.woff') format('woff');
   font-display: swap;
 }
 @font-face {
@@ -77,8 +77,8 @@
   font-weight: 500;
   font-style: italic;
   src: url('./fonts/TeleNeoWeb/TeleNeoWeb-MediumItalic.eot');
-  src: url('./fonts/TeleNeoWeb/TeleNeoWeb-MediumItalic.woff') format('woff'),
-    url('./fonts/TeleNeoWeb/TeleNeoWeb-MediumItalic.woff2') format('woff2');
+  src: url('./fonts/TeleNeoWeb/TeleNeoWeb-MediumItalic.woff2') format('woff2'),
+    url('./fonts/TeleNeoWeb/TeleNeoWeb-MediumItalic.woff') format('woff');
   font-display: swap;
 }
 @font-face {
@@ -86,8 +86,8 @@
   font-weight: 400;
   font-style: normal;
   src: url('./fonts/TeleNeoWeb/TeleNeoWeb-Regular.eot');
-  src: url('./fonts/TeleNeoWeb/TeleNeoWeb-Regular.woff') format('woff'),
-    url('./fonts/TeleNeoWeb/TeleNeoWeb-Regular.woff2') format('woff2');
+  src: url('./fonts/TeleNeoWeb/TeleNeoWeb-Regular.woff2') format('woff2'),
+    url('./fonts/TeleNeoWeb/TeleNeoWeb-Regular.woff') format('woff');
   font-display: swap;
 }
 @font-face {
@@ -95,8 +95,8 @@
   font-weight: 400;
   font-style: italic;
   src: url('./fonts/TeleNeoWeb/TeleNeoWeb-RegularItalic.eot');
-  src: url('./fonts/TeleNeoWeb/TeleNeoWeb-RegularItalic.woff') format('woff'),
-    url('./fonts/TeleNeoWeb/TeleNeoWeb-RegularItalic.woff2') format('woff2');
+  src: url('./fonts/TeleNeoWeb/TeleNeoWeb-RegularItalic.woff2') format('woff2'),
+    url('./fonts/TeleNeoWeb/TeleNeoWeb-RegularItalic.woff') format('woff');
   font-display: swap;
 }
 @font-face {
@@ -104,8 +104,8 @@
   font-weight: 200;
   font-style: normal;
   src: url('./fonts/TeleNeoWeb/TeleNeoWeb-Thin.eot');
-  src: url('./fonts/TeleNeoWeb/TeleNeoWeb-Thin.woff') format('woff'),
-    url('./fonts/TeleNeoWeb/TeleNeoWeb-Thin.woff2') format('woff2');
+  src: url('./fonts/TeleNeoWeb/TeleNeoWeb-Thin.woff2') format('woff2'),
+    url('./fonts/TeleNeoWeb/TeleNeoWeb-Thin.woff') format('woff');
   font-display: swap;
 }
 @font-face {
@@ -113,8 +113,8 @@
   font-weight: 200;
   font-style: italic;
   src: url('./fonts/TeleNeoWeb/TeleNeoWeb-ThinItalic.eot');
-  src: url('./fonts/TeleNeoWeb/TeleNeoWeb-ThinItalic.woff') format('woff'),
-    url('./fonts/TeleNeoWeb/TeleNeoWeb-ThinItalic.woff2') format('woff2');
+  src: url('./fonts/TeleNeoWeb/TeleNeoWeb-ThinItalic.woff2') format('woff2'),
+    url('./fonts/TeleNeoWeb/TeleNeoWeb-ThinItalic.woff') format('woff');
   font-display: swap;
 }
 

--- a/packages/components/src/global/fonts.css
+++ b/packages/components/src/global/fonts.css
@@ -41,7 +41,8 @@
   font-weight: 800;
   font-style: italic;
   src: url('./fonts/TeleNeoWeb/TeleNeoWeb-ExtraBoldItalic.eot');
-  src: url('./fonts/TeleNeoWeb/TeleNeoWeb-ExtraBoldItalic.woff2') format('woff2'),
+  src: url('./fonts/TeleNeoWeb/TeleNeoWeb-ExtraBoldItalic.woff2')
+      format('woff2'),
     url('./fonts/TeleNeoWeb/TeleNeoWeb-ExtraBoldItalic.woff') format('woff');
   font-display: swap;
 }

--- a/packages/components/src/telekom/fonts/scale-fonts-telekom.css
+++ b/packages/components/src/telekom/fonts/scale-fonts-telekom.css
@@ -14,8 +14,8 @@
   font-weight: 900;
   font-style: normal;
   src: url('./TeleNeoWeb/TeleNeoWeb-Ultra.eot');
-  src: url('./TeleNeoWeb/TeleNeoWeb-Ultra.woff') format('woff'),
-    url('./TeleNeoWeb/TeleNeoWeb-Ultra.woff2') format('woff2');
+  src: url('./TeleNeoWeb/TeleNeoWeb-Ultra.woff2') format('woff2'),
+    url('./TeleNeoWeb/TeleNeoWeb-Ultra.woff') format('woff');
   font-display: swap;
 }
 @font-face {
@@ -23,8 +23,8 @@
   font-weight: 900;
   font-style: italic;
   src: url('./TeleNeoWeb/TeleNeoWeb-UltraItalic.eot');
-  src: url('./TeleNeoWeb/TeleNeoWeb-UltraItalic.woff') format('woff'),
-    url('./TeleNeoWeb/TeleNeoWeb-UltraItalic.woff2') format('woff2');
+  src: url('./TeleNeoWeb/TeleNeoWeb-UltraItalic.woff2') format('woff2'),
+    url('./TeleNeoWeb/TeleNeoWeb-UltraItalic.woff') format('woff');
   font-display: swap;
 }
 @font-face {
@@ -32,8 +32,8 @@
   font-weight: 800;
   font-style: normal;
   src: url('./TeleNeoWeb/TeleNeoWeb-ExtraBold.eot');
-  src: url('./TeleNeoWeb/TeleNeoWeb-ExtraBold.woff') format('woff'),
-    url('./TeleNeoWeb/TeleNeoWeb-ExtraBold.woff2') format('woff2');
+  src: url('./TeleNeoWeb/TeleNeoWeb-ExtraBold.woff2') format('woff2'),
+    url('./TeleNeoWeb/TeleNeoWeb-ExtraBold.woff') format('woff');
   font-display: swap;
 }
 @font-face {
@@ -41,8 +41,8 @@
   font-weight: 800;
   font-style: italic;
   src: url('./TeleNeoWeb/TeleNeoWeb-ExtraBoldItalic.eot');
-  src: url('./TeleNeoWeb/TeleNeoWeb-ExtraBoldItalic.woff') format('woff'),
-    url('./TeleNeoWeb/TeleNeoWeb-ExtraBoldItalic.woff2') format('woff2');
+  src: url('./TeleNeoWeb/TeleNeoWeb-ExtraBoldItalic.woff2') format('woff2'),
+    url('./TeleNeoWeb/TeleNeoWeb-ExtraBoldItalic.woff') format('woff');
   font-display: swap;
 }
 @font-face {
@@ -50,8 +50,8 @@
   font-weight: 700;
   font-style: normal;
   src: url('./TeleNeoWeb/TeleNeoWeb-Bold.eot');
-  src: url('./TeleNeoWeb/TeleNeoWeb-Bold.woff') format('woff'),
-    url('./TeleNeoWeb/TeleNeoWeb-Bold.woff2') format('woff2');
+  src: url('./TeleNeoWeb/TeleNeoWeb-Bold.woff2') format('woff2'),
+    url('./TeleNeoWeb/TeleNeoWeb-Bold.woff') format('woff');
   font-display: swap;
 }
 @font-face {
@@ -59,8 +59,8 @@
   font-weight: 700;
   font-style: italic;
   src: url('./TeleNeoWeb/TeleNeoWeb-BoldItalic.eot');
-  src: url('./TeleNeoWeb/TeleNeoWeb-BoldItalic.woff') format('woff'),
-    url('./TeleNeoWeb/TeleNeoWeb-BoldItalic.woff2') format('woff2');
+  src: url('./TeleNeoWeb/TeleNeoWeb-BoldItalic.woff2') format('woff2'),
+    url('./TeleNeoWeb/TeleNeoWeb-BoldItalic.woff') format('woff');
   font-display: swap;
 }
 @font-face {
@@ -68,8 +68,8 @@
   font-weight: 500;
   font-style: normal;
   src: url('./TeleNeoWeb/TeleNeoWeb-Medium.eot');
-  src: url('./TeleNeoWeb/TeleNeoWeb-Medium.woff') format('woff'),
-    url('./TeleNeoWeb/TeleNeoWeb-Medium.woff2') format('woff2');
+  src: url('./TeleNeoWeb/TeleNeoWeb-Medium.woff2') format('woff2'),
+    url('./TeleNeoWeb/TeleNeoWeb-Medium.woff') format('woff');
   font-display: swap;
 }
 @font-face {
@@ -77,8 +77,8 @@
   font-weight: 500;
   font-style: italic;
   src: url('./TeleNeoWeb/TeleNeoWeb-MediumItalic.eot');
-  src: url('./TeleNeoWeb/TeleNeoWeb-MediumItalic.woff') format('woff'),
-    url('./TeleNeoWeb/TeleNeoWeb-MediumItalic.woff2') format('woff2');
+  src: url('./TeleNeoWeb/TeleNeoWeb-MediumItalic.woff2') format('woff2'),
+    url('./TeleNeoWeb/TeleNeoWeb-MediumItalic.woff') format('woff');
   font-display: swap;
 }
 @font-face {
@@ -86,8 +86,8 @@
   font-weight: 400;
   font-style: normal;
   src: url('./TeleNeoWeb/TeleNeoWeb-Regular.eot');
-  src: url('./TeleNeoWeb/TeleNeoWeb-Regular.woff') format('woff'),
-    url('./TeleNeoWeb/TeleNeoWeb-Regular.woff2') format('woff2');
+  src: url('./TeleNeoWeb/TeleNeoWeb-Regular.woff2') format('woff2'),
+    url('./TeleNeoWeb/TeleNeoWeb-Regular.woff') format('woff');
   font-display: swap;
 }
 @font-face {
@@ -95,8 +95,8 @@
   font-weight: 400;
   font-style: italic;
   src: url('./TeleNeoWeb/TeleNeoWeb-RegularItalic.eot');
-  src: url('./TeleNeoWeb/TeleNeoWeb-RegularItalic.woff') format('woff'),
-    url('./TeleNeoWeb/TeleNeoWeb-RegularItalic.woff2') format('woff2');
+  src: url('./TeleNeoWeb/TeleNeoWeb-RegularItalic.woff2') format('woff2'),
+    url('./TeleNeoWeb/TeleNeoWeb-RegularItalic.woff') format('woff');
   font-display: swap;
 }
 @font-face {
@@ -104,8 +104,8 @@
   font-weight: 200;
   font-style: normal;
   src: url('./TeleNeoWeb/TeleNeoWeb-Thin.eot');
-  src: url('./TeleNeoWeb/TeleNeoWeb-Thin.woff') format('woff'),
-    url('./TeleNeoWeb/TeleNeoWeb-Thin.woff2') format('woff2');
+  src: url('./TeleNeoWeb/TeleNeoWeb-Thin.woff2') format('woff2'),
+    url('./TeleNeoWeb/TeleNeoWeb-Thin.woff') format('woff');
   font-display: swap;
 }
 @font-face {
@@ -113,8 +113,8 @@
   font-weight: 200;
   font-style: italic;
   src: url('./TeleNeoWeb/TeleNeoWeb-ThinItalic.eot');
-  src: url('./TeleNeoWeb/TeleNeoWeb-ThinItalic.woff') format('woff'),
-    url('./TeleNeoWeb/TeleNeoWeb-ThinItalic.woff2') format('woff2');
+  src: url('./TeleNeoWeb/TeleNeoWeb-ThinItalic.woff2') format('woff2'),
+    url('./TeleNeoWeb/TeleNeoWeb-ThinItalic.woff') format('woff');
   font-display: swap;
 }
 


### PR DESCRIPTION
Due to bug in font order newest font format `woff2` was used as fallback for `woff`. This PR changes the fallback order making `woff` fallback for `woff2`.

`woff2` has a better compression and should be preferred generally. It's also [widely adopted](https://caniuse.com/?search=woff2).


Taking advantage of the opportunity I'd like to ask why `eot` (or even `woff` to certain extent) is needed? IE 11 is retired by MS, marked as dead in [by Browserlist](https://github.com/browserslist/browserslist?tab=readme-ov-file#full-list). It has less than 1% of usage. Is it really worth to have this font format in the repository?