### PR TITLE
fix(data-grid/text-cell): pass accessibilityTitle to prefix and suffix icons

### DIFF
--- a/packages/components/src/components/data-grid/cell-handlers/text-cell.tsx
+++ b/packages/components/src/components/data-grid/cell-handlers/text-cell.tsx
@@ -19,6 +19,8 @@ import { Cell } from './cell-interface';
 // editable?: boolean = false
 // iconPrefix?: string eg 'action-download'
 // iconSuffix?: string eg 'action-download'
+// iconPrefixAccessibilityTitle?: string eg 'Download'
+// iconSuffixAccessibilityTitle?: string eg 'Download'
 
 export const TextCell: Cell = {
   defaults: {
@@ -37,6 +39,8 @@ export const TextCell: Cell = {
       editable = false,
       iconPrefix,
       iconSuffix,
+      iconPrefixAccessibilityTitle,
+      iconSuffixAccessibilityTitle,
       label,
       textFieldProps = {},
     } = field;
@@ -80,13 +84,17 @@ export const TextCell: Cell = {
         <div class={`tbody__text-cell`}>
           {iconPrefix && (
             <span class={`tbody__text-cell-prefix`}>
-              {h(`scale-icon-${iconPrefix}`)}
+              {h(`scale-icon-${iconPrefix}`, {
+                'accessibility-title': iconPrefixAccessibilityTitle ?? label,
+              })}
             </span>
           )}
           <p class={`scl-${variant}`}>{value}</p>
           {iconSuffix && (
             <span class={`tbody__text-cell-suffix`}>
-              {h(`scale-icon-${iconSuffix}`)}
+              {h(`scale-icon-${iconSuffix}`, {
+                'accessibility-title': iconSuffixAccessibilityTitle ?? label,
+              })}
             </span>
           )}
         </div>

--- a/packages/components/src/components/data-grid/cell-handlers/text-cell.tsx
+++ b/packages/components/src/components/data-grid/cell-handlers/text-cell.tsx
@@ -85,7 +85,7 @@ export const TextCell: Cell = {
           {iconPrefix && (
             <span class={`tbody__text-cell-prefix`}>
               {h(`scale-icon-${iconPrefix}`, {
-                'accessibility-title': iconPrefixAccessibilityTitle ?? label,
+                'accessibility-title': iconPrefixAccessibilityTitle || label,
               })}
             </span>
           )}
@@ -93,7 +93,7 @@ export const TextCell: Cell = {
           {iconSuffix && (
             <span class={`tbody__text-cell-suffix`}>
               {h(`scale-icon-${iconSuffix}`, {
-                'accessibility-title': iconSuffixAccessibilityTitle ?? label,
+                'accessibility-title': iconSuffixAccessibilityTitle || label,
               })}
             </span>
           )}

--- a/packages/components/src/components/data-grid/data-grid.spec.ts
+++ b/packages/components/src/components/data-grid/data-grid.spec.ts
@@ -1,0 +1,55 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { DataGrid } from './data-grid';
+import { ActionDownload } from '../icons/action-download/action-download';
+
+describe('DataGrid', () => {
+  beforeEach(() => {
+    (global as any).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  });
+
+  it('should forward accessibility titles to prefix and suffix text cell icons', async () => {
+    const page = await newSpecPage({
+      components: [DataGrid, ActionDownload],
+      html: `<scale-data-grid hide-menu hide-info fields='[{"type":"text","label":"Attachment","iconPrefix":"action-download","iconPrefixAccessibilityTitle":"Download attachment","iconSuffix":"action-download","iconSuffixAccessibilityTitle":"Attachment ready"}]' rows='[["Invoice.pdf"]]'></scale-data-grid>`,
+    });
+
+    const icons = page.root.shadowRoot.querySelectorAll(
+      'scale-icon-action-download'
+    ) as NodeListOf<HTMLElement>;
+
+    expect(icons).toHaveLength(2);
+    expect(icons[0].getAttribute('accessibility-title')).toBe(
+      'Download attachment'
+    );
+    expect(icons[0].querySelector('title').textContent).toBe(
+      'Download attachment'
+    );
+    expect(icons[1].getAttribute('accessibility-title')).toBe(
+      'Attachment ready'
+    );
+    expect(icons[1].querySelector('title').textContent).toBe(
+      'Attachment ready'
+    );
+  });
+
+  it('should preserve label fallback when text cell icon accessibility titles are not provided', async () => {
+    const page = await newSpecPage({
+      components: [DataGrid, ActionDownload],
+      html: `<scale-data-grid hide-menu hide-info fields='[{"type":"text","label":"Status","iconPrefix":"action-download","iconSuffix":"action-download"}]' rows='[["Complete"]]'></scale-data-grid>`,
+    });
+
+    const icons = page.root.shadowRoot.querySelectorAll(
+      'scale-icon-action-download'
+    ) as NodeListOf<HTMLElement>;
+
+    expect(icons).toHaveLength(2);
+    expect(icons[0].getAttribute('accessibility-title')).toBe('Status');
+    expect(icons[0].querySelector('title').textContent).toBe('Status');
+    expect(icons[1].getAttribute('accessibility-title')).toBe('Status');
+    expect(icons[1].querySelector('title').textContent).toBe('Status');
+  });
+});

--- a/packages/components/src/components/data-grid/data-grid.spec.ts
+++ b/packages/components/src/components/data-grid/data-grid.spec.ts
@@ -1,22 +1,6 @@
-import { Component, h, Prop } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
 import { DataGrid } from './data-grid';
-
-@Component({
-  tag: 'scale-icon-action-download',
-  shadow: false,
-})
-class ActionDownloadStub {
-  @Prop({ attribute: 'accessibility-title' }) accessibilityTitle: string;
-
-  render() {
-    return (
-      <svg>
-        <title>{this.accessibilityTitle}</title>
-      </svg>
-    );
-  }
-}
+import { ActionDownload } from '../icons/action-download/action-download';
 
 describe('DataGrid', () => {
   beforeEach(() => {
@@ -29,7 +13,7 @@ describe('DataGrid', () => {
 
   it('should forward accessibility titles to prefix and suffix text cell icons', async () => {
     const page = await newSpecPage({
-      components: [DataGrid, ActionDownloadStub],
+      components: [DataGrid, ActionDownload],
       html: `<scale-data-grid hide-menu hide-info fields='[{"type":"text","label":"Attachment","iconPrefix":"action-download","iconPrefixAccessibilityTitle":"Download attachment","iconSuffix":"action-download","iconSuffixAccessibilityTitle":"Attachment ready"}]' rows='[["Invoice.pdf"]]'></scale-data-grid>`,
     });
 
@@ -54,7 +38,7 @@ describe('DataGrid', () => {
 
   it('should preserve label fallback when text cell icon accessibility titles are not provided', async () => {
     const page = await newSpecPage({
-      components: [DataGrid, ActionDownloadStub],
+      components: [DataGrid, ActionDownload],
       html: `<scale-data-grid hide-menu hide-info fields='[{"type":"text","label":"Status","iconPrefix":"action-download","iconSuffix":"action-download"}]' rows='[["Complete"]]'></scale-data-grid>`,
     });
 

--- a/packages/components/src/components/data-grid/data-grid.spec.ts
+++ b/packages/components/src/components/data-grid/data-grid.spec.ts
@@ -1,6 +1,22 @@
+import { Component, h, Prop } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
 import { DataGrid } from './data-grid';
-import { ActionDownload } from '../icons/action-download/action-download';
+
+@Component({
+  tag: 'scale-icon-action-download',
+  shadow: false,
+})
+class ActionDownloadStub {
+  @Prop({ attribute: 'accessibility-title' }) accessibilityTitle: string;
+
+  render() {
+    return (
+      <svg>
+        <title>{this.accessibilityTitle}</title>
+      </svg>
+    );
+  }
+}
 
 describe('DataGrid', () => {
   beforeEach(() => {
@@ -13,7 +29,7 @@ describe('DataGrid', () => {
 
   it('should forward accessibility titles to prefix and suffix text cell icons', async () => {
     const page = await newSpecPage({
-      components: [DataGrid, ActionDownload],
+      components: [DataGrid, ActionDownloadStub],
       html: `<scale-data-grid hide-menu hide-info fields='[{"type":"text","label":"Attachment","iconPrefix":"action-download","iconPrefixAccessibilityTitle":"Download attachment","iconSuffix":"action-download","iconSuffixAccessibilityTitle":"Attachment ready"}]' rows='[["Invoice.pdf"]]'></scale-data-grid>`,
     });
 
@@ -38,7 +54,7 @@ describe('DataGrid', () => {
 
   it('should preserve label fallback when text cell icon accessibility titles are not provided', async () => {
     const page = await newSpecPage({
-      components: [DataGrid, ActionDownload],
+      components: [DataGrid, ActionDownloadStub],
       html: `<scale-data-grid hide-menu hide-info fields='[{"type":"text","label":"Status","iconPrefix":"action-download","iconSuffix":"action-download"}]' rows='[["Complete"]]'></scale-data-grid>`,
     });
 

--- a/packages/components/src/components/data-grid/data-grid.spec.ts
+++ b/packages/components/src/components/data-grid/data-grid.spec.ts
@@ -1,6 +1,5 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { DataGrid } from './data-grid';
-import { ActionDownload } from '../icons/action-download/action-download';
 
 describe('DataGrid', () => {
   beforeEach(() => {
@@ -13,7 +12,7 @@ describe('DataGrid', () => {
 
   it('should forward accessibility titles to prefix and suffix text cell icons', async () => {
     const page = await newSpecPage({
-      components: [DataGrid, ActionDownload],
+      components: [DataGrid],
       html: `<scale-data-grid hide-menu hide-info fields='[{"type":"text","label":"Attachment","iconPrefix":"action-download","iconPrefixAccessibilityTitle":"Download attachment","iconSuffix":"action-download","iconSuffixAccessibilityTitle":"Attachment ready"}]' rows='[["Invoice.pdf"]]'></scale-data-grid>`,
     });
 
@@ -25,20 +24,14 @@ describe('DataGrid', () => {
     expect(icons[0].getAttribute('accessibility-title')).toBe(
       'Download attachment'
     );
-    expect(icons[0].querySelector('title').textContent).toBe(
-      'Download attachment'
-    );
     expect(icons[1].getAttribute('accessibility-title')).toBe(
-      'Attachment ready'
-    );
-    expect(icons[1].querySelector('title').textContent).toBe(
       'Attachment ready'
     );
   });
 
   it('should preserve label fallback when text cell icon accessibility titles are not provided', async () => {
     const page = await newSpecPage({
-      components: [DataGrid, ActionDownload],
+      components: [DataGrid],
       html: `<scale-data-grid hide-menu hide-info fields='[{"type":"text","label":"Status","iconPrefix":"action-download","iconSuffix":"action-download"}]' rows='[["Complete"]]'></scale-data-grid>`,
     });
 
@@ -48,8 +41,21 @@ describe('DataGrid', () => {
 
     expect(icons).toHaveLength(2);
     expect(icons[0].getAttribute('accessibility-title')).toBe('Status');
-    expect(icons[0].querySelector('title').textContent).toBe('Status');
     expect(icons[1].getAttribute('accessibility-title')).toBe('Status');
-    expect(icons[1].querySelector('title').textContent).toBe('Status');
+  });
+
+  it('should fall back to label when accessibility titles are empty strings', async () => {
+    const page = await newSpecPage({
+      components: [DataGrid],
+      html: `<scale-data-grid hide-menu hide-info fields='[{"type":"text","label":"Status","iconPrefix":"action-download","iconPrefixAccessibilityTitle":"","iconSuffix":"action-download","iconSuffixAccessibilityTitle":""}]' rows='[["Complete"]]'></scale-data-grid>`,
+    });
+
+    const icons = page.root.shadowRoot.querySelectorAll(
+      'scale-icon-action-download'
+    ) as NodeListOf<HTMLElement>;
+
+    expect(icons).toHaveLength(2);
+    expect(icons[0].getAttribute('accessibility-title')).toBe('Status');
+    expect(icons[1].getAttribute('accessibility-title')).toBe('Status');
   });
 });

--- a/packages/storybook-vue/stories/components/data-grid/DataGrid.stories.mdx
+++ b/packages/storybook-vue/stories/components/data-grid/DataGrid.stories.mdx
@@ -762,6 +762,8 @@ Expected format: unformatted `string`, eg `'this is a string'`
 - `variant?: 'body' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' = 'body'`
 - `iconPrefix?: scale-icon-string (eg 'action-download')`
 - `iconSuffix?: scale-icon-string (eg 'action-download')`
+- `iconPrefixAccessibilityTitle?: string (eg 'Download')`
+- `iconSuffixAccessibilityTitle?: string (eg 'Download')`
 - `editable?: boolean = false`
 - `textFieldProps?: Object (eg { type: 'number', helperText: 'Enter a number' })`
 


### PR DESCRIPTION
Fixes #2194
The accessibilityTitle  is now forwarded to prefix and suffix icons rendered in data grid text cells. This improves accessibility for screen reader users. Regression tests were added to cover the updated behavior.