### PR TITLE
fix(telekom-mobile-flyout-canvas): link app name

### DIFF
--- a/packages/components/src/components/telekom/telekom-mobile-flyout-canvas/telekom-mobile-flyout-canvas.css
+++ b/packages/components/src/components/telekom/telekom-mobile-flyout-canvas/telekom-mobile-flyout-canvas.css
@@ -47,6 +47,19 @@
   text-decoration: none;
 }
 
+[part~='heading'] a {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+[part~='heading'] a:hover {
+  color: var(--telekom-color-text-and-icon-primary-hovered);
+}
+
+[part~='heading'] a:active {
+  color: var(--telekom-color-text-and-icon-primary-pressed);
+}
+
 [part~='close-button'] {
   position: absolute;
   right: var(--telekom-spacing-composition-space-06);

--- a/packages/components/src/components/telekom/telekom-mobile-flyout-canvas/telekom-mobile-flyout-canvas.css
+++ b/packages/components/src/components/telekom/telekom-mobile-flyout-canvas/telekom-mobile-flyout-canvas.css
@@ -60,6 +60,13 @@
   color: var(--telekom-color-text-and-icon-primary-pressed);
 }
 
+[part~='heading'] a:focus-visible {
+  outline: var(--telekom-line-weight-highlight) solid
+    var(--telekom-color-functional-focus-standard);
+  outline-offset: 1px;
+  border-radius: var(--telekom-radius-small);
+}
+
 [part~='close-button'] {
   position: absolute;
   right: var(--telekom-spacing-composition-space-06);

--- a/packages/components/src/components/telekom/telekom-mobile-flyout-canvas/telekom-mobile-flyout-canvas.spec.ts
+++ b/packages/components/src/components/telekom/telekom-mobile-flyout-canvas/telekom-mobile-flyout-canvas.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Scale https://github.com/telekom/scale
+ *
+ * Copyright (c) 2021 Egor Kirpichev and contributors, Deutsche Telekom AG
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { newSpecPage } from '@stencil/core/testing';
+import { TelekomMobileFlyoutCanvas } from './telekom-mobile-flyout-canvas';
+
+describe('scale-telekom-mobile-flyout-canvas', () => {
+  it('renders the app name as a link when appNameLink is set', async () => {
+    const handleClick = jest.fn();
+    const page = await newSpecPage({
+      components: [TelekomMobileFlyoutCanvas],
+      html: `<scale-telekom-mobile-flyout-canvas app-name="Application Name" app-name-link="/foo"></scale-telekom-mobile-flyout-canvas>`,
+    });
+
+    page.root.appNameClick = handleClick;
+    await page.waitForChanges();
+
+    const link = page.root.shadowRoot.querySelector(
+      '[part="heading"] a'
+    ) as HTMLAnchorElement;
+
+    expect(link).toBeTruthy();
+    expect(link.getAttribute('href')).toBe('/foo');
+    expect(link.textContent).toBe('Application Name');
+
+    link.click();
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the app name as plain text when neither appNameLink nor appNameClick is set', async () => {
+    const page = await newSpecPage({
+      components: [TelekomMobileFlyoutCanvas],
+      html: `<scale-telekom-mobile-flyout-canvas app-name="Application Name"></scale-telekom-mobile-flyout-canvas>`,
+    });
+
+    const heading = page.root.shadowRoot.querySelector('[part="heading"]');
+    const link = heading.querySelector('a');
+
+    expect(link).toBeNull();
+    expect(heading.textContent).toBe('Application Name');
+  });
+
+  it('renders the app name as an action link when only appNameClick is set', async () => {
+    const handleClick = jest.fn();
+    const page = await newSpecPage({
+      components: [TelekomMobileFlyoutCanvas],
+      html: `<scale-telekom-mobile-flyout-canvas app-name="Application Name"></scale-telekom-mobile-flyout-canvas>`,
+    });
+
+    page.root.appNameClick = handleClick;
+    await page.waitForChanges();
+
+    const link = page.root.shadowRoot.querySelector(
+      '[part="heading"] a'
+    ) as HTMLAnchorElement;
+
+    expect(link).toBeTruthy();
+    expect(link.getAttribute('href')).toBe('javascript:void(0);');
+
+    link.click();
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/components/src/components/telekom/telekom-mobile-flyout-canvas/telekom-mobile-flyout-canvas.spec.ts
+++ b/packages/components/src/components/telekom/telekom-mobile-flyout-canvas/telekom-mobile-flyout-canvas.spec.ts
@@ -70,4 +70,20 @@ describe('scale-telekom-mobile-flyout-canvas', () => {
 
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
+
+  it('renders the app name as plain text when appNameClick is a non-function string', async () => {
+    const page = await newSpecPage({
+      components: [TelekomMobileFlyoutCanvas],
+      html: `<scale-telekom-mobile-flyout-canvas app-name="Application Name"></scale-telekom-mobile-flyout-canvas>`,
+    });
+
+    page.root.appNameClick = 'doSomething()';
+    await page.waitForChanges();
+
+    const heading = page.root.shadowRoot.querySelector('[part="heading"]');
+    const link = heading.querySelector('a');
+
+    expect(link).toBeNull();
+    expect(heading.textContent).toBe('Application Name');
+  });
 });

--- a/packages/components/src/components/telekom/telekom-mobile-flyout-canvas/telekom-mobile-flyout-canvas.tsx
+++ b/packages/components/src/components/telekom/telekom-mobile-flyout-canvas/telekom-mobile-flyout-canvas.tsx
@@ -32,13 +32,33 @@ export class TelekomMobileFlyoutCanvas {
 
   @Event({ eventName: 'scale-close-nav-flyout' }) scaleCloseNavFlyout;
 
+  get appNameHref(): string | undefined {
+    if (this.appNameLink) {
+      return this.appNameLink;
+    }
+
+    if (typeof this.appNameClick === 'function') {
+      return 'javascript:void(0);';
+    }
+
+    return undefined;
+  }
+
   render() {
     return (
       <Host>
         <div part="base">
           <div part="header">
             <slot name="heading">
-              <h2 part="heading">{this.appName}</h2>
+              <h2 part="heading">
+                {this.appNameHref ? (
+                  <a href={this.appNameHref} onClick={this.appNameClick}>
+                    {this.appName}
+                  </a>
+                ) : (
+                  this.appName
+                )}
+              </h2>
             </slot>
             <a
               href="javascript:void(0)"

--- a/packages/components/src/components/telekom/telekom-mobile-flyout-canvas/telekom-mobile-flyout-canvas.tsx
+++ b/packages/components/src/components/telekom/telekom-mobile-flyout-canvas/telekom-mobile-flyout-canvas.tsx
@@ -52,7 +52,14 @@ export class TelekomMobileFlyoutCanvas {
             <slot name="heading">
               <h2 part="heading">
                 {this.appNameHref ? (
-                  <a href={this.appNameHref} onClick={this.appNameClick}>
+                  <a
+                    href={this.appNameHref}
+                    onClick={
+                      typeof this.appNameClick === 'function'
+                        ? this.appNameClick
+                        : undefined
+                    }
+                  >
                     {this.appName}
                   </a>
                 ) : (


### PR DESCRIPTION
Fixes #2378

## Summary
- renders the mobile flyout canvas app name as a link when `app-name-link` is provided
- wires `app-name-click` behavior for the app name trigger
- adds component regression coverage for linked and click-handler app names

## Validation
- `yarn workspace @telekom/scale-components test --spec --max-workers=2`
- `yarn workspace @telekom/scale-components lint`
- `./node_modules/.bin/lerna run generate && yarn workspace @telekom/scale-components build`

Note: this component does not have a standalone static HTML demo page in `packages/components/src/html`; validation is covered by focused component tests plus build/lint.
