### PR TITLE
fix: slider in react and update react deps

### DIFF
--- a/packages/components-react/package.json
+++ b/packages/components-react/package.json
@@ -53,9 +53,14 @@
   },
   "peerDependencies": {
     "@telekom/scale-components": ">=3.0.0-beta.159",
-    "@types/react-dom": "^18.3.1",
+    "@types/react-dom": "^18.3.1 || ^19.0.0",
     "react": ">=16.13.1",
     "react-dom": ">=16.13.1"
+  },
+  "peerDependenciesMeta": {
+    "@types/react-dom": {
+      "optional": true
+    }
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/components/src/components/slider/slider.tsx
+++ b/packages/components/src/components/slider/slider.tsx
@@ -197,7 +197,7 @@ export class Slider {
   };
 
   onDragStart = () => {
-    const offsetKey = this.getKeyFor('offsetLeft');
+    const offsetKey = this.getKeyFor('trackOffsetLeft');
     this.dragging = true;
     this[offsetKey] = this.sliderTrack.getBoundingClientRect().left;
   };
@@ -207,7 +207,7 @@ export class Slider {
       return;
     }
     const valueKey = this.getKeyFor('value');
-    const offsetLeftKey = this.getKeyFor('offsetLeft');
+    const offsetLeftKey = this.getKeyFor('trackOffsetLeft');
     const offsetLeft = this[offsetLeftKey];
 
     const currentX = this.handleTouchEvent(event).clientX;
@@ -270,7 +270,7 @@ export class Slider {
    * @returns {string} The prop name with the range suffix if needed
    */
   getKeyFor = (
-    propName: 'value' | 'offsetLeft' | 'position',
+    propName: 'value' | 'trackOffsetLeft' | 'position',
     thumb?: string
   ) => {
     if (this.range) {


### PR DESCRIPTION
## Description

This PR adds React 19 support to `@telekom/scale-components-react` and fixes a runtime crash in the `scale-slider` component that surfaced when running under the React (custom elements) build.

### Changes

**1. React 19 type support (`packages/components-react/package.json`)**
- Widened the `@types/react-dom` peer dependency range from `^18.3.1` to `^18.3.1 || ^19.0.0`, so consumers on either React 18 or React 19 satisfy the peer requirement.
- Marked `@types/react-dom` as optional via `peerDependenciesMeta` (types are only needed at build time, not by every consumer).

**2. Slider crash fix (`packages/components/src/components/slider/slider.tsx`)**
- Renamed the internal state key `offsetLeft` → `trackOffsetLeft` (and its range variants `trackOffsetLeftFrom` / `trackOffsetLeftTo`).
- The component previously wrote to `this.offsetLeft`, which collides with the read-only native `HTMLElement.offsetLeft` getter. In the React / custom-elements build the component class extends `HTMLElement`, so this assignment threw at runtime.

### Bug fixed
Cannot set property offsetLeft of [object HTMLElement] which has only a getter


**Root cause:** The slider stored the track's left offset on `this.offsetLeft`. This worked in the lazy build (where the instance is not an `HTMLElement`) but crashed in the React/custom-elements build, where `offsetLeft` is a read-only DOM property. This is a library-side issue, not a consumer implementation problem — the React 19 upgrade only made it visible.

### Impact

- No public API changes; the renamed key is internal only.
- Fixes drag interaction for `scale-slider` (single and range) in React.
- Enables React 19 consumers to install without peer dependency conflicts.

### Testing

- [ ] Verified slider drag works in the React example app
- [ ] Verified install with React 18
- [ ] Verified install with React 19
- [ ] Rebuilt `@telekom/scale-components` and `@telekom/scale-components-react`