### PR TITLE
fix(tag): keyboard/a11y for tag arrow navigation (#2419)

### DIFF
--- a/packages/components/src/components/tag/__snapshots__/tag.spec.ts.snap
+++ b/packages/components/src/components/tag/__snapshots__/tag.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tag should have a link 1`] = `
-<scale-tag href="#">
+<scale-tag aria-selected="false" href="#" role="option" tabindex="0">
   <template shadowrootmode="open">
     <a class="tag tag--color-standard tag--link tag--type-standard" href="#" part="base type-standard color-standard link" target="_self">
       <slot></slot>
@@ -12,7 +12,7 @@ exports[`Tag should have a link 1`] = `
 `;
 
 exports[`Tag should match snapshot 1`] = `
-<scale-tag>
+<scale-tag aria-selected="false" role="option" tabindex="0">
   <template shadowrootmode="open">
     <span class="tag tag--color-standard tag--type-standard" part="base type-standard color-standard">
       <slot></slot>

--- a/packages/components/src/components/tag/__snapshots__/tag.spec.ts.snap
+++ b/packages/components/src/components/tag/__snapshots__/tag.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tag should have a link 1`] = `
-<scale-tag aria-selected="false" href="#" role="option" tabindex="0">
+<scale-tag href="#">
   <template shadowrootmode="open">
     <a class="tag tag--color-standard tag--link tag--type-standard" href="#" part="base type-standard color-standard link" target="_self">
       <slot></slot>
@@ -12,7 +12,7 @@ exports[`Tag should have a link 1`] = `
 `;
 
 exports[`Tag should match snapshot 1`] = `
-<scale-tag aria-selected="false" role="option" tabindex="0">
+<scale-tag aria-label="Label">
   <template shadowrootmode="open">
     <span class="tag tag--color-standard tag--type-standard" part="base type-standard color-standard">
       <slot></slot>

--- a/packages/components/src/components/tag/tag.e2e.ts
+++ b/packages/components/src/components/tag/tag.e2e.ts
@@ -18,4 +18,203 @@ describe('scale-tag', () => {
     const element = await page.find('scale-tag');
     expect(element).toHaveClass('hydrated');
   });
+
+  describe('Keyboard Navigation', () => {
+    it('should have role and aria attributes for accessibility', async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+        <div>
+          <scale-tag>Tag 1</scale-tag>
+          <scale-tag>Tag 2</scale-tag>
+          <scale-tag>Tag 3</scale-tag>
+        </div>
+      `);
+
+      const firstTag = await page.find('scale-tag');
+      const role = await firstTag.getAttribute('role');
+      const ariaSelected = await firstTag.getAttribute('aria-selected');
+
+      expect(role).toBe('option');
+      expect(ariaSelected).toBe('false');
+    });
+
+    it('should have tabindex set for roving tabindex pattern', async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+        <div>
+          <scale-tag>Tag 1</scale-tag>
+          <scale-tag>Tag 2</scale-tag>
+          <scale-tag>Tag 3</scale-tag>
+        </div>
+      `);
+
+      const tags = await page.findAll('scale-tag');
+      expect(tags.length).toBe(3);
+
+      // First tag should be focusable
+      const firstTabindex = await tags[0].getAttribute('tabindex');
+      expect(firstTabindex).toBe('0');
+
+      // Other tags should not be focusable
+      const secondTabindex = await tags[1].getAttribute('tabindex');
+      const thirdTabindex = await tags[2].getAttribute('tabindex');
+      expect(secondTabindex).toBe('-1');
+      expect(thirdTabindex).toBe('-1');
+    });
+
+    it('should navigate to next tag on ArrowRight key', async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+        <div>
+          <scale-tag id="tag1">Tag 1</scale-tag>
+          <scale-tag id="tag2">Tag 2</scale-tag>
+          <scale-tag id="tag3">Tag 3</scale-tag>
+        </div>
+      `);
+
+      const firstTag = await page.find('#tag1');
+      const secondTag = await page.find('#tag2');
+
+      // Focus on first tag and press ArrowRight
+      await firstTag.focus();
+      await page.keyboard.press('ArrowRight');
+      await page.waitForChanges();
+
+      // Check tabindex values after navigation
+      const firstTabindex = await firstTag.getAttribute('tabindex');
+      const secondTabindex = await secondTag.getAttribute('tabindex');
+
+      expect(firstTabindex).toBe('-1');
+      expect(secondTabindex).toBe('0');
+    });
+
+    it('should navigate to previous tag on ArrowLeft key', async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+        <div>
+          <scale-tag id="tag1">Tag 1</scale-tag>
+          <scale-tag id="tag2">Tag 2</scale-tag>
+          <scale-tag id="tag3">Tag 3</scale-tag>
+        </div>
+      `);
+
+      const firstTag = await page.find('#tag1');
+      const secondTag = await page.find('#tag2');
+      const thirdTag = await page.find('#tag3');
+
+      // Focus on second tag and press ArrowLeft
+      await secondTag.focus();
+      await page.keyboard.press('ArrowLeft');
+      await page.waitForChanges();
+
+      // Check tabindex values - should go back to first tag
+      const firstTabindex = await firstTag.getAttribute('tabindex');
+      const secondTabindex = await secondTag.getAttribute('tabindex');
+
+      expect(firstTabindex).toBe('0');
+      expect(secondTabindex).toBe('-1');
+    });
+
+    it('should navigate to next tag on ArrowDown key', async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+        <div>
+          <scale-tag id="tag1">Tag 1</scale-tag>
+          <scale-tag id="tag2">Tag 2</scale-tag>
+        </div>
+      `);
+
+      const firstTag = await page.find('#tag1');
+      const secondTag = await page.find('#tag2');
+
+      // Focus on first tag and press ArrowDown
+      await firstTag.focus();
+      await page.keyboard.press('ArrowDown');
+      await page.waitForChanges();
+
+      // Check tabindex values
+      const firstTabindex = await firstTag.getAttribute('tabindex');
+      const secondTabindex = await secondTag.getAttribute('tabindex');
+
+      expect(firstTabindex).toBe('-1');
+      expect(secondTabindex).toBe('0');
+    });
+
+    it('should navigate to previous tag on ArrowUp key', async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+        <div>
+          <scale-tag id="tag1">Tag 1</scale-tag>
+          <scale-tag id="tag2">Tag 2</scale-tag>
+        </div>
+      `);
+
+      const firstTag = await page.find('#tag1');
+      const secondTag = await page.find('#tag2');
+
+      // Focus on second tag and press ArrowUp
+      await secondTag.focus();
+      await page.keyboard.press('ArrowUp');
+      await page.waitForChanges();
+
+      // Check tabindex values
+      const firstTabindex = await firstTag.getAttribute('tabindex');
+      const secondTabindex = await secondTag.getAttribute('tabindex');
+
+      expect(firstTabindex).toBe('0');
+      expect(secondTabindex).toBe('-1');
+    });
+
+    it('should wrap around from last to first tag on ArrowRight', async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+        <div>
+          <scale-tag id="tag1">Tag 1</scale-tag>
+          <scale-tag id="tag2">Tag 2</scale-tag>
+          <scale-tag id="tag3">Tag 3</scale-tag>
+        </div>
+      `);
+
+      const firstTag = await page.find('#tag1');
+      const thirdTag = await page.find('#tag3');
+
+      // Focus on last tag and press ArrowRight
+      await thirdTag.focus();
+      await page.keyboard.press('ArrowRight');
+      await page.waitForChanges();
+
+      // Check tabindex values - should wrap to first
+      const firstTabindex = await firstTag.getAttribute('tabindex');
+      const thirdTabindex = await thirdTag.getAttribute('tabindex');
+
+      expect(firstTabindex).toBe('0');
+      expect(thirdTabindex).toBe('-1');
+    });
+
+    it('should wrap around from first to last tag on ArrowLeft', async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+        <div>
+          <scale-tag id="tag1">Tag 1</scale-tag>
+          <scale-tag id="tag2">Tag 2</scale-tag>
+          <scale-tag id="tag3">Tag 3</scale-tag>
+        </div>
+      `);
+
+      const firstTag = await page.find('#tag1');
+      const thirdTag = await page.find('#tag3');
+
+      // Focus on first tag and press ArrowLeft
+      await firstTag.focus();
+      await page.keyboard.press('ArrowLeft');
+      await page.waitForChanges();
+
+      // Check tabindex values - should wrap to last
+      const firstTabindex = await firstTag.getAttribute('tabindex');
+      const thirdTabindex = await thirdTag.getAttribute('tabindex');
+
+      expect(firstTabindex).toBe('-1');
+      expect(thirdTabindex).toBe('0');
+    });
+  });
 });

--- a/packages/components/src/components/tag/tag.e2e.ts
+++ b/packages/components/src/components/tag/tag.e2e.ts
@@ -19,202 +19,98 @@ describe('scale-tag', () => {
     expect(element).toHaveClass('hydrated');
   });
 
-  describe('Keyboard Navigation', () => {
-    it('should have role and aria attributes for accessibility', async () => {
+  describe('Accessibility', () => {
+    it('should keep read-only tags out of the tab order', async () => {
       const page = await newE2EPage();
       await page.setContent(`
         <div>
-          <scale-tag>Tag 1</scale-tag>
-          <scale-tag>Tag 2</scale-tag>
-          <scale-tag>Tag 3</scale-tag>
+          <button id="before">Before</button>
+          <scale-tag id="tag1">Tag 1</scale-tag>
+          <scale-tag id="tag2">Tag 2</scale-tag>
+          <button id="after">After</button>
         </div>
       `);
 
-      const firstTag = await page.find('scale-tag');
-      const role = await firstTag.getAttribute('role');
-      const ariaSelected = await firstTag.getAttribute('aria-selected');
+      await page.focus('#before');
+      await page.keyboard.press('Tab');
+      await page.waitForChanges();
 
-      expect(role).toBe('option');
-      expect(ariaSelected).toBe('false');
+      const activeElementId = await page.evaluate(
+        () => document.activeElement.id
+      );
+      expect(activeElementId).toBe('after');
     });
 
-    it('should have tabindex set for roving tabindex pattern', async () => {
+    it('should not emit option semantics without a listbox owner', async () => {
       const page = await newE2EPage();
       await page.setContent(`
         <div>
-          <scale-tag>Tag 1</scale-tag>
-          <scale-tag>Tag 2</scale-tag>
-          <scale-tag>Tag 3</scale-tag>
+          <scale-tag id="tag1">Tag 1</scale-tag>
+          <scale-tag id="tag2">Tag 2</scale-tag>
         </div>
+      `);
+
+      const firstTag = await page.find('#tag1');
+      const secondTag = await page.find('#tag2');
+
+      expect(await firstTag.getAttribute('role')).toBeNull();
+      expect(await firstTag.getAttribute('aria-selected')).toBeNull();
+      expect(await secondTag.getAttribute('role')).toBeNull();
+      expect(await secondTag.getAttribute('aria-selected')).toBeNull();
+    });
+
+    it('should expose wrapped read-only tags without making them tabbable', async () => {
+      const page = await newE2EPage();
+      await page.setContent(`
+        <ul>
+          <li><scale-tag id="tag1">Tag 1</scale-tag></li>
+          <li><scale-tag id="tag2" disabled>Tag 2</scale-tag></li>
+          <li><scale-tag id="tag3">Tag 3</scale-tag></li>
+        </ul>
       `);
 
       const tags = await page.findAll('scale-tag');
       expect(tags.length).toBe(3);
 
-      // First tag should be focusable
-      const firstTabindex = await tags[0].getAttribute('tabindex');
-      expect(firstTabindex).toBe('0');
-
-      // Other tags should not be focusable
-      const secondTabindex = await tags[1].getAttribute('tabindex');
-      const thirdTabindex = await tags[2].getAttribute('tabindex');
-      expect(secondTabindex).toBe('-1');
-      expect(thirdTabindex).toBe('-1');
+      expect(await tags[0].getAttribute('tabindex')).toBeNull();
+      expect(await tags[1].getAttribute('tabindex')).toBeNull();
+      expect(await tags[2].getAttribute('tabindex')).toBeNull();
+      expect(await tags[0].getAttribute('aria-label')).toBe('Tag 1');
+      expect(await tags[1].getAttribute('aria-disabled')).toBe('true');
+      expect(await tags[1].getAttribute('aria-label')).toBe('Tag 2');
+      expect(await tags[2].getAttribute('aria-label')).toBe('Tag 3');
     });
 
-    it('should navigate to next tag on ArrowRight key', async () => {
+    it('should keep href and dismissable tags interactive without host tab stops', async () => {
       const page = await newE2EPage();
       await page.setContent(`
         <div>
-          <scale-tag id="tag1">Tag 1</scale-tag>
-          <scale-tag id="tag2">Tag 2</scale-tag>
-          <scale-tag id="tag3">Tag 3</scale-tag>
+          <button id="before">Before</button>
+          <scale-tag id="link-tag" href="#target">Link tag</scale-tag>
+          <scale-tag id="dismissable-tag" dismissable dismiss-text="Remove tag">
+            Dismissable tag
+          </scale-tag>
+          <button id="after">After</button>
         </div>
       `);
 
-      const firstTag = await page.find('#tag1');
-      const secondTag = await page.find('#tag2');
+      const linkTag = await page.find('#link-tag');
+      const dismissableTag = await page.find('#dismissable-tag');
+      const link = await page.find('#link-tag >>> a');
+      const button = await page.find('#dismissable-tag >>> button');
 
-      // Focus on first tag and press ArrowRight
-      await firstTag.focus();
-      await page.keyboard.press('ArrowRight');
-      await page.waitForChanges();
+      expect(await linkTag.getAttribute('tabindex')).toBeNull();
+      expect(await dismissableTag.getAttribute('tabindex')).toBeNull();
+      expect(await link.getAttribute('href')).toBe('#target');
+      expect(await button.getAttribute('aria-label')).toBe('Remove tag');
 
-      // Check tabindex values after navigation
-      const firstTabindex = await firstTag.getAttribute('tabindex');
-      const secondTabindex = await secondTag.getAttribute('tabindex');
+      await page.focus('#before');
+      await page.keyboard.press('Tab');
+      const activeElementTagName = await page.evaluate(() =>
+        document.activeElement.shadowRoot.activeElement.tagName.toLowerCase()
+      );
 
-      expect(firstTabindex).toBe('-1');
-      expect(secondTabindex).toBe('0');
-    });
-
-    it('should navigate to previous tag on ArrowLeft key', async () => {
-      const page = await newE2EPage();
-      await page.setContent(`
-        <div>
-          <scale-tag id="tag1">Tag 1</scale-tag>
-          <scale-tag id="tag2">Tag 2</scale-tag>
-          <scale-tag id="tag3">Tag 3</scale-tag>
-        </div>
-      `);
-
-      const firstTag = await page.find('#tag1');
-      const secondTag = await page.find('#tag2');
-      const thirdTag = await page.find('#tag3');
-
-      // Focus on second tag and press ArrowLeft
-      await secondTag.focus();
-      await page.keyboard.press('ArrowLeft');
-      await page.waitForChanges();
-
-      // Check tabindex values - should go back to first tag
-      const firstTabindex = await firstTag.getAttribute('tabindex');
-      const secondTabindex = await secondTag.getAttribute('tabindex');
-
-      expect(firstTabindex).toBe('0');
-      expect(secondTabindex).toBe('-1');
-    });
-
-    it('should navigate to next tag on ArrowDown key', async () => {
-      const page = await newE2EPage();
-      await page.setContent(`
-        <div>
-          <scale-tag id="tag1">Tag 1</scale-tag>
-          <scale-tag id="tag2">Tag 2</scale-tag>
-        </div>
-      `);
-
-      const firstTag = await page.find('#tag1');
-      const secondTag = await page.find('#tag2');
-
-      // Focus on first tag and press ArrowDown
-      await firstTag.focus();
-      await page.keyboard.press('ArrowDown');
-      await page.waitForChanges();
-
-      // Check tabindex values
-      const firstTabindex = await firstTag.getAttribute('tabindex');
-      const secondTabindex = await secondTag.getAttribute('tabindex');
-
-      expect(firstTabindex).toBe('-1');
-      expect(secondTabindex).toBe('0');
-    });
-
-    it('should navigate to previous tag on ArrowUp key', async () => {
-      const page = await newE2EPage();
-      await page.setContent(`
-        <div>
-          <scale-tag id="tag1">Tag 1</scale-tag>
-          <scale-tag id="tag2">Tag 2</scale-tag>
-        </div>
-      `);
-
-      const firstTag = await page.find('#tag1');
-      const secondTag = await page.find('#tag2');
-
-      // Focus on second tag and press ArrowUp
-      await secondTag.focus();
-      await page.keyboard.press('ArrowUp');
-      await page.waitForChanges();
-
-      // Check tabindex values
-      const firstTabindex = await firstTag.getAttribute('tabindex');
-      const secondTabindex = await secondTag.getAttribute('tabindex');
-
-      expect(firstTabindex).toBe('0');
-      expect(secondTabindex).toBe('-1');
-    });
-
-    it('should wrap around from last to first tag on ArrowRight', async () => {
-      const page = await newE2EPage();
-      await page.setContent(`
-        <div>
-          <scale-tag id="tag1">Tag 1</scale-tag>
-          <scale-tag id="tag2">Tag 2</scale-tag>
-          <scale-tag id="tag3">Tag 3</scale-tag>
-        </div>
-      `);
-
-      const firstTag = await page.find('#tag1');
-      const thirdTag = await page.find('#tag3');
-
-      // Focus on last tag and press ArrowRight
-      await thirdTag.focus();
-      await page.keyboard.press('ArrowRight');
-      await page.waitForChanges();
-
-      // Check tabindex values - should wrap to first
-      const firstTabindex = await firstTag.getAttribute('tabindex');
-      const thirdTabindex = await thirdTag.getAttribute('tabindex');
-
-      expect(firstTabindex).toBe('0');
-      expect(thirdTabindex).toBe('-1');
-    });
-
-    it('should wrap around from first to last tag on ArrowLeft', async () => {
-      const page = await newE2EPage();
-      await page.setContent(`
-        <div>
-          <scale-tag id="tag1">Tag 1</scale-tag>
-          <scale-tag id="tag2">Tag 2</scale-tag>
-          <scale-tag id="tag3">Tag 3</scale-tag>
-        </div>
-      `);
-
-      const firstTag = await page.find('#tag1');
-      const thirdTag = await page.find('#tag3');
-
-      // Focus on first tag and press ArrowLeft
-      await firstTag.focus();
-      await page.keyboard.press('ArrowLeft');
-      await page.waitForChanges();
-
-      // Check tabindex values - should wrap to last
-      const firstTabindex = await firstTag.getAttribute('tabindex');
-      const thirdTabindex = await thirdTag.getAttribute('tabindex');
-
-      expect(firstTabindex).toBe('-1');
-      expect(thirdTabindex).toBe('0');
+      expect(activeElementTagName).toBe('a');
     });
   });
 });

--- a/packages/components/src/components/tag/tag.spec.ts
+++ b/packages/components/src/components/tag/tag.spec.ts
@@ -44,4 +44,142 @@ describe('Tag', () => {
     element.href = 'http://example.com';
     expect(element.getCssClassMap()).toContain('tag--link');
   });
+
+  describe('Keyboard Navigation (Roving Tabindex)', () => {
+    it('should have role="option" and aria-selected attributes', async () => {
+      const page = await newSpecPage({
+        components: [Tag],
+        html: `<scale-tag>Tag 1</scale-tag>`,
+      });
+      const tag = page.root;
+      expect(tag.getAttribute('role')).toBe('option');
+      expect(tag.getAttribute('aria-selected')).toBe('false');
+    });
+
+    it('should have tabindex initially set to 0', async () => {
+      const page = await newSpecPage({
+        components: [Tag],
+        html: `<scale-tag>Tag 1</scale-tag>`,
+      });
+      const tag = page.root;
+      expect(tag.getAttribute('tabindex')).toBe('0');
+    });
+
+    it('should handle ArrowRight keyboard event on a single tag', async () => {
+      const page = await newSpecPage({
+        components: [Tag],
+        html: `<scale-tag>Tag</scale-tag>`,
+      });
+
+      const tag = page.root;
+      expect(tag).not.toBeNull();
+
+      // Simulate ArrowRight key press on tag
+      const event = new KeyboardEvent('keydown', {
+        key: 'ArrowRight',
+        bubbles: true,
+      });
+      tag.dispatchEvent(event);
+      await page.waitForChanges();
+
+      // Verify that tag still has tabindex 0
+      expect(tag.getAttribute('tabindex')).toBe('0');
+    });
+
+    it('should handle ArrowLeft keyboard event on a single tag', async () => {
+      const page = await newSpecPage({
+        components: [Tag],
+        html: `<scale-tag>Tag</scale-tag>`,
+      });
+
+      const tag = page.root;
+      expect(tag).not.toBeNull();
+
+      // Simulate ArrowLeft key press
+      const event = new KeyboardEvent('keydown', {
+        key: 'ArrowLeft',
+        bubbles: true,
+      });
+      tag.dispatchEvent(event);
+      await page.waitForChanges();
+
+      expect(tag.getAttribute('tabindex')).toBe('0');
+    });
+
+    it('should handle ArrowDown keyboard event on a single tag', async () => {
+      const page = await newSpecPage({
+        components: [Tag],
+        html: `<scale-tag>Tag</scale-tag>`,
+      });
+
+      const tag = page.root;
+      expect(tag).not.toBeNull();
+
+      // Simulate ArrowDown key press
+      const event = new KeyboardEvent('keydown', {
+        key: 'ArrowDown',
+        bubbles: true,
+      });
+      tag.dispatchEvent(event);
+      await page.waitForChanges();
+
+      expect(tag.getAttribute('tabindex')).toBe('0');
+    });
+
+    it('should handle ArrowUp keyboard event on a single tag', async () => {
+      const page = await newSpecPage({
+        components: [Tag],
+        html: `<scale-tag>Tag</scale-tag>`,
+      });
+
+      const tag = page.root;
+      expect(tag).not.toBeNull();
+
+      // Simulate ArrowUp key press
+      const event = new KeyboardEvent('keydown', {
+        key: 'ArrowUp',
+        bubbles: true,
+      });
+      tag.dispatchEvent(event);
+      await page.waitForChanges();
+
+      expect(tag.getAttribute('tabindex')).toBe('0');
+    });
+
+    it('should handle focus event on a single tag', async () => {
+      const page = await newSpecPage({
+        components: [Tag],
+        html: `<scale-tag>Tag</scale-tag>`,
+      });
+
+      const tag = page.root;
+      expect(tag).not.toBeNull();
+
+      // Simulate focus event
+      const focusEvent = new FocusEvent('focus', { bubbles: true });
+      tag.dispatchEvent(focusEvent);
+      await page.waitForChanges();
+
+      expect(tag.getAttribute('tabindex')).toBe('0');
+    });
+
+    it('should not prevent default for non-arrow keys', async () => {
+      const page = await newSpecPage({
+        components: [Tag],
+        html: `<scale-tag>Tag</scale-tag>`,
+      });
+
+      const tag = page.root;
+      const event = new KeyboardEvent('keydown', {
+        key: 'Enter',
+        bubbles: true,
+      });
+      const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+      tag.dispatchEvent(event);
+      await page.waitForChanges();
+
+      expect(preventDefaultSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/components/src/components/tag/tag.spec.ts
+++ b/packages/components/src/components/tag/tag.spec.ts
@@ -45,141 +45,68 @@ describe('Tag', () => {
     expect(element.getCssClassMap()).toContain('tag--link');
   });
 
-  describe('Keyboard Navigation (Roving Tabindex)', () => {
-    it('should have role="option" and aria-selected attributes', async () => {
+  describe('Accessibility', () => {
+    it('should keep read-only tags out of tab order and invalid option context', async () => {
       const page = await newSpecPage({
         components: [Tag],
         html: `<scale-tag>Tag 1</scale-tag>`,
       });
       const tag = page.root;
-      expect(tag.getAttribute('role')).toBe('option');
-      expect(tag.getAttribute('aria-selected')).toBe('false');
+      expect(tag.hasAttribute('tabindex')).toBe(false);
+      expect(tag.hasAttribute('role')).toBe(false);
+      expect(tag.hasAttribute('aria-selected')).toBe(false);
+      expect(tag.getAttribute('aria-label')).toBe('Tag 1');
     });
 
-    it('should have tabindex initially set to 0', async () => {
+    it('should preserve explicit aria-label on read-only tags', async () => {
       const page = await newSpecPage({
         components: [Tag],
-        html: `<scale-tag>Tag 1</scale-tag>`,
+        html: `<scale-tag aria-label="Custom label">Tag 1</scale-tag>`,
       });
       const tag = page.root;
-      expect(tag.getAttribute('tabindex')).toBe('0');
+      expect(tag.getAttribute('aria-label')).toBe('Custom label');
     });
 
-    it('should handle ArrowRight keyboard event on a single tag', async () => {
+    it('should not put wrapped read-only tags into tab order', async () => {
       const page = await newSpecPage({
         components: [Tag],
-        html: `<scale-tag>Tag</scale-tag>`,
+        html: `
+          <ul>
+            <li><scale-tag>Tag 1</scale-tag></li>
+            <li><scale-tag disabled>Tag 2</scale-tag></li>
+            <li><scale-tag>Tag 3</scale-tag></li>
+          </ul>
+        `,
       });
 
-      const tag = page.root;
-      expect(tag).not.toBeNull();
-
-      // Simulate ArrowRight key press on tag
-      const event = new KeyboardEvent('keydown', {
-        key: 'ArrowRight',
-        bubbles: true,
+      const tags = page.body.querySelectorAll('scale-tag');
+      tags.forEach((tag) => {
+        expect(tag.hasAttribute('tabindex')).toBe(false);
+        expect(tag.hasAttribute('role')).toBe(false);
+        expect(tag.hasAttribute('aria-selected')).toBe(false);
       });
-      tag.dispatchEvent(event);
-      await page.waitForChanges();
-
-      // Verify that tag still has tabindex 0
-      expect(tag.getAttribute('tabindex')).toBe('0');
+      expect(tags[1].getAttribute('aria-disabled')).toBe('true');
     });
 
-    it('should handle ArrowLeft keyboard event on a single tag', async () => {
+    it('should keep href and dismissable behavior on the internal controls', async () => {
       const page = await newSpecPage({
         components: [Tag],
-        html: `<scale-tag>Tag</scale-tag>`,
+        html: `
+          <scale-tag href="https://example.com">Link tag</scale-tag>
+          <scale-tag dismissable dismiss-text="Remove tag">Dismissable tag</scale-tag>
+        `,
       });
 
-      const tag = page.root;
-      expect(tag).not.toBeNull();
+      const [linkTag, dismissableTag] = Array.from(
+        page.body.querySelectorAll('scale-tag')
+      );
+      const link = linkTag.shadowRoot.querySelector('a');
+      const button = dismissableTag.shadowRoot.querySelector('button');
 
-      // Simulate ArrowLeft key press
-      const event = new KeyboardEvent('keydown', {
-        key: 'ArrowLeft',
-        bubbles: true,
-      });
-      tag.dispatchEvent(event);
-      await page.waitForChanges();
-
-      expect(tag.getAttribute('tabindex')).toBe('0');
-    });
-
-    it('should handle ArrowDown keyboard event on a single tag', async () => {
-      const page = await newSpecPage({
-        components: [Tag],
-        html: `<scale-tag>Tag</scale-tag>`,
-      });
-
-      const tag = page.root;
-      expect(tag).not.toBeNull();
-
-      // Simulate ArrowDown key press
-      const event = new KeyboardEvent('keydown', {
-        key: 'ArrowDown',
-        bubbles: true,
-      });
-      tag.dispatchEvent(event);
-      await page.waitForChanges();
-
-      expect(tag.getAttribute('tabindex')).toBe('0');
-    });
-
-    it('should handle ArrowUp keyboard event on a single tag', async () => {
-      const page = await newSpecPage({
-        components: [Tag],
-        html: `<scale-tag>Tag</scale-tag>`,
-      });
-
-      const tag = page.root;
-      expect(tag).not.toBeNull();
-
-      // Simulate ArrowUp key press
-      const event = new KeyboardEvent('keydown', {
-        key: 'ArrowUp',
-        bubbles: true,
-      });
-      tag.dispatchEvent(event);
-      await page.waitForChanges();
-
-      expect(tag.getAttribute('tabindex')).toBe('0');
-    });
-
-    it('should handle focus event on a single tag', async () => {
-      const page = await newSpecPage({
-        components: [Tag],
-        html: `<scale-tag>Tag</scale-tag>`,
-      });
-
-      const tag = page.root;
-      expect(tag).not.toBeNull();
-
-      // Simulate focus event
-      const focusEvent = new FocusEvent('focus', { bubbles: true });
-      tag.dispatchEvent(focusEvent);
-      await page.waitForChanges();
-
-      expect(tag.getAttribute('tabindex')).toBe('0');
-    });
-
-    it('should not prevent default for non-arrow keys', async () => {
-      const page = await newSpecPage({
-        components: [Tag],
-        html: `<scale-tag>Tag</scale-tag>`,
-      });
-
-      const tag = page.root;
-      const event = new KeyboardEvent('keydown', {
-        key: 'Enter',
-        bubbles: true,
-      });
-      const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
-
-      tag.dispatchEvent(event);
-      await page.waitForChanges();
-
-      expect(preventDefaultSpy).not.toHaveBeenCalled();
+      expect(link.getAttribute('href')).toBe('https://example.com');
+      expect(button.getAttribute('aria-label')).toBe('Remove tag');
+      expect(linkTag.hasAttribute('tabindex')).toBe(false);
+      expect(dismissableTag.hasAttribute('tabindex')).toBe(false);
     });
   });
 });

--- a/packages/components/src/components/tag/tag.tsx
+++ b/packages/components/src/components/tag/tag.tsx
@@ -80,7 +80,7 @@ export class Tag {
   };
 
   render() {
-    const element = !!this.href && !this.disabled ? 'a' : 'span';
+    const TagElement = !!this.href && !this.disabled ? 'a' : 'span';
     const linkProps = !!this.href
       ? {
           href: this.href,
@@ -98,7 +98,7 @@ export class Tag {
       >
         {this.styles && <style>{this.styles}</style>}
 
-        <element
+        <TagElement
           part={this.getBasePartMap()}
           class={this.getCssClassMap()}
           {...linkProps}
@@ -115,7 +115,7 @@ export class Tag {
               <scale-icon-action-close part="icon-dismissable" size={16} />
             </button>
           )}
-        </element>
+        </TagElement>
       </Host>
     );
   }

--- a/packages/components/src/components/tag/tag.tsx
+++ b/packages/components/src/components/tag/tag.tsx
@@ -9,15 +9,18 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { Component, Event, EventEmitter, h, Host, Prop } from '@stencil/core';
+import { Component, Element, Event, EventEmitter, h, Host, Prop } from '@stencil/core';
 import classNames from 'classnames';
 import { emitEvent } from '../../utils/utils';
+
 @Component({
   tag: 'scale-tag',
   styleUrl: './tag.css',
   shadow: true,
 })
 export class Tag {
+  @Element() hostElement!: HTMLElement;
+
   /** (optional) Tag size */
   @Prop() size?: 'small';
   /** (optional) Tag type */
@@ -52,8 +55,84 @@ export class Tag {
   /** (optional) Close icon click event */
   @Event({ eventName: 'scale-close' }) scaleClose: EventEmitter<MouseEvent>;
 
+  componentDidLoad() {
+    this.initializeRovingTabindex();
+  }
+
   componentWillUpdate() {}
   disconnectedCallback() {}
+
+  private initializeRovingTabindex() {
+    // Find all sibling scale-tag elements
+    const siblings = this.getSiblingTags();
+    if (siblings.length === 0) return;
+
+    // Set first tag as focusable, others as not focusable
+    siblings.forEach((tag, index) => {
+      if (index === 0) {
+        tag.setAttribute('tabindex', '0');
+      } else {
+        tag.setAttribute('tabindex', '-1');
+      }
+      // Set ARIA attributes for accessibility
+      tag.setAttribute('role', 'option');
+      tag.setAttribute('aria-selected', 'false');
+    });
+  }
+
+  private getSiblingTags(): HTMLElement[] {
+    if (!this.hostElement.parentElement) return [];
+
+    const allTags = Array.from(
+      this.hostElement.parentElement.querySelectorAll('scale-tag')
+    ) as HTMLElement[];
+    return allTags;
+  }
+
+  private updateRoving(newFocusedTag: HTMLElement) {
+    const siblings = this.getSiblingTags();
+    siblings.forEach((tag) => {
+      if (tag === newFocusedTag) {
+        tag.setAttribute('tabindex', '0');
+      } else {
+        tag.setAttribute('tabindex', '-1');
+      }
+    });
+    // Focus the new tag
+    newFocusedTag.focus();
+  }
+
+  private handleKeyDown = (event: KeyboardEvent) => {
+    const keyCode = event.key;
+    if (!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(keyCode)) {
+      return;
+    }
+
+    event.preventDefault();
+    const siblings = this.getSiblingTags();
+    const currentIndex = siblings.indexOf(this.hostElement);
+
+    let nextIndex = currentIndex;
+
+    if (keyCode === 'ArrowRight' || keyCode === 'ArrowDown') {
+      nextIndex = (currentIndex + 1) % siblings.length;
+    } else if (keyCode === 'ArrowLeft' || keyCode === 'ArrowUp') {
+      nextIndex = (currentIndex - 1 + siblings.length) % siblings.length;
+    }
+
+    this.updateRoving(siblings[nextIndex]);
+  };
+
+  private handleFocus = (event: FocusEvent) => {
+    const siblings = this.getSiblingTags();
+    siblings.forEach((tag) => {
+      if (tag === this.hostElement) {
+        tag.setAttribute('tabindex', '0');
+      } else {
+        tag.setAttribute('tabindex', '-1');
+      }
+    });
+  };
 
   handleClose = (event: MouseEvent) => {
     event.preventDefault();
@@ -74,7 +153,13 @@ export class Tag {
       : {};
 
     return (
-      <Host>
+      <Host
+        role="option"
+        aria-selected="false"
+        tabindex={0}
+        onKeyDown={this.handleKeyDown}
+        onFocus={this.handleFocus}
+      >
         {this.styles && <style>{this.styles}</style>}
 
         <Element

--- a/packages/components/src/components/tag/tag.tsx
+++ b/packages/components/src/components/tag/tag.tsx
@@ -146,7 +146,9 @@ export class Tag {
   private initializeRovingTabindex() {
     // Find all sibling scale-tag elements
     const siblings = this.getSiblingTags();
-    if (siblings.length === 0) { return; }
+    if (siblings.length === 0) {
+      return;
+    }
 
     // Set first tag as focusable, others as not focusable
     siblings.forEach((tag, index) => {
@@ -162,7 +164,9 @@ export class Tag {
   }
 
   private getSiblingTags(): HTMLElement[] {
-    if (!this.hostElement.parentElement) { return []; }
+    if (!this.hostElement.parentElement) {
+      return [];
+    }
 
     const allTags = Array.from(
       this.hostElement.parentElement.querySelectorAll('scale-tag')

--- a/packages/components/src/components/tag/tag.tsx
+++ b/packages/components/src/components/tag/tag.tsx
@@ -70,10 +70,83 @@ export class Tag {
   componentWillUpdate() {}
   disconnectedCallback() {}
 
+  handleClose = (event: MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (this.disabled) {
+      return;
+    }
+    emitEvent(this, 'scale-close', event);
+  };
+
+  render() {
+    const element = !!this.href && !this.disabled ? 'a' : 'span';
+    const linkProps = !!this.href
+      ? {
+          href: this.href,
+          target: this.target,
+        }
+      : {};
+
+    return (
+      <Host
+        role="option"
+        aria-selected="false"
+        tabindex={0}
+        onKeyDown={this.handleKeyDown}
+        onFocus={this.handleFocus}
+      >
+        {this.styles && <style>{this.styles}</style>}
+
+        <element
+          part={this.getBasePartMap()}
+          class={this.getCssClassMap()}
+          {...linkProps}
+        >
+          <slot />
+
+          {this.dismissable && (
+            <button
+              part="button-dismissable"
+              disabled={this.disabled}
+              aria-label={this.dismissText}
+              onClick={this.handleClose}
+            >
+              <scale-icon-action-close part="icon-dismissable" size={16} />
+            </button>
+          )}
+        </element>
+      </Host>
+    );
+  }
+
+  getBasePartMap() {
+    return this.getCssOrBasePartMap('basePart');
+  }
+
+  getCssClassMap() {
+    return this.getCssOrBasePartMap('css');
+  }
+
+  getCssOrBasePartMap(mode: 'basePart' | 'css') {
+    const component = 'tag';
+    const prefix = mode === 'basePart' ? '' : `${component}--`;
+
+    return classNames(
+      mode === 'basePart' ? 'base' : component,
+      this.size && `${prefix}size-${this.size}`,
+      this.type && `${prefix}type-${this.type}`,
+      this.color && `${prefix}color-${this.color}`,
+      !!this.href && `${prefix}link`,
+      !!this.dismissable && `${prefix}dismissable`,
+      !!this.disabled && `${prefix}disabled`
+    );
+  }
+
   private initializeRovingTabindex() {
     // Find all sibling scale-tag elements
     const siblings = this.getSiblingTags();
-    if (siblings.length === 0) return;
+    if (siblings.length === 0) { return; }
 
     // Set first tag as focusable, others as not focusable
     siblings.forEach((tag, index) => {
@@ -89,7 +162,7 @@ export class Tag {
   }
 
   private getSiblingTags(): HTMLElement[] {
-    if (!this.hostElement.parentElement) return [];
+    if (!this.hostElement.parentElement) { return []; }
 
     const allTags = Array.from(
       this.hostElement.parentElement.querySelectorAll('scale-tag')
@@ -143,77 +216,4 @@ export class Tag {
       }
     });
   };
-
-  handleClose = (event: MouseEvent) => {
-    event.preventDefault();
-    event.stopPropagation();
-    if (this.disabled) {
-      return;
-    }
-    emitEvent(this, 'scale-close', event);
-  };
-
-  render() {
-    const Element = !!this.href && !this.disabled ? 'a' : 'span';
-    const linkProps = !!this.href
-      ? {
-          href: this.href,
-          target: this.target,
-        }
-      : {};
-
-    return (
-      <Host
-        role="option"
-        aria-selected="false"
-        tabindex={0}
-        onKeyDown={this.handleKeyDown}
-        onFocus={this.handleFocus}
-      >
-        {this.styles && <style>{this.styles}</style>}
-
-        <Element
-          part={this.getBasePartMap()}
-          class={this.getCssClassMap()}
-          {...linkProps}
-        >
-          <slot />
-
-          {this.dismissable && (
-            <button
-              part="button-dismissable"
-              disabled={this.disabled}
-              aria-label={this.dismissText}
-              onClick={this.handleClose}
-            >
-              <scale-icon-action-close part="icon-dismissable" size={16} />
-            </button>
-          )}
-        </Element>
-      </Host>
-    );
-  }
-
-  getBasePartMap() {
-    return this.getCssOrBasePartMap('basePart');
-  }
-
-  getCssClassMap() {
-    return this.getCssOrBasePartMap('css');
-  }
-
-  getCssOrBasePartMap(mode: 'basePart' | 'css') {
-    const component = 'tag';
-    const prefix = mode === 'basePart' ? '' : `${component}--`;
-
-    return classNames(
-      mode === 'basePart' ? 'base' : component,
-      this.size && `${prefix}size-${this.size}`,
-      this.type && `${prefix}type-${this.type}`,
-      this.color && `${prefix}color-${this.color}`,
-      !!this.href && `${prefix}link`,
-      !!this.dismissable && `${prefix}dismissable`,
-      !!this.disabled && `${prefix}disabled`
-    );
-  }
 }

--- a/packages/components/src/components/tag/tag.tsx
+++ b/packages/components/src/components/tag/tag.tsx
@@ -9,7 +9,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { Component, Element, Event, EventEmitter, h, Host, Prop } from '@stencil/core';
+import {
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  h,
+  Host,
+  Prop,
+} from '@stencil/core';
 import classNames from 'classnames';
 import { emitEvent } from '../../utils/utils';
 
@@ -104,7 +112,9 @@ export class Tag {
 
   private handleKeyDown = (event: KeyboardEvent) => {
     const keyCode = event.key;
-    if (!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(keyCode)) {
+    if (
+      !['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(keyCode)
+    ) {
       return;
     }
 

--- a/packages/components/src/components/tag/tag.tsx
+++ b/packages/components/src/components/tag/tag.tsx
@@ -63,8 +63,14 @@ export class Tag {
   /** (optional) Close icon click event */
   @Event({ eventName: 'scale-close' }) scaleClose: EventEmitter<MouseEvent>;
 
+  private generatedAriaLabel?: string;
+
   componentDidLoad() {
-    this.initializeRovingTabindex();
+    this.syncReadonlyAccessibility();
+  }
+
+  componentDidUpdate() {
+    this.syncReadonlyAccessibility();
   }
 
   componentWillUpdate() {}
@@ -89,13 +95,7 @@ export class Tag {
       : {};
 
     return (
-      <Host
-        role="option"
-        aria-selected="false"
-        tabindex={0}
-        onKeyDown={this.handleKeyDown}
-        onFocus={this.handleFocus}
-      >
+      <Host aria-disabled={this.disabled ? 'true' : null}>
         {this.styles && <style>{this.styles}</style>}
 
         <TagElement
@@ -103,7 +103,7 @@ export class Tag {
           class={this.getCssClassMap()}
           {...linkProps}
         >
-          <slot />
+          <slot onSlotchange={this.syncReadonlyAccessibility} />
 
           {this.dismissable && (
             <button
@@ -143,81 +143,37 @@ export class Tag {
     );
   }
 
-  private initializeRovingTabindex() {
-    // Find all sibling scale-tag elements
-    const siblings = this.getSiblingTags();
-    if (siblings.length === 0) {
+  private syncReadonlyAccessibility = () => {
+    if (this.hasInteractiveControl()) {
+      if (
+        this.generatedAriaLabel != null &&
+        this.hostElement.getAttribute('aria-label') === this.generatedAriaLabel
+      ) {
+        this.hostElement.removeAttribute('aria-label');
+      }
+      this.generatedAriaLabel = undefined;
       return;
     }
 
-    // Set first tag as focusable, others as not focusable
-    siblings.forEach((tag, index) => {
-      if (index === 0) {
-        tag.setAttribute('tabindex', '0');
-      } else {
-        tag.setAttribute('tabindex', '-1');
-      }
-      // Set ARIA attributes for accessibility
-      tag.setAttribute('role', 'option');
-      tag.setAttribute('aria-selected', 'false');
-    });
-  }
-
-  private getSiblingTags(): HTMLElement[] {
-    if (!this.hostElement.parentElement) {
-      return [];
-    }
-
-    const allTags = Array.from(
-      this.hostElement.parentElement.querySelectorAll('scale-tag')
-    ) as HTMLElement[];
-    return allTags;
-  }
-
-  private updateRoving(newFocusedTag: HTMLElement) {
-    const siblings = this.getSiblingTags();
-    siblings.forEach((tag) => {
-      if (tag === newFocusedTag) {
-        tag.setAttribute('tabindex', '0');
-      } else {
-        tag.setAttribute('tabindex', '-1');
-      }
-    });
-    // Focus the new tag
-    newFocusedTag.focus();
-  }
-
-  private handleKeyDown = (event: KeyboardEvent) => {
-    const keyCode = event.key;
+    const currentAriaLabel = this.hostElement.getAttribute('aria-label');
     if (
-      !['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(keyCode)
+      currentAriaLabel != null &&
+      currentAriaLabel !== this.generatedAriaLabel
     ) {
       return;
     }
 
-    event.preventDefault();
-    const siblings = this.getSiblingTags();
-    const currentIndex = siblings.indexOf(this.hostElement);
-
-    let nextIndex = currentIndex;
-
-    if (keyCode === 'ArrowRight' || keyCode === 'ArrowDown') {
-      nextIndex = (currentIndex + 1) % siblings.length;
-    } else if (keyCode === 'ArrowLeft' || keyCode === 'ArrowUp') {
-      nextIndex = (currentIndex - 1 + siblings.length) % siblings.length;
+    const text = this.hostElement.textContent?.trim().replace(/\s+/g, ' ');
+    if (text) {
+      this.hostElement.setAttribute('aria-label', text);
+      this.generatedAriaLabel = text;
+    } else {
+      this.hostElement.removeAttribute('aria-label');
+      this.generatedAriaLabel = undefined;
     }
-
-    this.updateRoving(siblings[nextIndex]);
   };
 
-  private handleFocus = (event: FocusEvent) => {
-    const siblings = this.getSiblingTags();
-    siblings.forEach((tag) => {
-      if (tag === this.hostElement) {
-        tag.setAttribute('tabindex', '0');
-      } else {
-        tag.setAttribute('tabindex', '-1');
-      }
-    });
-  };
+  private hasInteractiveControl() {
+    return (!!this.href || this.dismissable) && !this.disabled;
+  }
 }


### PR DESCRIPTION
Implement roving tabindex and ARIA role for scale-tag so arrow keys move focus and screen readers announce tags. Add unit and e2e tests.

fixes #2419 