### PR TITLE
fix(telekom-nav-flyout): open anchor flyouts with keyboard

### DIFF
--- a/packages/components/src/components/telekom/telekom-nav-flyout/telekom-nav-flyout.spec.ts
+++ b/packages/components/src/components/telekom/telekom-nav-flyout/telekom-nav-flyout.spec.ts
@@ -9,7 +9,7 @@ const keyboardEvent = (key: string) =>
   });
 
 describe('scale-telekom-nav-flyout', () => {
-  it('opens a collapsed hover flyout before following an anchor trigger', async () => {
+  it('opens a collapsed hover flyout on Enter', async () => {
     const page = await newSpecPage({
       components: [TelekomNavItem],
       html: `
@@ -56,5 +56,69 @@ describe('scale-telekom-nav-flyout', () => {
     await page.waitForChanges();
 
     expect(keydown.defaultPrevented).toBe(false);
+  });
+
+  it('does not block a second Enter activation after the flyout was opened by Enter', async () => {
+    const page = await newSpecPage({
+      components: [TelekomNavItem],
+      html: `
+        <a id="trigger" href="#target">Topic One</a>
+        <scale-telekom-nav-flyout hover>
+          <scale-telekom-mega-menu></scale-telekom-mega-menu>
+        </scale-telekom-nav-flyout>
+      `,
+    });
+    const trigger = page.doc.querySelector('#trigger') as HTMLAnchorElement;
+    const flyout = page.root as HTMLScaleTelekomNavFlyoutElement;
+
+    const firstKeydown = keyboardEvent('Enter');
+    trigger.dispatchEvent(firstKeydown);
+    await page.waitForChanges();
+
+    expect(firstKeydown.defaultPrevented).toBe(true);
+    expect(flyout.expanded).toBe(true);
+
+    const firstClick = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      detail: 0,
+    });
+    trigger.dispatchEvent(firstClick);
+
+    const secondKeydown = keyboardEvent('Enter');
+    trigger.dispatchEvent(secondKeydown);
+    await page.waitForChanges();
+
+    expect(secondKeydown.defaultPrevented).toBe(false);
+
+    const secondClick = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      detail: 0,
+    });
+    trigger.dispatchEvent(secondClick);
+
+    expect(secondClick.defaultPrevented).toBe(false);
+  });
+
+  it('runs show only once when opening via Enter in hover mode', async () => {
+    const page = await newSpecPage({
+      components: [TelekomNavItem],
+      html: `
+        <a id="trigger" href="#target">Topic One</a>
+        <scale-telekom-nav-flyout hover>
+          <scale-telekom-mega-menu></scale-telekom-mega-menu>
+        </scale-telekom-nav-flyout>
+      `,
+    });
+    const trigger = page.doc.querySelector('#trigger') as HTMLAnchorElement;
+    const flyout = page.rootInstance as TelekomNavItem;
+    const showSpy = jest.spyOn(flyout, 'show');
+
+    const keydown = keyboardEvent('Enter');
+    trigger.dispatchEvent(keydown);
+    await page.waitForChanges();
+
+    expect(showSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/components/src/components/telekom/telekom-nav-flyout/telekom-nav-flyout.spec.ts
+++ b/packages/components/src/components/telekom/telekom-nav-flyout/telekom-nav-flyout.spec.ts
@@ -36,7 +36,7 @@ describe('scale-telekom-nav-flyout', () => {
     });
     trigger.dispatchEvent(click);
 
-    expect(click.defaultPrevented).toBe(true);
+    expect(click.defaultPrevented).toBe(false);
   });
 
   it('does not block keyboard activation when a hover flyout is already expanded', async () => {
@@ -77,13 +77,6 @@ describe('scale-telekom-nav-flyout', () => {
 
     expect(firstKeydown.defaultPrevented).toBe(true);
     expect(flyout.expanded).toBe(true);
-
-    const firstClick = new MouseEvent('click', {
-      bubbles: true,
-      cancelable: true,
-      detail: 0,
-    });
-    trigger.dispatchEvent(firstClick);
 
     const secondKeydown = keyboardEvent('Enter');
     trigger.dispatchEvent(secondKeydown);

--- a/packages/components/src/components/telekom/telekom-nav-flyout/telekom-nav-flyout.spec.ts
+++ b/packages/components/src/components/telekom/telekom-nav-flyout/telekom-nav-flyout.spec.ts
@@ -1,0 +1,60 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { TelekomNavItem } from './telekom-nav-flyout';
+
+const keyboardEvent = (key: string) =>
+  new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    key,
+  });
+
+describe('scale-telekom-nav-flyout', () => {
+  it('opens a collapsed hover flyout before following an anchor trigger', async () => {
+    const page = await newSpecPage({
+      components: [TelekomNavItem],
+      html: `
+        <a id="trigger" href="#target">Topic One</a>
+        <scale-telekom-nav-flyout hover>
+          <scale-telekom-mega-menu></scale-telekom-mega-menu>
+        </scale-telekom-nav-flyout>
+      `,
+    });
+    const trigger = page.doc.querySelector('#trigger') as HTMLAnchorElement;
+    const flyout = page.root as HTMLScaleTelekomNavFlyoutElement;
+
+    const keydown = keyboardEvent('Enter');
+    trigger.dispatchEvent(keydown);
+    await page.waitForChanges();
+
+    expect(keydown.defaultPrevented).toBe(true);
+    expect(flyout.expanded).toBe(true);
+
+    const click = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      detail: 0,
+    });
+    trigger.dispatchEvent(click);
+
+    expect(click.defaultPrevented).toBe(true);
+  });
+
+  it('does not block keyboard activation when a hover flyout is already expanded', async () => {
+    const page = await newSpecPage({
+      components: [TelekomNavItem],
+      html: `
+        <a id="trigger" href="#target">Topic One</a>
+        <scale-telekom-nav-flyout hover expanded>
+          <scale-telekom-mega-menu></scale-telekom-mega-menu>
+        </scale-telekom-nav-flyout>
+      `,
+    });
+    const trigger = page.doc.querySelector('#trigger') as HTMLAnchorElement;
+
+    const keydown = keyboardEvent('Enter');
+    trigger.dispatchEvent(keydown);
+    await page.waitForChanges();
+
+    expect(keydown.defaultPrevented).toBe(false);
+  });
+});

--- a/packages/components/src/components/telekom/telekom-nav-flyout/telekom-nav-flyout.tsx
+++ b/packages/components/src/components/telekom/telekom-nav-flyout/telekom-nav-flyout.tsx
@@ -58,6 +58,7 @@ export class TelekomNavItem {
   @Event({ eventName: 'scale-expanded', bubbles: true }) scaleExpanded;
 
   private parentElement: HTMLElement;
+  private suppressKeyboardTriggerClick = false;
 
   @Listen('keydown', { target: 'window' })
   handleWindowKeydown(event) {
@@ -106,8 +107,12 @@ export class TelekomNavItem {
     if (this.hover) {
       this.triggerElement.addEventListener('mouseenter', this.handlePointerIn);
       this.triggerElement.addEventListener(
-        'keypress',
+        'keydown',
         this.handleSpaceOrEnterForHover
+      );
+      this.triggerElement.addEventListener(
+        'click',
+        this.handleHoverTriggerClick
       );
     } else {
       this.triggerElement.addEventListener('click', this.handleTriggerClick);
@@ -116,9 +121,13 @@ export class TelekomNavItem {
 
   disconnectedCallback() {
     this.triggerElement.removeEventListener('click', this.handleTriggerClick);
+    this.triggerElement.removeEventListener(
+      'click',
+      this.handleHoverTriggerClick
+    );
     this.triggerElement.removeEventListener('mouseenter', this.handlePointerIn);
     this.triggerElement.removeEventListener(
-      'keypress',
+      'keydown',
       this.handleSpaceOrEnterForHover
     );
   }
@@ -128,8 +137,22 @@ export class TelekomNavItem {
       return;
     }
     if (event.key === 'Enter' || event.key === ' ') {
+      this.suppressKeyboardTriggerClick = true;
+      event.preventDefault();
       this.expanded = true;
       this.show();
+    }
+  };
+  handleHoverTriggerClick = (event: MouseEvent) => {
+    if (!this.suppressKeyboardTriggerClick) {
+      return;
+    }
+
+    this.suppressKeyboardTriggerClick = false;
+
+    if (event.detail === 0) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
     }
   };
   handleTriggerClick = (event: MouseEvent) => {

--- a/packages/components/src/components/telekom/telekom-nav-flyout/telekom-nav-flyout.tsx
+++ b/packages/components/src/components/telekom/telekom-nav-flyout/telekom-nav-flyout.tsx
@@ -140,7 +140,6 @@ export class TelekomNavItem {
       this.suppressKeyboardTriggerClick = true;
       event.preventDefault();
       this.expanded = true;
-      this.show();
     }
   };
   handleHoverTriggerClick = (event: MouseEvent) => {

--- a/packages/components/src/components/telekom/telekom-nav-flyout/telekom-nav-flyout.tsx
+++ b/packages/components/src/components/telekom/telekom-nav-flyout/telekom-nav-flyout.tsx
@@ -192,6 +192,7 @@ export class TelekomNavItem {
 
   @Method()
   async show() {
+    this.suppressKeyboardTriggerClick = false;
     this.isExpanded = true;
     this.animationState = 'in';
     requestAnimationFrame(async () => {

--- a/packages/components/src/html/telekom-header.html
+++ b/packages/components/src/html/telekom-header.html
@@ -65,7 +65,7 @@
       <!-- MAIN NAV -->
       <scale-telekom-nav-list variant="main-nav" slot="main-nav">
         <scale-telekom-nav-item active>
-          <button><span>Topic One</span></button>
+          <a href="#topic-one-target"><span>Topic One</span></a>
           <scale-telekom-nav-flyout hover>
             <scale-telekom-mega-menu>
               <scale-telekom-mega-menu-column>
@@ -580,6 +580,9 @@
         --size-md: 1;
       }
     </style>
+    <div id="topic-one-target" style="margin-top: 120vh; padding: 1rem">
+      Topic One target
+    </div>
     <scale-grid>
       <scale-grid-item foo>1</scale-grid-item>
       <scale-grid-item foo>2</scale-grid-item>


### PR DESCRIPTION
Fixes #2416

## Summary
- changes hover flyout keyboard handling from `keypress` to `keydown`
- prevents the generated keyboard click from navigating the anchor when Enter/Space opens the flyout
- adds component tests for initial keyboard open and already-expanded activation behavior

## Validation
- `yarn workspace @telekom/scale-components test --spec --max-workers=2`
- `yarn workspace @telekom/scale-components lint`
- `./node_modules/.bin/lerna run generate && yarn workspace @telekom/scale-components build`
- Playwright static page check against `telekom-header.html`: keyboard-created hover flyout opens on Enter and prevents the generated navigation click; screenshot saved locally at `/tmp/scale-2416-header.png`
