### PR TITLE
chore: add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,10 @@
 version: 2
 updates:
   # This repository uses Yarn v1 workspaces. Dependabot uses the "npm"
-  # ecosystem value for npm, pnpm, and Yarn, and updates package manifests
-  # together with the root yarn.lock when dependency updates are opened.
+  # ecosystem value for npm, pnpm, and Yarn, and follows the root workspace
+  # manifest to update package manifests together with the root yarn.lock.
   - package-ecosystem: "npm"
-    directories:
-      - "/"
-      - "/packages/*"
+    directory: "/"
     schedule:
       interval: "weekly"
     cooldown:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # This repository uses Yarn v1 workspaces. Dependabot uses the "npm"
+  # ecosystem value for npm, pnpm, and Yarn, and updates package manifests
+  # together with the root yarn.lock when dependency updates are opened.
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+      - "/packages/*"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 15
+    versioning-strategy: "auto"
+    allow:
+      - dependency-type: "development"


### PR DESCRIPTION
## Summary
- Add Dependabot configuration for Yarn v1 workspace npm ecosystem updates
- Cover root and packages/* manifests in the monorepo
- Limit updates to development dependencies and apply a 15-day cooldown

## Testing
- Not run; configuration-only change