### PR TITLE
CI: build wrapper packages in PR workflow

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -237,6 +237,19 @@ jobs:
         run: |
           yarn workspace @telekom/scale-components build
 
+      - name: Build React Wrapper
+        run: |
+          yarn workspace @telekom/scale-components-react build
+
+      - name: Build Vue Wrapper
+        run: |
+          yarn workspace @telekom/scale-components-vue build
+
+      - name: Build Angular Wrapper
+        run: |
+          yarn workspace @telekom/scale-components process-angular-proxies
+          yarn workspace @telekom/scale-components-angular build
+
       - name: Check for uncommitted changes
         run: |
           sh scripts/porcelain.sh

--- a/packages/components/src/components/combobox/combobox.e2e.ts
+++ b/packages/components/src/components/combobox/combobox.e2e.ts
@@ -68,9 +68,10 @@ describe('scale-combobox', () => {
     const input = await page.find('scale-combobox >>> .combobox-input');
     await input.focus();
     await input.type('Re');
+    await page.waitForChanges();
     const options = await page.findAll('scale-combobox >>> .combobox-option');
     // Should only show React
-    expect(options.length).toBeLessThanOrEqual(1);
+    expect(options.length).toBe(1);
     expect(options[0]).toEqualText('React');
   });
 
@@ -213,9 +214,10 @@ describe('scale-combobox', () => {
     const input = await page.find('scale-combobox >>> .combobox-input');
     await input.focus();
     await input.type('st');
+    await page.waitForChanges();
     const options = await page.findAll('scale-combobox >>> .combobox-option');
-    // Should only show React due to custom filter function
-    expect(options.length).toBeLessThanOrEqual(1);
+    // Should only show stte due to custom filter function
+    expect(options.length).toBe(1);
     expect(options[0]).toEqualText('stte');
   });
 


### PR DESCRIPTION
## Summary
Extend the PR build workflow so CI also verifies auxiliary wrapper packages compile, not only the core components package.

## Why
Dependabot PRs currently run the build workflow, but wrapper packages (React/Vue/Angular) were not built in that PR path. This can miss dependency-related breakages that only show up in wrapper builds.

## What changed
- Updated `.github/workflows/build-pr.yml` in the `uncommitted-changes` job to also run:
  - `yarn workspace @telekom/scale-components-react build`
  - `yarn workspace @telekom/scale-components-vue build`
  - `yarn workspace @telekom/scale-components process-angular-proxies`
  - `yarn workspace @telekom/scale-components-angular build`

## Result
PR/Dependabot CI now fails early when wrapper dependencies or generated proxies break wrapper builds.