### PR TITLE
fix(checkbox): submit native default value

### DIFF
--- a/packages/components/src/components/checkbox/__snapshots__/checkbox.spec.ts.snap
+++ b/packages/components/src/components/checkbox/__snapshots__/checkbox.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`Checkbox should match snapshot 1`] = `
 <scale-checkbox>
   <!---->
-  <input id="input-checkbox-0" part="input" type="checkbox" value="">
+  <input id="input-checkbox-0" part="input" type="checkbox" value="on">
   <label htmlfor="input-checkbox-0" part="container">
     <span part="checkbox"></span>
     <span part="label"></span>
@@ -14,7 +14,7 @@ exports[`Checkbox should match snapshot 1`] = `
 exports[`Checkbox should match snapshot 2`] = `
 <scale-checkbox helper-text="helpertext">
   <!---->
-  <input aria-describedby="helper-message-2" id="input-checkbox-2" part="input" type="checkbox" value="">
+  <input aria-describedby="helper-message-2" id="input-checkbox-2" part="input" type="checkbox" value="on">
   <label htmlfor="input-checkbox-2" part="container">
     <span part="checkbox"></span>
     <span part="label"></span>

--- a/packages/components/src/components/checkbox/checkbox.e2e.ts
+++ b/packages/components/src/components/checkbox/checkbox.e2e.ts
@@ -46,4 +46,47 @@ describe('scale-checkbox', () => {
 
     expect(color).toBe(expectedColor);
   });
+
+  it('should submit the native default checkbox value after user interaction', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <form>
+        <scale-checkbox
+          name="scale-checkbox"
+          label="Scale checkbox"
+        ></scale-checkbox>
+      </form>
+    `);
+
+    const checkbox = await page.find('scale-checkbox >>> input');
+    await checkbox.click();
+    await page.waitForChanges();
+
+    const formEntries = await page.evaluate(() =>
+      Array.from(new FormData(document.querySelector('form')).entries())
+    );
+
+    expect(formEntries).toEqual([['scale-checkbox', 'on']]);
+  });
+
+  it('should preserve an explicitly provided checkbox value in forms', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <form>
+        <scale-checkbox
+          checked
+          name="scale-checkbox"
+          value="newsletter"
+          label="Scale checkbox"
+        ></scale-checkbox>
+      </form>
+    `);
+    await page.waitForChanges();
+
+    const formEntries = await page.evaluate(() =>
+      Array.from(new FormData(document.querySelector('form')).entries())
+    );
+
+    expect(formEntries).toEqual([['scale-checkbox', 'newsletter']]);
+  });
 });

--- a/packages/components/src/components/checkbox/checkbox.spec.ts
+++ b/packages/components/src/components/checkbox/checkbox.spec.ts
@@ -56,6 +56,21 @@ describe('Checkbox', () => {
     expect(page.rootInstance.value).toBe('testvalue');
   });
 
+  it('should use the native checkbox default value', async () => {
+    page = await newSpecPage({
+      components: [Checkbox],
+      html: `
+        <form>
+          <scale-checkbox checked name="scale-checkbox"></scale-checkbox>
+        </form>`,
+    });
+    await page.waitForChanges();
+
+    const input = page.doc.querySelector('input');
+
+    expect(input.value).toBe('on');
+  });
+
   it('should emit on change', async () => {
     const changeSpy = jest.fn();
     const element = page.root.querySelector('input');

--- a/packages/components/src/components/checkbox/checkbox.tsx
+++ b/packages/components/src/components/checkbox/checkbox.tsx
@@ -58,7 +58,7 @@ export class Checkbox {
   /** (optional) indeterminate */
   @Prop({ mutable: true, reflect: true }) indeterminate?: boolean = false;
   /** (optional) Input value */
-  @Prop() value?: string = '';
+  @Prop() value?: string = 'on';
   /** (optional) Input checkbox id */
   @Prop({ mutable: true }) inputId?: string;
   /** (optional) Injected CSS styles */

--- a/packages/components/src/components/checkbox/readme.md
+++ b/packages/components/src/components/checkbox/readme.md
@@ -24,7 +24,7 @@
 | `required`          | `required`            | (optional) Input required                                                                                        | `boolean` | `undefined` |
 | `status`            | `status`              | <span style="color:red">**[DEPRECATED]**</span> - invalid should replace status<br/><br/>                        | `string`  | `''`        |
 | `styles`            | `styles`              | (optional) Injected CSS styles                                                                                   | `string`  | `undefined` |
-| `value`             | `value`               | (optional) Input value                                                                                           | `string`  | `''`        |
+| `value`             | `value`               | (optional) Input value                                                                                           | `string`  | `'on'`      |
 
 
 ## Events

--- a/packages/components/src/html/checkbox.html
+++ b/packages/components/src/html/checkbox.html
@@ -46,5 +46,42 @@
         label="My styles were affecting checkbox styles"
       ></scale-switch>
     </p>
+    <form id="checkbox-form" style="max-width: 40rem; padding-top: 2rem">
+      <h2>Form submission</h2>
+      <p>
+        <input checked name="native-checkbox" type="checkbox" />
+        Native checkbox
+      </p>
+      <p>
+        <scale-checkbox
+          checked
+          label="Scale checkbox"
+          name="scale-checkbox"
+        ></scale-checkbox>
+      </p>
+      <p>
+        <button type="submit">Serialize form</button>
+      </p>
+      <pre
+        id="checkbox-form-result"
+        style="background: #f3f3f3; padding: 1rem"
+      ></pre>
+    </form>
+    <script>
+      const form = document.getElementById('checkbox-form');
+      const output = document.getElementById('checkbox-form-result');
+
+      const renderFormData = () => {
+        const params = new URLSearchParams(new FormData(form));
+        output.textContent = params.toString();
+      };
+
+      form.addEventListener('submit', (event) => {
+        event.preventDefault();
+        renderFormData();
+      });
+
+      renderFormData();
+    </script>
   </body>
 </html>

--- a/packages/components/src/html/form.html
+++ b/packages/components/src/html/form.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="/build/scale-components.css" />
   </head>
   <body>
-    <form style="max-width: 40ch; padding: 2rem">
+    <form id="demo-form" style="max-width: 40ch; padding: 2rem">
       <h1>Say hello</h1>
       <p>
         <scale-input label="Name" name="name" variant="animated"></scale-input>
@@ -24,6 +24,17 @@
         ></scale-input>
       </p>
       <p>
+        <input checked name="native-checkbox" type="checkbox" />
+        Native checkbox
+      </p>
+      <p>
+        <scale-checkbox
+          checked
+          label="Scale checkbox"
+          name="scale-checkbox"
+        ></scale-checkbox>
+      </p>
+      <p>
         <scale-button>Submit</scale-button>
       </p>
       <p>
@@ -34,12 +45,30 @@
       <p>
         <button>Submit for real</button>
       </p>
+      <pre id="form-output" style="background: #f3f3f3; padding: 1rem"></pre>
     </form>
     <script>
-      function handleClick(event) {
-        const form = event.target.closest('form');
-        if (form) form.submit();
+      const form = document.getElementById('demo-form');
+      const output = document.getElementById('form-output');
+
+      function renderFormData() {
+        const params = new URLSearchParams(new FormData(form));
+        output.textContent = params.toString();
       }
+
+      function handleClick(event) {
+        const targetForm = event
+          .composedPath()
+          .find((node) => node.tagName === 'FORM');
+        if (targetForm) targetForm.requestSubmit();
+      }
+
+      form.addEventListener('submit', (event) => {
+        event.preventDefault();
+        renderFormData();
+      });
+
+      renderFormData();
     </script>
   </body>
 </html>


### PR DESCRIPTION
Fixes #2392

## Summary
- default scale-checkbox value now matches native checkbox behavior (`on`) when no explicit value is provided
- adds regression coverage for form submission behavior

## Validation
- `yarn workspace @telekom/scale-components test --spec --max-workers=2`
- `./node_modules/.bin/lerna run generate && yarn workspace @telekom/scale-components test --e2e --max-workers=2 && yarn workspace @telekom/scale-components lint`
- `./node_modules/.bin/lerna run generate && yarn workspace @telekom/scale-components build`
- Playwright static page check against `form.html`: checked checkbox without explicit value submits `on`; screenshot saved locally at `/tmp/scale-2392-form.png`
